### PR TITLE
ci: bump actions to v5 and Node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     env:
       DATABASE_URL: "file:./dev.db"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Removes the deprecated-Node-runtime annotation GitHub adds to runs using actions/checkout@v4 and setup-node@v4. Node 22 LTS satisfies Next 14 and Prisma 7 requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)