### PR TITLE
Cascade v2 Wave A: LLM relevance judge for 'must', cheap-model routing, retry/backoff, opt-in live bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Intent-IDE-PRD-v6.pdf
 memory-bank/raw_reflection_log.md
 memory-bank/activeContext.md
 memory-bank/consolidated_learnings.md
+
+# Live bench output (opt-in, per-run JSON reports)
+bench-results/

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ npx playwright test  # optional e2e (needs dev server; graph tests skip without 
 
 CI runs typecheck, lint, unit tests, and a production build on every push.
 
+### Evaluation
+
+The cascade pipeline ships with an EditPropBench-style eval. The scripted variant runs in `npm run test`; a live variant replays the same fixtures against a real model (opt-in, never CI):
+
+```bash
+# Terminal A — serve /api/structured
+npm run dev
+
+# Terminal B — run the live bench against it
+BENCH_PROVIDER=claude BENCH_MODEL=claude-sonnet-4-6 BENCH_API_KEY=sk-ant-... npm run bench:live
+```
+
+Recall/precision/citation metrics are printed as a table and written per-fixture to `bench-results/` (gitignored). `BENCH_BASE_URL` overrides the default `http://localhost:3000`.
+
 ## License
 
 [MIT](LICENSE)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "bench:live": "BENCH_LIVE=1 vitest run src/lib/graphrag/__tests__/editPropBench.live.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.30.0",

--- a/src/app/api/structured/route.ts
+++ b/src/app/api/structured/route.ts
@@ -26,6 +26,9 @@ interface ToolCall {
   input: unknown
 }
 
+/** Only cache-mark user payloads above this size — tiny prompts aren't worth a cache write. */
+const CACHE_MIN_CHARS = 2000
+
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
   const provider = request.headers.get('x-provider') || 'claude'
@@ -57,6 +60,37 @@ export async function POST(request: NextRequest) {
       const systemMessage = messages.find((m) => m.role === 'system')?.content || ''
       const userMessages = messages.filter((m) => m.role !== 'system')
 
+      // Prompt caching: cascade/graph payloads resend the same large block
+      // listing across calls (cascade → judge, rebuild → rebuild). When the
+      // last user message is big enough to be worth caching, mark it — and the
+      // system prompt — with ephemeral cache_control so Anthropic caches the
+      // shared prefix. Small payloads keep the plain string shape untouched.
+      const lastUser = userMessages[userMessages.length - 1]
+      const shouldCache =
+        typeof lastUser?.content === 'string' && lastUser.content.length > CACHE_MIN_CHARS
+
+      const claudeMessages = shouldCache
+        ? userMessages.map((m, i) =>
+            i === userMessages.length - 1
+              ? {
+                  role: m.role,
+                  content: [
+                    {
+                      type: 'text',
+                      text: m.content,
+                      cache_control: { type: 'ephemeral' },
+                    },
+                  ],
+                }
+              : m
+          )
+        : userMessages
+
+      const claudeSystem =
+        shouldCache && systemMessage
+          ? [{ type: 'text', text: systemMessage, cache_control: { type: 'ephemeral' } }]
+          : systemMessage
+
       const response = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
         headers: {
@@ -68,8 +102,8 @@ export async function POST(request: NextRequest) {
           model,
           max_tokens: maxTokens,
           ...(modelRejectsSampling(model) ? {} : { temperature }),
-          system: systemMessage,
-          messages: userMessages,
+          system: claudeSystem,
+          messages: claudeMessages,
           tools,
           // Encourage but don't force — the model may legitimately propose zero edits.
           tool_choice: { type: 'auto' },

--- a/src/app/api/structured/route.ts
+++ b/src/app/api/structured/route.ts
@@ -26,9 +26,6 @@ interface ToolCall {
   input: unknown
 }
 
-/** Only cache-mark user payloads above this size — tiny prompts aren't worth a cache write. */
-const CACHE_MIN_CHARS = 2000
-
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
   const provider = request.headers.get('x-provider') || 'claude'
@@ -60,37 +57,6 @@ export async function POST(request: NextRequest) {
       const systemMessage = messages.find((m) => m.role === 'system')?.content || ''
       const userMessages = messages.filter((m) => m.role !== 'system')
 
-      // Prompt caching: cascade/graph payloads resend the same large block
-      // listing across calls (cascade → judge, rebuild → rebuild). When the
-      // last user message is big enough to be worth caching, mark it — and the
-      // system prompt — with ephemeral cache_control so Anthropic caches the
-      // shared prefix. Small payloads keep the plain string shape untouched.
-      const lastUser = userMessages[userMessages.length - 1]
-      const shouldCache =
-        typeof lastUser?.content === 'string' && lastUser.content.length > CACHE_MIN_CHARS
-
-      const claudeMessages = shouldCache
-        ? userMessages.map((m, i) =>
-            i === userMessages.length - 1
-              ? {
-                  role: m.role,
-                  content: [
-                    {
-                      type: 'text',
-                      text: m.content,
-                      cache_control: { type: 'ephemeral' },
-                    },
-                  ],
-                }
-              : m
-          )
-        : userMessages
-
-      const claudeSystem =
-        shouldCache && systemMessage
-          ? [{ type: 'text', text: systemMessage, cache_control: { type: 'ephemeral' } }]
-          : systemMessage
-
       const response = await fetch('https://api.anthropic.com/v1/messages', {
         method: 'POST',
         headers: {
@@ -102,8 +68,8 @@ export async function POST(request: NextRequest) {
           model,
           max_tokens: maxTokens,
           ...(modelRejectsSampling(model) ? {} : { temperature }),
-          system: claudeSystem,
-          messages: claudeMessages,
+          system: systemMessage,
+          messages: userMessages,
           tools,
           // Encourage but don't force — the model may legitimately propose zero edits.
           tool_choice: { type: 'auto' },

--- a/src/lib/ai/__tests__/modelCapabilities.test.ts
+++ b/src/lib/ai/__tests__/modelCapabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { modelRejectsSampling, pickUtilityModel } from '@/lib/ai/modelCapabilities'
 
 // modelRejectsSampling(model) is true when the (case-insensitive) id contains
 // one of the sampling-rejecting frontier families: opus-4-7, opus-4-8, fable-5,
@@ -108,5 +108,26 @@ describe('modelRejectsSampling — empty and garbage input', () => {
     expect(modelRejectsSampling('fable')).toBe(false)
     expect(modelRejectsSampling('4-8')).toBe(false)
     expect(modelRejectsSampling('   ')).toBe(false)
+  })
+})
+
+// ── pickUtilityModel ──────────────────────────────────────────────────────────
+
+describe('pickUtilityModel', () => {
+  it('pins Claude utility calls to Haiku regardless of the selected model', () => {
+    expect(pickUtilityModel({ provider: 'claude', model: 'claude-fable-5' })).toBe(
+      'claude-haiku-4-5',
+    )
+    expect(pickUtilityModel({ provider: 'claude', model: 'claude-opus-4-8' })).toBe(
+      'claude-haiku-4-5',
+    )
+    expect(pickUtilityModel({ provider: 'claude', model: 'claude-haiku-4-5' })).toBe(
+      'claude-haiku-4-5',
+    )
+  })
+
+  it('keeps the selected model for non-Claude providers (no cheaper sibling assumed)', () => {
+    expect(pickUtilityModel({ provider: 'openai', model: 'gpt-4o' })).toBe('gpt-4o')
+    expect(pickUtilityModel({ provider: 'ollama', model: 'llama3.2' })).toBe('llama3.2')
   })
 })

--- a/src/lib/ai/__tests__/orchestrator.test.ts
+++ b/src/lib/ai/__tests__/orchestrator.test.ts
@@ -7,6 +7,7 @@ import { buildDeterministicGraph, invalidateDocGraphCache } from '@/lib/graphrag
 import type { CallStructuredFn, StructuredRequest } from '@/lib/ai/structuredClient'
 import type { LLMConfig } from '@/stores/settingsStore'
 import type { SuggestedEdit } from '@/lib/annotations/types'
+import type { JudgeFn, JudgeVerdict } from '@/lib/ai/relevanceJudge'
 import {
   proposeCascadeEdits,
   primaryProposedEdit,
@@ -38,6 +39,15 @@ function scripted(
     return { toolCalls: calls }
   }
 }
+
+/** Judge that confirms every candidate — keeps derived musts as musts. */
+const confirmAllJudge: JudgeFn = async (candidates) =>
+  new Map(
+    candidates.map((_, i): [number, JudgeVerdict] => [
+      i,
+      { genuinelyConflicts: true, reason: 'confirmed' },
+    ]),
+  )
 
 /** Primary edit replacing `phrase` inside block `blockId`. */
 function primaryEditFor(doc: PMNode, blockId: string, phrase: string, newText: string): SuggestedEdit {
@@ -374,6 +384,7 @@ describe('proposeCascadeEdits — evidence gating and severity', () => {
     return proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
       graph: buildDeterministicGraph(FIXTURE_DOC),
       callStructured: scripted([{ name: 'propose_edit', input }]),
+      judge: confirmAllJudge,
     })
   }
 
@@ -457,6 +468,7 @@ describe('proposeCascadeEdits — evidence gating and severity', () => {
     const state = stateOf(FIXTURE_DOC)
     const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
       graph: buildDeterministicGraph(FIXTURE_DOC),
+      judge: confirmAllJudge,
       callStructured: scripted([
         {
           name: 'propose_edit',
@@ -482,6 +494,149 @@ describe('proposeCascadeEdits — evidence gating and severity', () => {
       ]),
     })
     expect(edits.map((e) => e.severity)).toEqual(['must', 'optional'])
+  })
+})
+
+describe('proposeCascadeEdits — relevance judge gating must', () => {
+  const primaryOf = (doc: PMNode) => primaryEditFor(doc, 'b1', 'March 1, 2026', 'June 1, 2026')
+
+  // A proposal that derives 'must': cited, and b2 still contains the stale date.
+  const MUST_PROPOSAL = {
+    name: 'propose_edit',
+    input: {
+      block_id: 'b2',
+      target_text: 'ends on March 1, 2026',
+      new_text: 'ends on June 1, 2026',
+      reason: 'stale date',
+      source_block_id: 'b1',
+      quoted_text: 'March 1, 2026',
+      edge_type: 'contradicts',
+    },
+  }
+
+  it('demotes a non-confirmed must to probably with an auto-review note', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    const denyAll: JudgeFn = async (candidates) =>
+      new Map(
+        candidates.map((_, i): [number, JudgeVerdict] => [
+          i,
+          { genuinelyConflicts: false, reason: 'coincidental date match' },
+        ]),
+      )
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: scripted([MUST_PROPOSAL]),
+      judge: denyAll,
+    })
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('probably')
+    expect(edits[0].reason).toBe('stale date (auto-review: coincidental date match)')
+  })
+
+  it('keeps derived severities unchanged when the judge throws (best-effort)', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: scripted([MUST_PROPOSAL]),
+      judge: async () => {
+        throw new Error('judge down')
+      },
+    })
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('must')
+    expect(edits[0].reason).toBe('stale date')
+  })
+
+  it('never calls the judge when no must survives derivation', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    let judgeCalled = false
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: scripted([
+        {
+          name: 'propose_edit',
+          input: {
+            block_id: 'b3',
+            target_text: 'Marketing emails',
+            new_text: 'Promotional emails',
+            reason: 'style, uncited', // no evidence → optional
+          },
+        },
+      ]),
+      judge: async () => {
+        judgeCalled = true
+        return new Map()
+      },
+    })
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('optional')
+    expect(judgeCalled).toBe(false)
+  })
+
+  it('default judge runs over callStructured and applies the skeptical missing-verdict default', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    const requests: StructuredRequest[] = []
+    // One scripted transport answering BOTH stages: cascade → the must proposal,
+    // judge → no verdicts at all (model went silent).
+    const transport: CallStructuredFn = async (req) => {
+      requests.push(req)
+      if (req.tools.some((t) => t.name === 'propose_edit')) {
+        return { toolCalls: [MUST_PROPOSAL] }
+      }
+      return { toolCalls: [] }
+    }
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: transport,
+    })
+    expect(requests.map((r) => r.tools[0].name)).toEqual(['propose_edit', 'verdict'])
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('probably')
+    expect(edits[0].reason).toContain('(auto-review: no verdict returned)')
+  })
+
+  it('re-sorts after demotion so confirmed musts stay ahead of demoted ones', async () => {
+    // Two blocks that BOTH derive 'must' (each still contains the stale date);
+    // the judge denies the earlier one (b2) and confirms the later one (b3).
+    const doc = docOf(
+      p('b1', '"Launch Date" means March 1, 2026.'),
+      p('b2', 'The beta program ends on March 1, 2026, just before the Launch Date.'),
+      p('b3', 'Printed banners show March 1, 2026 as the Launch Date.'),
+    )
+    const state = stateOf(doc)
+    const judge: JudgeFn = async (candidates) =>
+      new Map(
+        candidates.map((c, i): [number, JudgeVerdict] => [
+          i,
+          c.blockId === 'b2'
+            ? { genuinelyConflicts: false, reason: 'unrelated' }
+            : { genuinelyConflicts: true, reason: 'confirmed' },
+        ]),
+      )
+    const edits = await proposeCascadeEdits(state, primaryOf(doc), CONFIG, {
+      graph: buildDeterministicGraph(doc),
+      callStructured: scripted([
+        MUST_PROPOSAL,
+        {
+          name: 'propose_edit',
+          input: {
+            block_id: 'b3',
+            target_text: 'March 1, 2026 as the Launch Date',
+            new_text: 'June 1, 2026 as the Launch Date',
+            reason: 'stale banner date',
+            source_block_id: 'b1',
+            quoted_text: 'March 1, 2026',
+            edge_type: 'contradicts',
+          },
+        },
+      ]),
+      judge,
+    })
+    expect(edits).toHaveLength(2)
+    expect(edits.map((e) => [e.blockId, e.severity])).toEqual([
+      ['b3', 'must'],
+      ['b2', 'probably'],
+    ])
   })
 })
 

--- a/src/lib/ai/__tests__/orchestrator.test.ts
+++ b/src/lib/ai/__tests__/orchestrator.test.ts
@@ -573,11 +573,12 @@ describe('proposeCascadeEdits — relevance judge gating must', () => {
     expect(judgeCalled).toBe(false)
   })
 
-  it('default judge runs over callStructured and applies the skeptical missing-verdict default', async () => {
+  it('default judge: ZERO verdicts is a malfunction — derived severities are preserved', async () => {
     const state = stateOf(FIXTURE_DOC)
     const requests: StructuredRequest[] = []
     // One scripted transport answering BOTH stages: cascade → the must proposal,
-    // judge → no verdicts at all (model went silent).
+    // judge → no verdicts at all (prose reply / truncation / model confusion).
+    // The judge prompt allows no silent path, so silence must NOT demote.
     const transport: CallStructuredFn = async (req) => {
       requests.push(req)
       if (req.tools.some((t) => t.name === 'propose_edit')) {
@@ -591,8 +592,68 @@ describe('proposeCascadeEdits — relevance judge gating must', () => {
     })
     expect(requests.map((r) => r.tools[0].name)).toEqual(['propose_edit', 'verdict'])
     expect(edits).toHaveLength(1)
-    expect(edits[0].severity).toBe('probably')
-    expect(edits[0].reason).toContain('(auto-review: no verdict returned)')
+    expect(edits[0].severity).toBe('must')
+    expect(edits[0].reason).toBe('stale date')
+  })
+
+  it('default judge: PARTIAL verdicts demote only the missing indexes (skeptical default)', async () => {
+    // Two blocks that both derive 'must'; the judge confirms candidate [1]
+    // (b2) and goes silent on candidate [2] (b3) — only b3 may demote.
+    const doc = docOf(
+      p('b1', '"Launch Date" means March 1, 2026.'),
+      p('b2', 'The beta program ends on March 1, 2026, just before the Launch Date.'),
+      p('b3', 'Printed banners show March 1, 2026 as the Launch Date.'),
+    )
+    const state = stateOf(doc)
+    const transport: CallStructuredFn = async (req) => {
+      if (req.tools.some((t) => t.name === 'propose_edit')) {
+        return {
+          toolCalls: [
+            MUST_PROPOSAL,
+            {
+              name: 'propose_edit',
+              input: {
+                block_id: 'b3',
+                target_text: 'March 1, 2026 as the Launch Date',
+                new_text: 'June 1, 2026 as the Launch Date',
+                reason: 'stale banner date',
+                source_block_id: 'b1',
+                quoted_text: 'March 1, 2026',
+                edge_type: 'contradicts',
+              },
+            },
+          ],
+        }
+      }
+      return {
+        toolCalls: [
+          { name: 'verdict', input: { index: 1, genuinely_conflicts: true, reason: 'confirmed' } },
+        ],
+      }
+    }
+    const edits = await proposeCascadeEdits(state, primaryOf(doc), CONFIG, {
+      graph: buildDeterministicGraph(doc),
+      callStructured: transport,
+    })
+    expect(edits).toHaveLength(2)
+    expect(edits.map((e) => [e.blockId, e.severity])).toEqual([
+      ['b2', 'must'],
+      ['b3', 'probably'],
+    ])
+    expect(edits[0].reason).toBe('stale date')
+    expect(edits[1].reason).toContain('(auto-review: no verdict returned)')
+  })
+
+  it('a custom judge returning an empty verdict map preserves derived severities', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: scripted([MUST_PROPOSAL]),
+      judge: async () => new Map(),
+    })
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('must')
+    expect(edits[0].reason).toBe('stale date')
   })
 
   it('re-sorts after demotion so confirmed musts stay ahead of demoted ones', async () => {

--- a/src/lib/ai/__tests__/relevanceJudge.test.ts
+++ b/src/lib/ai/__tests__/relevanceJudge.test.ts
@@ -72,6 +72,29 @@ describe('judgeMustCandidates — batching and prompt shape', () => {
     expect(everything.toLowerCase()).not.toContain("'must'")
   })
 
+  it('routes the verdict call to the utility model (Haiku on Claude, unchanged elsewhere)', async () => {
+    const seen: string[] = []
+    const capturingCall: CallStructuredFn = async (_req, config) => {
+      seen.push(config.model)
+      return { toolCalls: [] }
+    }
+    await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      { provider: 'claude', apiKey: 'k', model: 'claude-fable-5' },
+      capturingCall,
+    )
+    await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      { provider: 'ollama', apiKey: '', model: 'llama3.2' },
+      capturingCall,
+    )
+    expect(seen).toEqual(['claude-haiku-4-5', 'llama3.2'])
+  })
+
   it('returns an empty map without calling the model when there are no candidates', async () => {
     let called = false
     const verdicts = await judgeMustCandidates([], PRIMARY, DOC, CONFIG, async () => {

--- a/src/lib/ai/__tests__/relevanceJudge.test.ts
+++ b/src/lib/ai/__tests__/relevanceJudge.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { CallStructuredFn, StructuredRequest } from '@/lib/ai/structuredClient'
+import type { ProposedEdit } from '@/lib/annotations/types'
+import { judgeMustCandidates, type JudgePrimary } from '@/lib/ai/relevanceJudge'
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
+
+const PRIMARY: JudgePrimary = { before: '$50,000', newText: '$75,000' }
+
+const DOC: PMNode = schema.node('doc', null, [
+  schema.node('paragraph', { blockId: 'b1' }, [schema.text('"Total Budget" means $50,000.')]),
+])
+
+function candidate(overrides: Partial<ProposedEdit> = {}): ProposedEdit {
+  return {
+    id: 'pe_test',
+    from: 10,
+    to: 20,
+    newText: 'new',
+    reason: 'stale figure',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: 'Total Budget of $50,000',
+    blockId: 'b2',
+    severity: 'must',
+    evidence: { sourceBlockId: 'b1', quotedText: '$50,000', edgeType: 'contradicts' },
+    ...overrides,
+  }
+}
+
+function scripted(
+  calls: Array<{ name: string; input: Record<string, unknown> }>,
+  capture?: StructuredRequest[],
+): CallStructuredFn {
+  return async (req) => {
+    capture?.push(req)
+    return { toolCalls: calls }
+  }
+}
+
+function verdict(index: number, genuinely_conflicts: boolean, reason = 'because') {
+  return { name: 'verdict', input: { index, genuinely_conflicts, reason } }
+}
+
+describe('judgeMustCandidates — batching and prompt shape', () => {
+  it('makes exactly ONE structured call listing every candidate in the prescribed format', async () => {
+    const captured: StructuredRequest[] = []
+    await judgeMustCandidates(
+      [candidate(), candidate({ blockId: 'b3', targetText: 'renewal at $50,000' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true), verdict(2, true)], captured),
+    )
+    expect(captured).toHaveLength(1)
+    const user = captured[0].messages.find((m) => m.role === 'user')!.content
+    expect(user).toContain('[1] TARGET (block b2): "Total Budget of $50,000"')
+    expect(user).toContain('[2] TARGET (block b3): "renewal at $50,000"')
+    expect(user).toContain('CITED: "$50,000"')
+    expect(user).toContain('PRIMARY was "$50,000" now "$75,000"')
+    expect(captured[0].tools.map((t) => t.name)).toEqual(['verdict'])
+  })
+
+  it('never leaks a severity field to the model', async () => {
+    const captured: StructuredRequest[] = []
+    await judgeMustCandidates([candidate()], PRIMARY, DOC, CONFIG, scripted([], captured))
+    const everything = captured[0].messages.map((m) => m.content).join('\n')
+    expect(everything.toLowerCase()).not.toContain('severity')
+    expect(everything.toLowerCase()).not.toContain("'must'")
+  })
+
+  it('returns an empty map without calling the model when there are no candidates', async () => {
+    let called = false
+    const verdicts = await judgeMustCandidates([], PRIMARY, DOC, CONFIG, async () => {
+      called = true
+      return { toolCalls: [] }
+    })
+    expect(verdicts.size).toBe(0)
+    expect(called).toBe(false)
+  })
+})
+
+describe('judgeMustCandidates — verdict parsing', () => {
+  it('maps 1-based prompt indices back to 0-based candidate indices', async () => {
+    const verdicts = await judgeMustCandidates(
+      [candidate(), candidate({ blockId: 'b3' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true, 'real conflict'), verdict(2, false, 'coincidental figure')]),
+    )
+    expect(verdicts.get(0)).toEqual({ genuinelyConflicts: true, reason: 'real conflict' })
+    expect(verdicts.get(1)).toEqual({ genuinelyConflicts: false, reason: 'coincidental figure' })
+  })
+
+  it('a missing verdict for an index defaults to NOT confirmed (skeptical default)', async () => {
+    const verdicts = await judgeMustCandidates(
+      [candidate(), candidate({ blockId: 'b3' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(2, true)]), // model skipped candidate 1
+    )
+    expect(verdicts.get(0)).toEqual({
+      genuinelyConflicts: false,
+      reason: 'no verdict returned',
+    })
+    expect(verdicts.get(1)?.genuinelyConflicts).toBe(true)
+  })
+
+  it('ignores out-of-range, non-numeric, and non-verdict tool calls', async () => {
+    const verdicts = await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([
+        verdict(0, true), // below range
+        verdict(7, true), // above range
+        { name: 'verdict', input: { index: 'one', genuinely_conflicts: true, reason: 'x' } },
+        { name: 'propose_edit', input: { index: 1, genuinely_conflicts: true } },
+      ]),
+    )
+    expect(verdicts.get(0)).toEqual({
+      genuinelyConflicts: false,
+      reason: 'no verdict returned',
+    })
+  })
+
+  it('treats a non-boolean genuinely_conflicts as a denial and fills blank reasons', async () => {
+    const verdicts = await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([{ name: 'verdict', input: { index: 1, genuinely_conflicts: 'yes', reason: '' } }]),
+    )
+    expect(verdicts.get(0)).toEqual({ genuinelyConflicts: false, reason: 'no reason given' })
+  })
+
+  it('propagates a structured-call failure to the caller (who keeps derived severities)', async () => {
+    await expect(
+      judgeMustCandidates([candidate()], PRIMARY, DOC, CONFIG, async () => {
+        throw new Error('provider down')
+      }),
+    ).rejects.toThrow('provider down')
+  })
+})

--- a/src/lib/ai/__tests__/relevanceJudge.test.ts
+++ b/src/lib/ai/__tests__/relevanceJudge.test.ts
@@ -64,9 +64,58 @@ describe('judgeMustCandidates — batching and prompt shape', () => {
     expect(captured[0].tools.map((t) => t.name)).toEqual(['verdict'])
   })
 
+  it("includes the target block's live text as CONTEXT when the blockId resolves", async () => {
+    const captured: StructuredRequest[] = []
+    await judgeMustCandidates(
+      [candidate({ blockId: 'b1', targetText: '$50,000' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true)], captured),
+    )
+    const user = captured[0].messages.find((m) => m.role === 'user')!.content
+    // The judge sees the whole surrounding block, not just the target span.
+    expect(user).toContain('CONTEXT: ""Total Budget" means $50,000."')
+  })
+
+  it('falls back to targetText as CONTEXT when the block no longer resolves', async () => {
+    const captured: StructuredRequest[] = []
+    await judgeMustCandidates(
+      [candidate({ blockId: 'vanished-block' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true)], captured),
+    )
+    const user = captured[0].messages.find((m) => m.role === 'user')!.content
+    expect(user).toContain('CONTEXT: "Total Budget of $50,000"')
+  })
+
+  it('scales maxTokens with candidate count and caps at 8000', async () => {
+    const captured: StructuredRequest[] = []
+    await judgeMustCandidates(
+      [candidate(), candidate({ blockId: 'b3' }), candidate({ blockId: 'b4' })],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true)], captured),
+    )
+    expect(captured[0].maxTokens).toBe(400 + 200 * 3)
+
+    const many = Array.from({ length: 50 }, (_, i) => candidate({ blockId: `m${i}` }))
+    await judgeMustCandidates(many, PRIMARY, DOC, CONFIG, scripted([verdict(1, true)], captured))
+    expect(captured[1].maxTokens).toBe(8000)
+  })
+
   it('never leaks a severity field to the model', async () => {
     const captured: StructuredRequest[] = []
-    await judgeMustCandidates([candidate()], PRIMARY, DOC, CONFIG, scripted([], captured))
+    await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true)], captured),
+    )
     const everything = captured[0].messages.map((m) => m.content).join('\n')
     expect(everything.toLowerCase()).not.toContain('severity')
     expect(everything.toLowerCase()).not.toContain("'must'")
@@ -76,7 +125,7 @@ describe('judgeMustCandidates — batching and prompt shape', () => {
     const seen: string[] = []
     const capturingCall: CallStructuredFn = async (_req, config) => {
       seen.push(config.model)
-      return { toolCalls: [] }
+      return { toolCalls: [verdict(1, true)] }
     }
     await judgeMustCandidates(
       [candidate()],
@@ -119,7 +168,7 @@ describe('judgeMustCandidates — verdict parsing', () => {
     expect(verdicts.get(1)).toEqual({ genuinelyConflicts: false, reason: 'coincidental figure' })
   })
 
-  it('a missing verdict for an index defaults to NOT confirmed (skeptical default)', async () => {
+  it('a PARTIALLY missing verdict defaults the skipped index to NOT confirmed (skeptical default)', async () => {
     const verdicts = await judgeMustCandidates(
       [candidate(), candidate({ blockId: 'b3' })],
       PRIMARY,
@@ -134,9 +183,32 @@ describe('judgeMustCandidates — verdict parsing', () => {
     expect(verdicts.get(1)?.genuinelyConflicts).toBe(true)
   })
 
-  it('ignores out-of-range, non-numeric, and non-verdict tool calls', async () => {
+  it('ZERO verdicts on a successful call throws (protocol malfunction, not an all-deny)', async () => {
+    await expect(
+      judgeMustCandidates([candidate(), candidate({ blockId: 'b3' })], PRIMARY, DOC, CONFIG, scripted([])),
+    ).rejects.toThrow('zero valid verdicts')
+  })
+
+  it('all-garbage tool calls count as zero verdicts and throw', async () => {
+    await expect(
+      judgeMustCandidates(
+        [candidate()],
+        PRIMARY,
+        DOC,
+        CONFIG,
+        scripted([
+          verdict(0, true), // below range
+          verdict(7, true), // above range
+          { name: 'verdict', input: { index: 'one', genuinely_conflicts: true, reason: 'x' } },
+          { name: 'propose_edit', input: { index: 1, genuinely_conflicts: true } },
+        ]),
+      ),
+    ).rejects.toThrow('zero valid verdicts')
+  })
+
+  it('ignores out-of-range, non-numeric, and non-verdict tool calls around a valid one', async () => {
     const verdicts = await judgeMustCandidates(
-      [candidate()],
+      [candidate(), candidate({ blockId: 'b3' })],
       PRIMARY,
       DOC,
       CONFIG,
@@ -145,12 +217,47 @@ describe('judgeMustCandidates — verdict parsing', () => {
         verdict(7, true), // above range
         { name: 'verdict', input: { index: 'one', genuinely_conflicts: true, reason: 'x' } },
         { name: 'propose_edit', input: { index: 1, genuinely_conflicts: true } },
+        verdict(1, true, 'the only valid verdict'),
       ]),
     )
-    expect(verdicts.get(0)).toEqual({
+    expect(verdicts.get(0)).toEqual({ genuinelyConflicts: true, reason: 'the only valid verdict' })
+    // The judge engaged, so the individually skipped index gets the skeptical default.
+    expect(verdicts.get(1)).toEqual({
       genuinelyConflicts: false,
       reason: 'no verdict returned',
     })
+  })
+
+  it('duplicate indexes: first write wins, but a deny always sticks', async () => {
+    // deny first → later confirm cannot launder it
+    const denyFirst = await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, false, 'denied'), verdict(1, true, 'laundered confirm')]),
+    )
+    expect(denyFirst.get(0)).toEqual({ genuinelyConflicts: false, reason: 'denied' })
+
+    // confirm first → later deny overrides it
+    const denyLater = await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true, 'early confirm'), verdict(1, false, 'second thoughts')]),
+    )
+    expect(denyLater.get(0)).toEqual({ genuinelyConflicts: false, reason: 'second thoughts' })
+
+    // confirm twice → first reason wins
+    const confirmTwice = await judgeMustCandidates(
+      [candidate()],
+      PRIMARY,
+      DOC,
+      CONFIG,
+      scripted([verdict(1, true, 'first'), verdict(1, true, 'second')]),
+    )
+    expect(confirmTwice.get(0)).toEqual({ genuinelyConflicts: true, reason: 'first' })
   })
 
   it('treats a non-boolean genuinely_conflicts as a denial and fills blank reasons', async () => {

--- a/src/lib/ai/__tests__/structuredClient.test.ts
+++ b/src/lib/ai/__tests__/structuredClient.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LLMConfig } from '@/stores/settingsStore'
+import { fetchStructured, fetchWithRetry } from '@/lib/ai/structuredClient'
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
+
+const REQ = { messages: [{ role: 'user', content: 'hi' }], tools: [] }
+
+// Tiny backoff so retry paths run in milliseconds.
+const FAST = { baseDelayMs: 1 }
+
+function response(status: number, body: unknown = { toolCalls: [] }): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetchWithRetry', () => {
+  it('retries 429s and succeeds on a later attempt (429 → 429 → 200)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response(429))
+      .mockResolvedValueOnce(response(429))
+      .mockResolvedValueOnce(response(200))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await fetchWithRetry('/api/structured', {}, FAST)
+    expect(res.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws immediately on 400 without retrying', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(400))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchWithRetry('/api/structured', {}, FAST)).rejects.toThrow(
+      'structured call failed: 400',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws after exhausting retries on persistent 500s (three attempts total)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(500))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchWithRetry('/api/structured', {}, FAST)).rejects.toThrow(
+      'structured call failed: 500',
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(3) // initial + retries=2
+  })
+
+  it('retries network errors and can recover', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(response(200))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await fetchWithRetry('/api/structured', {}, FAST)
+    expect(res.ok).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('rethrows the network error once retries are exhausted', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchWithRetry('/api/structured', {}, FAST)).rejects.toThrow('ECONNRESET')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('honors a custom retry budget', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(503))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      fetchWithRetry('/api/structured', {}, { ...FAST, retries: 0 }),
+    ).rejects.toThrow('structured call failed: 503')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('fetchStructured (through the retry layer)', () => {
+  it('returns tool calls on success and sends provider headers', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(response(200, { toolCalls: [{ name: 'verdict', input: {} }] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await fetchStructured(REQ, CONFIG)
+    expect(res.toolCalls).toEqual([{ name: 'verdict', input: {} }])
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/structured')
+    expect((init.headers as Record<string, string>)['x-provider']).toBe('claude')
+  })
+
+  it('throws on a non-retryable HTTP failure instead of returning empty tool calls', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(401))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchStructured(REQ, CONFIG)).rejects.toThrow('structured call failed: 401')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('normalizes a malformed body to empty tool calls', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response(200, { nope: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const res = await fetchStructured(REQ, CONFIG)
+    expect(res.toolCalls).toEqual([])
+  })
+})

--- a/src/lib/ai/modelCapabilities.ts
+++ b/src/lib/ai/modelCapabilities.ts
@@ -19,3 +19,14 @@ export function modelRejectsSampling(model: string): boolean {
     m.includes('mythos')
   )
 }
+
+/**
+ * The model to use for utility calls (context compaction, graph extraction,
+ * relevance judging) — housekeeping that should never run at Opus/Fable
+ * prices. On the Claude provider this pins the cheapest capable model; other
+ * providers (OpenAI/Ollama) keep the user's selected model since we can't
+ * assume a cheaper sibling exists.
+ */
+export function pickUtilityModel(config: { provider: string; model: string }): string {
+  return config.provider === 'claude' ? 'claude-haiku-4-5' : config.model
+}

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -239,6 +239,10 @@ async function applyRelevanceJudge(
   } catch {
     return false // judge down — keep derived severities
   }
+  // Zero verdicts for a non-empty candidate set is a judge malfunction, not
+  // an all-deny (the judge contract yields one verdict per candidate or
+  // throws). Treat it like a failed call: keep derived severities.
+  if (verdicts.size === 0) return false
 
   let demoted = false
   musts.forEach((edit, i) => {

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -12,6 +12,7 @@ import { findTextInDoc } from '@/lib/prosemirror/applyProposedEdits'
 import { blockIdAtPos, blockTextRange, findBlockById } from '@/lib/prosemirror/blockIds'
 import { containsTerm, getDocGraph, getNeighborhood, type DocGraph } from '@/lib/graphrag/docGraph'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { judgeMustCandidates, type JudgeFn } from '@/lib/ai/relevanceJudge'
 
 /**
  * Graph-scoped cascade: instead of one whole-doc LLM pass (previously
@@ -206,6 +207,48 @@ export interface CascadeOptions {
   hops?: number
   /** Cap on candidate blocks sent to the model (block COUNT — text is never truncated). */
   maxBlocks?: number
+  /** Relevance judge for 'must' candidates; defaults to judgeMustCandidates over callStructured. */
+  judge?: JudgeFn
+}
+
+/**
+ * Second-pass gate on 'must': a batched judge call re-examines each cited
+ * conflict and demotes candidates it cannot confirm to 'probably', appending
+ * the judge's reason. Runs only when at least one must exists. Best-effort —
+ * a judge failure keeps the derived severities unchanged, never blocks.
+ * Mutates the edits in place; returns true when any severity changed.
+ */
+async function applyRelevanceJudge(
+  edits: ProposedEdit[],
+  primary: { before: string; newText: string },
+  doc: EditorState['doc'],
+  config: LLMConfig,
+  opts: CascadeOptions,
+): Promise<boolean> {
+  const musts = edits.filter((e) => e.severity === 'must' && e.evidence !== null)
+  if (musts.length === 0) return false
+
+  const judge: JudgeFn =
+    opts.judge ??
+    ((candidates, prim, d, cfg) =>
+      judgeMustCandidates(candidates, prim, d, cfg, opts.callStructured ?? fetchStructured))
+
+  let verdicts: Awaited<ReturnType<JudgeFn>>
+  try {
+    verdicts = await judge(musts, primary, doc, config)
+  } catch {
+    return false // judge down — keep derived severities
+  }
+
+  let demoted = false
+  musts.forEach((edit, i) => {
+    const verdict = verdicts.get(i)
+    if (verdict?.genuinelyConflicts) return
+    edit.severity = 'probably'
+    edit.reason = `${edit.reason} (auto-review: ${verdict?.reason ?? 'no verdict returned'})`
+    demoted = true
+  })
+  return demoted
 }
 
 /**
@@ -336,6 +379,17 @@ export async function proposeCascadeEdits(
   }
 
   edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+
+  const demoted = await applyRelevanceJudge(
+    edits,
+    { before: primaryBefore, newText: primary.newText },
+    doc,
+    config,
+    opts,
+  )
+  if (demoted) {
+    edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+  }
   return edits
 }
 

--- a/src/lib/ai/relevanceJudge.ts
+++ b/src/lib/ai/relevanceJudge.ts
@@ -1,6 +1,7 @@
 import type { Node as PMNode } from 'prosemirror-model'
 import type { ProposedEdit } from '@/lib/annotations/types'
 import type { LLMConfig } from '@/stores/settingsStore'
+import { findBlockById } from '@/lib/prosemirror/blockIds'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
 import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
 
@@ -14,7 +15,12 @@ import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
  * that the evidence genuinely conflicts with the target passage. The judge
  * only confirms/denies conflicts — the model never sees or emits a severity;
  * the caller demotes non-confirmed candidates. Skeptical defaults throughout:
- * a missing verdict means NOT confirmed.
+ * a missing verdict means NOT confirmed — but ONLY when the judge engaged at
+ * all. A transport-successful call that yields ZERO valid verdicts is a
+ * protocol malfunction (prose reply, truncation, model confusion), not an
+ * all-deny: the system prompt gives the model no legitimate silent path, so
+ * that case throws and callers keep derived severities, exactly like a
+ * network failure.
  */
 
 export interface JudgeVerdict {
@@ -78,9 +84,31 @@ interface VerdictInput {
   reason?: unknown
 }
 
-function candidateLine(edit: ProposedEdit, n: number, primary: JudgePrimary): string {
+/** How much of the target block's text the judge sees per candidate. */
+const CONTEXT_MAX_CHARS = 300
+
+/**
+ * The target block's surrounding text — without it the judge cannot tell a
+ * coincidental figure ("the 2019 renovation also cost $50,000") from a
+ * genuine conflict. Falls back to the target text when the block no longer
+ * resolves in the live doc.
+ */
+function candidateContext(edit: ProposedEdit, doc: PMNode): string {
+  const blockText = edit.blockId
+    ? findBlockById(doc, edit.blockId)?.node.textContent
+    : undefined
+  return (blockText ?? edit.targetText).slice(0, CONTEXT_MAX_CHARS)
+}
+
+function candidateLine(
+  edit: ProposedEdit,
+  n: number,
+  primary: JudgePrimary,
+  doc: PMNode,
+): string {
   return [
     `[${n}] TARGET (block ${edit.blockId ?? 'unknown'}): "${edit.targetText}"`,
+    `CONTEXT: "${candidateContext(edit, doc)}"`,
     `CITED: "${edit.evidence?.quotedText ?? ''}"`,
     `PRIMARY was "${primary.before}" now "${primary.newText}"`,
   ].join(' | ')
@@ -90,8 +118,10 @@ function candidateLine(edit: ProposedEdit, n: number, primary: JudgePrimary): st
  * One batched structured call over all candidates (ProposedEdits derived
  * 'must' with non-null evidence). Returns a verdict for EVERY candidate
  * index: any index the model skipped, duplicated away, or garbled comes back
- * as not-confirmed. Throws only when the structured call itself fails —
- * callers treat that as "keep derived severities" (best-effort, never blocks).
+ * as not-confirmed. Throws when the structured call itself fails OR when a
+ * transport-successful call produces zero valid verdicts (protocol
+ * malfunction — the prompt allows no silent path) — callers treat both as
+ * "keep derived severities" (best-effort, never blocks).
  */
 export async function judgeMustCandidates(
   candidates: ProposedEdit[],
@@ -100,13 +130,12 @@ export async function judgeMustCandidates(
   config: LLMConfig,
   call: CallStructuredFn = fetchStructured,
 ): Promise<Map<number, JudgeVerdict>> {
-  void doc // reserved: block-level context could be added to the prompt later
   const verdicts = new Map<number, JudgeVerdict>()
   if (candidates.length === 0) return verdicts
 
   const userPrompt = [
     'CANDIDATES (verify each cited conflict):',
-    ...candidates.map((edit, i) => candidateLine(edit, i + 1, primary)),
+    ...candidates.map((edit, i) => candidateLine(edit, i + 1, primary, doc)),
   ].join('\n')
 
   const { toolCalls } = await call(
@@ -116,7 +145,9 @@ export async function judgeMustCandidates(
         { role: 'user', content: userPrompt },
       ],
       tools: [VERDICT_TOOL],
-      maxTokens: 1000,
+      // Each verdict tool_use block costs ~60-120 output tokens; a flat cap
+      // truncates the tail of large batches into silent demotions.
+      maxTokens: Math.min(8000, 400 + 200 * candidates.length),
       temperature: 0,
     },
     // Verdict checking is utility work — route it to the cheap model.
@@ -128,13 +159,30 @@ export async function judgeMustCandidates(
     const input = tc.input as VerdictInput
     const n = typeof input?.index === 'number' ? Math.trunc(input.index) : NaN
     if (!Number.isInteger(n) || n < 1 || n > candidates.length) continue
-    verdicts.set(n - 1, {
+    const parsed: JudgeVerdict = {
       genuinelyConflicts: input.genuinely_conflicts === true,
       reason: typeof input.reason === 'string' && input.reason ? input.reason : 'no reason given',
-    })
+    }
+    // Duplicate indexes: first write wins, except a deny always sticks — a
+    // later confirm may not launder an earlier denial (and vice versa a later
+    // deny overrides an earlier confirm).
+    const existing = verdicts.get(n - 1)
+    if (existing) {
+      if (!existing.genuinelyConflicts || parsed.genuinelyConflicts) continue
+    }
+    verdicts.set(n - 1, parsed)
   }
 
-  // Skeptical default: every candidate without a usable verdict is NOT confirmed.
+  // Zero valid verdicts on a successful call is a malfunction, not an
+  // all-deny: the system prompt requires one verdict per candidate, so a
+  // silent reply means prose, truncation, or confusion. Throw so the caller
+  // preserves derived severities — exactly like a failed call.
+  if (verdicts.size === 0) {
+    throw new Error('relevance judge returned zero valid verdicts')
+  }
+
+  // Skeptical default: with the judge demonstrably engaged, every candidate
+  // it individually skipped, duplicated away, or garbled is NOT confirmed.
   for (let i = 0; i < candidates.length; i++) {
     if (!verdicts.has(i)) verdicts.set(i, NO_VERDICT)
   }

--- a/src/lib/ai/relevanceJudge.ts
+++ b/src/lib/ai/relevanceJudge.ts
@@ -1,0 +1,140 @@
+import type { Node as PMNode } from 'prosemirror-model'
+import type { ProposedEdit } from '@/lib/annotations/types'
+import type { LLMConfig } from '@/stores/settingsStore'
+import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+
+/**
+ * LLM relevance judge for 'must' cascade candidates.
+ *
+ * hasVerbatimConflict is a string check: a stale-looking token in the target
+ * block proves nothing about MEANING (the same figure can describe an
+ * unrelated cost). Before a candidate keeps its derived 'must' severity, one
+ * batched structured call re-examines each citation and confirms or denies
+ * that the evidence genuinely conflicts with the target passage. The judge
+ * only confirms/denies conflicts — the model never sees or emits a severity;
+ * the caller demotes non-confirmed candidates. Skeptical defaults throughout:
+ * a missing verdict means NOT confirmed.
+ */
+
+export interface JudgeVerdict {
+  genuinelyConflicts: boolean
+  reason: string
+}
+
+/** The primary edit's before/after text — context the judge needs to assess staleness. */
+export interface JudgePrimary {
+  before: string
+  newText: string
+}
+
+/**
+ * Judge contract used by the cascade: returns one verdict per candidate,
+ * keyed by the candidate's index in the input array.
+ */
+export type JudgeFn = (
+  candidates: ProposedEdit[],
+  primary: JudgePrimary,
+  doc: PMNode,
+  config: LLMConfig,
+) => Promise<Map<number, JudgeVerdict>>
+
+const VERDICT_TOOL = {
+  name: 'verdict',
+  description:
+    'Deliver your verdict for ONE listed candidate. Call this tool exactly once per candidate, using the [n] index shown in brackets.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      index: {
+        type: 'number',
+        description: 'The [n] index of the candidate this verdict is for.',
+      },
+      genuinely_conflicts: {
+        type: 'boolean',
+        description:
+          'true only when the cited evidence genuinely makes the target passage stale or contradictory given the primary change.',
+      },
+      reason: {
+        type: 'string',
+        description: 'One short sentence justifying the verdict.',
+      },
+    },
+    required: ['index', 'genuinely_conflicts', 'reason'],
+  },
+}
+
+const JUDGE_SYSTEM =
+  'You verify whether cited evidence GENUINELY conflicts with a target passage. Be skeptical: matching words or figures are not enough — the target passage is only in conflict if the primary change actually makes it stale, wrong, or contradictory in meaning. A coincidental match (the same number describing something unrelated, a citation about a different subject) does not conflict. For each numbered candidate, call verdict once with its index.'
+
+const NO_VERDICT: JudgeVerdict = {
+  genuinelyConflicts: false,
+  reason: 'no verdict returned',
+}
+
+interface VerdictInput {
+  index?: unknown
+  genuinely_conflicts?: unknown
+  reason?: unknown
+}
+
+function candidateLine(edit: ProposedEdit, n: number, primary: JudgePrimary): string {
+  return [
+    `[${n}] TARGET (block ${edit.blockId ?? 'unknown'}): "${edit.targetText}"`,
+    `CITED: "${edit.evidence?.quotedText ?? ''}"`,
+    `PRIMARY was "${primary.before}" now "${primary.newText}"`,
+  ].join(' | ')
+}
+
+/**
+ * One batched structured call over all candidates (ProposedEdits derived
+ * 'must' with non-null evidence). Returns a verdict for EVERY candidate
+ * index: any index the model skipped, duplicated away, or garbled comes back
+ * as not-confirmed. Throws only when the structured call itself fails —
+ * callers treat that as "keep derived severities" (best-effort, never blocks).
+ */
+export async function judgeMustCandidates(
+  candidates: ProposedEdit[],
+  primary: JudgePrimary,
+  doc: PMNode,
+  config: LLMConfig,
+  call: CallStructuredFn = fetchStructured,
+): Promise<Map<number, JudgeVerdict>> {
+  void doc // reserved: block-level context could be added to the prompt later
+  const verdicts = new Map<number, JudgeVerdict>()
+  if (candidates.length === 0) return verdicts
+
+  const userPrompt = [
+    'CANDIDATES (verify each cited conflict):',
+    ...candidates.map((edit, i) => candidateLine(edit, i + 1, primary)),
+  ].join('\n')
+
+  const { toolCalls } = await call(
+    {
+      messages: [
+        { role: 'system', content: JUDGE_SYSTEM },
+        { role: 'user', content: userPrompt },
+      ],
+      tools: [VERDICT_TOOL],
+      maxTokens: 1000,
+      temperature: 0,
+    },
+    config,
+  )
+
+  for (const tc of toolCalls) {
+    if (tc.name !== 'verdict') continue
+    const input = tc.input as VerdictInput
+    const n = typeof input?.index === 'number' ? Math.trunc(input.index) : NaN
+    if (!Number.isInteger(n) || n < 1 || n > candidates.length) continue
+    verdicts.set(n - 1, {
+      genuinelyConflicts: input.genuinely_conflicts === true,
+      reason: typeof input.reason === 'string' && input.reason ? input.reason : 'no reason given',
+    })
+  }
+
+  // Skeptical default: every candidate without a usable verdict is NOT confirmed.
+  for (let i = 0; i < candidates.length; i++) {
+    if (!verdicts.has(i)) verdicts.set(i, NO_VERDICT)
+  }
+  return verdicts
+}

--- a/src/lib/ai/relevanceJudge.ts
+++ b/src/lib/ai/relevanceJudge.ts
@@ -2,6 +2,7 @@ import type { Node as PMNode } from 'prosemirror-model'
 import type { ProposedEdit } from '@/lib/annotations/types'
 import type { LLMConfig } from '@/stores/settingsStore'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
 
 /**
  * LLM relevance judge for 'must' cascade candidates.
@@ -118,7 +119,8 @@ export async function judgeMustCandidates(
       maxTokens: 1000,
       temperature: 0,
     },
-    config,
+    // Verdict checking is utility work — route it to the cheap model.
+    { ...config, model: pickUtilityModel(config) },
   )
 
   for (const tc of toolCalls) {

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -9,6 +9,7 @@ import { getBlockText, getSectionText } from '@/lib/prosemirror/helpers'
 import { runMADS } from './mads'
 import { logResolutionAudit } from '@/lib/audit/auditLogger'
 import { primaryProposedEdit, proposeCascadeEdits } from './orchestrator'
+import { pickUtilityModel } from './modelCapabilities'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { getDefaultVerbosity } from '@/lib/annotations/types'
 import type { Annotation, ConversationMessage, Resolution, ResolutionAction, SuggestedEdit, Scope, Verbosity } from '@/lib/annotations/types'
@@ -679,8 +680,7 @@ async function maybeCompactContext(): Promise<void> {
 
   // Compaction is pure housekeeping — pin it to the cheapest capable model so it
   // never runs at Opus/Fable prices when the user has selected one of those.
-  const compactionModel =
-    config.provider === 'claude' ? 'claude-haiku-4-5' : config.model
+  const compactionModel = pickUtilityModel(config)
 
   try {
     const response = await fetch('/api/resolve', {

--- a/src/lib/ai/structuredClient.ts
+++ b/src/lib/ai/structuredClient.ts
@@ -36,6 +36,16 @@ export type CallStructuredFn = (
   config: LLMConfig,
 ) => Promise<{ toolCalls: StructuredToolCall[] }>
 
+// Module-level base-URL override for out-of-browser callers (the live bench
+// runs under vitest/node, where relative URLs have no origin). Default '' keeps
+// the browser's relative '/api/structured'.
+let structuredBaseUrl = ''
+
+/** Point fetchStructured at an absolute origin (e.g. http://localhost:3000). */
+export function setStructuredBaseUrl(url: string): void {
+  structuredBaseUrl = url.replace(/\/$/, '')
+}
+
 export interface RetryOptions {
   /** Additional attempts after the first (default 2 → up to 3 requests total). */
   retries?: number
@@ -80,7 +90,7 @@ export async function fetchWithRetry(
 }
 
 export const fetchStructured: CallStructuredFn = async (req, config) => {
-  const res = await fetchWithRetry('/api/structured', {
+  const res = await fetchWithRetry(`${structuredBaseUrl}/api/structured`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/ai/structuredClient.ts
+++ b/src/lib/ai/structuredClient.ts
@@ -36,8 +36,51 @@ export type CallStructuredFn = (
   config: LLMConfig,
 ) => Promise<{ toolCalls: StructuredToolCall[] }>
 
+export interface RetryOptions {
+  /** Additional attempts after the first (default 2 → up to 3 requests total). */
+  retries?: number
+  baseDelayMs?: number
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * fetch with jittered exponential backoff for transient failures: 429,
+ * 5xx, and network errors are retried (delay = baseDelayMs * 4^attempt *
+ * (0.5 + random)); any other non-ok status throws immediately — a 400 will
+ * not get better on the second try. After exhausting retries the last
+ * failure throws. HTTP failure must THROW, not masquerade as an empty
+ * tool-call response: callers distinguish "the model chose to call nothing"
+ * (valid, cacheable) from "the provider is down" (must not poison caches).
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  opts: RetryOptions = {},
+): Promise<Response> {
+  const retries = opts.retries ?? 2
+  const baseDelayMs = opts.baseDelayMs ?? 300
+  for (let attempt = 0; ; attempt++) {
+    let res: Response | null = null
+    try {
+      res = await fetch(url, init)
+    } catch (err) {
+      // Network error — retryable.
+      if (attempt >= retries) throw err
+    }
+    if (res) {
+      if (res.ok) return res
+      const retryable = res.status === 429 || res.status >= 500
+      if (!retryable || attempt >= retries) {
+        throw new Error(`structured call failed: ${res.status}`)
+      }
+    }
+    await sleep(baseDelayMs * 4 ** attempt * (0.5 + Math.random()))
+  }
+}
+
 export const fetchStructured: CallStructuredFn = async (req, config) => {
-  const res = await fetch('/api/structured', {
+  const res = await fetchWithRetry('/api/structured', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -48,10 +91,6 @@ export const fetchStructured: CallStructuredFn = async (req, config) => {
     },
     body: JSON.stringify(req),
   })
-  // HTTP failure must THROW, not masquerade as an empty tool-call response:
-  // callers distinguish "the model chose to call nothing" (valid, cacheable)
-  // from "the provider is down" (retryable — must not poison caches).
-  if (!res.ok) throw new Error(`structured call failed: ${res.status}`)
   const data = await res.json()
   return { toolCalls: Array.isArray(data.toolCalls) ? data.toolCalls : [] }
 }

--- a/src/lib/ai/structuredClient.ts
+++ b/src/lib/ai/structuredClient.ts
@@ -62,6 +62,8 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
  * failure throws. HTTP failure must THROW, not masquerade as an empty
  * tool-call response: callers distinguish "the model chose to call nothing"
  * (valid, cacheable) from "the provider is down" (must not poison caches).
+ * NOTE: retry assumes `init.body` is a reusable string — a stream body would
+ * be consumed on attempt 1 and replay empty.
  */
 export async function fetchWithRetry(
   url: string,

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -231,6 +231,25 @@ describe('augmentWithLlmEdges', () => {
     expect(llmEdges[0].evidence).toBeUndefined()
   })
 
+  it('routes the extraction call to the utility model (Haiku on Claude, unchanged elsewhere)', async () => {
+    const seen: string[] = []
+    const capturingCall: CallStructuredFn = async (_req, config) => {
+      seen.push(config.model)
+      return { toolCalls: [] }
+    }
+    await augmentWithLlmEdges(
+      buildDeterministicGraph(doc),
+      { provider: 'claude', apiKey: 'k', model: 'claude-fable-5' },
+      capturingCall,
+    )
+    await augmentWithLlmEdges(
+      buildDeterministicGraph(doc),
+      { provider: 'ollama', apiKey: '', model: 'llama3.2' },
+      capturingCall,
+    )
+    expect(seen).toEqual(['claude-haiku-4-5', 'llama3.2'])
+  })
+
   it('leaves the deterministic graph intact when the call throws', async () => {
     const graph = buildDeterministicGraph(doc)
     const before = graph.edges.length

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -231,7 +231,9 @@ describe('augmentWithLlmEdges', () => {
     expect(llmEdges[0].evidence).toBeUndefined()
   })
 
-  it('routes the extraction call to the utility model (Haiku on Claude, unchanged elsewhere)', async () => {
+  it("extraction runs on the USER's selected model — never a silent cheap-model downgrade", async () => {
+    // Edge extraction is the cascade's recall mechanism for paraphrase
+    // dependencies; downgrading it would be unmeasured recall loss.
     const seen: string[] = []
     const capturingCall: CallStructuredFn = async (_req, config) => {
       seen.push(config.model)
@@ -247,7 +249,7 @@ describe('augmentWithLlmEdges', () => {
       { provider: 'ollama', apiKey: '', model: 'llama3.2' },
       capturingCall,
     )
-    expect(seen).toEqual(['claude-haiku-4-5', 'llama3.2'])
+    expect(seen).toEqual(['claude-fable-5', 'llama3.2'])
   })
 
   it('leaves the deterministic graph intact when the call throws', async () => {

--- a/src/lib/graphrag/__tests__/editPropBench.fixtures.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.fixtures.ts
@@ -426,11 +426,17 @@ export const CASCADE_FIXTURES: CascadeFixture[] = [
         reason: 'the $50,000 in this block is a 2019 renovation cost, not the Total Budget',
       }),
     ],
-    extraAssertions: (edits) => {
+    extraAssertions: (edits, captured) => {
       expect(edits).toHaveLength(1)
       expect(edits[0].severity).toBe('probably')
       expect(edits[0].reason).toContain('(auto-review:')
       expect(edits[0].evidence).not.toBeNull() // citation kept, confidence lowered
+      // The judge could only make this call because it SAW the target block's
+      // surrounding text — the candidate line must carry b2's context.
+      const judgeReq = captured.find((r) => r.tools.some((t) => t.name === 'verdict'))
+      expect(judgeReq).toBeDefined()
+      const judgePrompt = judgeReq!.messages.map((m) => m.content).join('\n')
+      expect(judgePrompt).toContain('CONTEXT: "Historical note: the 2019 office renovation')
     },
   },
 

--- a/src/lib/graphrag/__tests__/editPropBench.fixtures.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.fixtures.ts
@@ -28,6 +28,11 @@ export interface CascadeFixture {
   scriptedCascadeCalls: Array<{ name: string; input: Record<string, unknown> }>
   /** When present, an LLM graph-extraction pass is replayed before the cascade. */
   scriptedGraphCalls?: Array<{ name: string; input: Record<string, unknown> }>
+  /**
+   * Scripted relevance-judge verdicts for 'must' candidates. When absent the
+   * runner uses a confirm-all judge so derived musts stay musts.
+   */
+  scriptedJudgeCalls?: Array<{ name: string; input: Record<string, unknown> }>
   /** Simulate a dead provider: the cascade structured call throws. */
   throwOnCascade?: boolean
   /** Fixture-specific assertions beyond the shared metric checks. */
@@ -52,6 +57,10 @@ function propose(input: Record<string, unknown>) {
 
 function link(input: Record<string, unknown>) {
   return { name: 'link_blocks', input }
+}
+
+function verdict(input: Record<string, unknown>) {
+  return { name: 'verdict', input }
 }
 
 /** ~15+ pages: 70 paragraphs, ≫ the old 6000-char truncation window. */
@@ -380,6 +389,48 @@ export const CASCADE_FIXTURES: CascadeFixture[] = [
     extraAssertions: (edits) => {
       expect(edits).toHaveLength(1)
       expect(edits[0].severity).toBe('optional')
+    },
+  },
+
+  {
+    name: 'judge demotes irrelevant citation — string-match must is not meaning-match must',
+    buildDoc: () =>
+      docOf(
+        p('b1', '"Total Budget" means $50,000 for the pilot program, as noted in the appendix.'),
+        p('b2', 'Historical note: the 2019 office renovation also cost $50,000, unrelated to the Total Budget.'),
+      ),
+    primaryEdit: { blockId: 'b1', targetText: '$50,000', newText: '$75,000' },
+    labels: {
+      directTargets: ['b1'],
+      requiredDownstream: [],
+      protectedUnchanged: [],
+    },
+    scriptedCascadeCalls: [
+      propose({
+        block_id: 'b2',
+        target_text: 'also cost $50,000',
+        new_text: 'also cost $75,000',
+        reason: 'Stale figure',
+        // Real text from b1 — verifies verbatim — but says nothing about b2's figure.
+        source_block_id: 'b1',
+        quoted_text: 'as noted in the appendix',
+        edge_type: 'references',
+      }),
+    ],
+    // hasVerbatimConflict sees the shared "$50,000" and derives 'must'; the
+    // judge recognizes the renovation cost is a coincidental figure and denies.
+    scriptedJudgeCalls: [
+      verdict({
+        index: 1,
+        genuinely_conflicts: false,
+        reason: 'the $50,000 in this block is a 2019 renovation cost, not the Total Budget',
+      }),
+    ],
+    extraAssertions: (edits) => {
+      expect(edits).toHaveLength(1)
+      expect(edits[0].severity).toBe('probably')
+      expect(edits[0].reason).toContain('(auto-review:')
+      expect(edits[0].evidence).not.toBeNull() // citation kept, confidence lowered
     },
   },
 

--- a/src/lib/graphrag/__tests__/editPropBench.live.test.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.live.test.ts
@@ -101,8 +101,18 @@ function computeLiveMetrics(
 }
 
 describe.skipIf(!LIVE)('EditPropBench LIVE (real model via /api/structured)', () => {
-  beforeAll(() => {
-    setStructuredBaseUrl(process.env.BENCH_BASE_URL || 'http://localhost:3000')
+  beforeAll(async () => {
+    const baseUrl = process.env.BENCH_BASE_URL || 'http://localhost:3000'
+    // Preflight: fail fast on a dead transport instead of burning the full
+    // retry backoff once per fixture and reporting all-zero "results".
+    try {
+      await fetch(baseUrl)
+    } catch {
+      throw new Error(
+        `bench:live — ${baseUrl} is unreachable. Start the app first (npm run dev) or point BENCH_BASE_URL at a running instance.`,
+      )
+    }
+    setStructuredBaseUrl(baseUrl)
     fs.mkdirSync(RESULTS_DIR, { recursive: true })
     const config = benchConfig()
     if (config.provider !== 'ollama' && !config.apiKey) {
@@ -158,6 +168,9 @@ describe.skipIf(!LIVE)('EditPropBench LIVE (real model via /api/structured)', ()
   }
 
   afterAll(() => {
+    // Leave no cross-suite residue: later suites must see the default
+    // relative '/api/structured' again.
+    setStructuredBaseUrl('')
     if (collected.length === 0) return
     // eslint-disable-next-line no-console
     console.table(
@@ -171,5 +184,13 @@ describe.skipIf(!LIVE)('EditPropBench LIVE (real model via /api/structured)', ()
         'ms': m.durationMs,
       })),
     )
+    // A run where NO fixture produced a single proposal is a dead or broken
+    // transport wearing green, not a model opinion — every fixture here has
+    // at least one genuinely stale downstream block. Fail loudly rather than
+    // greenwash it.
+    expect(
+      collected.some((m) => m.proposals > 0),
+      'bench:live — zero proposals across ALL fixtures; the transport or provider is almost certainly broken (check the dev server logs and BENCH_API_KEY)',
+    ).toBe(true)
   })
 })

--- a/src/lib/graphrag/__tests__/editPropBench.live.test.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.live.test.ts
@@ -1,0 +1,175 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import { blockTextRange } from '@/lib/prosemirror/blockIds'
+import type { LLMConfig, LLMProvider } from '@/stores/settingsStore'
+import type { ProposedEdit } from '@/lib/annotations/types'
+import { setStructuredBaseUrl } from '@/lib/ai/structuredClient'
+import { proposeCascadeEdits } from '@/lib/ai/orchestrator'
+import { buildDeterministicGraph, augmentWithLlmEdges, invalidateDocGraphCache } from '../docGraph'
+import { CASCADE_FIXTURES, resolvePrimary, type CascadeFixture } from './editPropBench.fixtures'
+
+/**
+ * LIVE EditPropBench run — opt-in only, never CI.
+ *
+ * Replays the CASCADE_FIXTURES against a REAL model through the running app's
+ * /api/structured route: graph extraction, cascade proposal, and relevance
+ * judging all use the production fetchStructured (no scripted calls). Real
+ * models vary run to run, so nothing is hard-asserted except citation
+ * validity; recall/precision are REPORTED via console.table and written as
+ * per-fixture JSON under bench-results/ for comparison across models.
+ *
+ * Two-terminal flow:
+ *   1. Terminal A: npm run dev            # serves /api/structured on :3000
+ *   2. Terminal B: BENCH_PROVIDER=claude BENCH_MODEL=claude-sonnet-4-6 \
+ *        BENCH_API_KEY=sk-ant-... npm run bench:live
+ *
+ * Env:
+ *   BENCH_LIVE=1        gate — anything else skips the whole suite
+ *   BENCH_BASE_URL      app origin (default http://localhost:3000)
+ *   BENCH_PROVIDER      claude | openai | ollama (default claude)
+ *   BENCH_MODEL         model id (default claude-sonnet-4-6)
+ *   BENCH_API_KEY       provider key (Ollama needs none)
+ */
+
+const LIVE = process.env.BENCH_LIVE === '1'
+
+const RESULTS_DIR = path.join(process.cwd(), 'bench-results')
+const FIXTURE_TIMEOUT_MS = 120_000
+
+// Provider-failure fixtures exist to script a dead transport — meaningless live.
+const LIVE_FIXTURES = CASCADE_FIXTURES.filter((f) => !f.throwOnCascade)
+
+interface LiveMetrics {
+  fixture: string
+  provider: string
+  model: string
+  recall: number | null
+  fpViolations: number
+  proposals: number
+  musts: number
+  validCitations: number
+  durationMs: number
+}
+
+const collected: LiveMetrics[] = []
+
+function benchConfig(): LLMConfig {
+  return {
+    provider: (process.env.BENCH_PROVIDER || 'claude') as LLMProvider,
+    model: process.env.BENCH_MODEL || 'claude-sonnet-4-6',
+    apiKey: process.env.BENCH_API_KEY || '',
+  }
+}
+
+function computeLiveMetrics(
+  fixture: CascadeFixture,
+  edits: ProposedEdit[],
+  config: LLMConfig,
+  durationMs: number,
+): LiveMetrics {
+  const { requiredDownstream, protectedUnchanged } = fixture.labels
+  const proposedBlockIds = new Set(edits.map((e) => e.blockId).filter(Boolean))
+
+  const recall =
+    requiredDownstream.length === 0
+      ? null
+      : requiredDownstream.filter((id) => proposedBlockIds.has(id)).length /
+        requiredDownstream.length
+
+  const fpViolations = edits.filter(
+    (e) =>
+      (e.severity === 'must' || e.severity === 'probably') &&
+      e.blockId !== undefined &&
+      protectedUnchanged.includes(e.blockId),
+  ).length
+
+  const musts = edits.filter((e) => e.severity === 'must')
+  return {
+    fixture: fixture.name,
+    provider: config.provider,
+    model: config.model,
+    recall,
+    fpViolations,
+    proposals: edits.length,
+    musts: musts.length,
+    validCitations: musts.filter((m) => m.evidence !== null).length,
+    durationMs,
+  }
+}
+
+describe.skipIf(!LIVE)('EditPropBench LIVE (real model via /api/structured)', () => {
+  beforeAll(() => {
+    setStructuredBaseUrl(process.env.BENCH_BASE_URL || 'http://localhost:3000')
+    fs.mkdirSync(RESULTS_DIR, { recursive: true })
+    const config = benchConfig()
+    if (config.provider !== 'ollama' && !config.apiKey) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'bench:live — no BENCH_API_KEY set; non-Ollama runs will skip the LLM graph pass and cascade calls will 401.',
+      )
+    }
+  })
+
+  beforeEach(() => {
+    invalidateDocGraphCache()
+  })
+
+  for (const fixture of LIVE_FIXTURES) {
+    it(
+      fixture.name,
+      async () => {
+        const doc = fixture.buildDoc()
+        const state = EditorState.create({ schema, doc })
+        const primary = resolvePrimary(doc, fixture)
+        const config = benchConfig()
+
+        const started = Date.now()
+        // Real LLM graph augmentation over the deterministic base…
+        const graph = buildDeterministicGraph(doc)
+        await augmentWithLlmEdges(graph, config)
+        // …and a real cascade + relevance judge (default fetchStructured, default judge).
+        const edits = await proposeCascadeEdits(state, primary, config, { graph })
+        const durationMs = Date.now() - started
+
+        const metrics = computeLiveMetrics(fixture, edits, config, durationMs)
+        collected.push(metrics)
+
+        // The ONLY hard gate: every surviving 'must' must carry a citation
+        // that re-verifies verbatim against the live document. Recall and
+        // precision are reported, not asserted — real models vary.
+        for (const must of edits.filter((e) => e.severity === 'must')) {
+          expect(must.evidence).not.toBeNull()
+          expect(
+            blockTextRange(doc, must.evidence!.sourceBlockId, must.evidence!.quotedText),
+          ).not.toBeNull()
+        }
+
+        const slug = fixture.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 80)
+        fs.writeFileSync(
+          path.join(RESULTS_DIR, `${slug}.json`),
+          JSON.stringify({ ...metrics, edits, ranAt: new Date().toISOString() }, null, 2),
+        )
+      },
+      FIXTURE_TIMEOUT_MS,
+    )
+  }
+
+  afterAll(() => {
+    if (collected.length === 0) return
+    // eslint-disable-next-line no-console
+    console.table(
+      collected.map((m) => ({
+        fixture: m.fixture.length > 48 ? `${m.fixture.slice(0, 45)}…` : m.fixture,
+        recall: m.recall === null ? 'n/a' : m.recall.toFixed(2),
+        'fp violations': m.fpViolations,
+        proposals: m.proposals,
+        musts: m.musts,
+        'valid citations': m.validCitations,
+        'ms': m.durationMs,
+      })),
+    )
+  })
+})

--- a/src/lib/graphrag/__tests__/editPropBench.test.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.test.ts
@@ -6,6 +6,7 @@ import type { LLMConfig } from '@/stores/settingsStore'
 import type { CallStructuredFn, StructuredRequest } from '@/lib/ai/structuredClient'
 import type { ProposedEdit } from '@/lib/annotations/types'
 import { proposeCascadeEdits } from '@/lib/ai/orchestrator'
+import { judgeMustCandidates, type JudgeFn, type JudgeVerdict } from '@/lib/ai/relevanceJudge'
 import { buildDeterministicGraph, augmentWithLlmEdges, invalidateDocGraphCache } from '../docGraph'
 import { CASCADE_FIXTURES, resolvePrimary, type CascadeFixture } from './editPropBench.fixtures'
 
@@ -46,6 +47,23 @@ function scripted(
   }
 }
 
+/** Default judge: confirm every derived must so unjudged fixtures keep their labels. */
+const confirmAllJudge: JudgeFn = async (candidates) =>
+  new Map(
+    candidates.map((_, i): [number, JudgeVerdict] => [
+      i,
+      { genuinelyConflicts: true, reason: 'confirmed' },
+    ]),
+  )
+
+/** Scripted judge: the real judgeMustCandidates parsing over scripted verdicts. */
+function scriptedJudge(
+  calls: Array<{ name: string; input: Record<string, unknown> }>,
+): JudgeFn {
+  return (candidates, primary, doc, config) =>
+    judgeMustCandidates(candidates, primary, doc, config, scripted(calls, []))
+}
+
 async function runFixture(fixture: CascadeFixture): Promise<{
   edits: ProposedEdit[]
   captured: StructuredRequest[]
@@ -64,6 +82,7 @@ async function runFixture(fixture: CascadeFixture): Promise<{
   const edits = await proposeCascadeEdits(state, primary, CONFIG, {
     graph,
     callStructured: scripted(fixture.scriptedCascadeCalls, captured, fixture.throwOnCascade),
+    judge: fixture.scriptedJudgeCalls ? scriptedJudge(fixture.scriptedJudgeCalls) : confirmAllJudge,
   })
   return { edits, captured, doc }
 }

--- a/src/lib/graphrag/__tests__/editPropBench.test.ts
+++ b/src/lib/graphrag/__tests__/editPropBench.test.ts
@@ -59,9 +59,10 @@ const confirmAllJudge: JudgeFn = async (candidates) =>
 /** Scripted judge: the real judgeMustCandidates parsing over scripted verdicts. */
 function scriptedJudge(
   calls: Array<{ name: string; input: Record<string, unknown> }>,
+  capture: StructuredRequest[],
 ): JudgeFn {
   return (candidates, primary, doc, config) =>
-    judgeMustCandidates(candidates, primary, doc, config, scripted(calls, []))
+    judgeMustCandidates(candidates, primary, doc, config, scripted(calls, capture))
 }
 
 async function runFixture(fixture: CascadeFixture): Promise<{
@@ -78,11 +79,15 @@ async function runFixture(fixture: CascadeFixture): Promise<{
     await augmentWithLlmEdges(graph, CONFIG, scripted(fixture.scriptedGraphCalls, []))
   }
 
+  // Cascade AND judge requests share one capture list, so fixtures can
+  // assert what the judge was actually shown (e.g. target-block context).
   const captured: StructuredRequest[] = []
   const edits = await proposeCascadeEdits(state, primary, CONFIG, {
     graph,
     callStructured: scripted(fixture.scriptedCascadeCalls, captured, fixture.throwOnCascade),
-    judge: fixture.scriptedJudgeCalls ? scriptedJudge(fixture.scriptedJudgeCalls) : confirmAllJudge,
+    judge: fixture.scriptedJudgeCalls
+      ? scriptedJudge(fixture.scriptedJudgeCalls, captured)
+      : confirmAllJudge,
   })
   return { edits, captured, doc }
 }

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -4,6 +4,7 @@ import type { LLMConfig } from '@/stores/settingsStore'
 import type { CascadeEdgeType } from '@/lib/annotations/types'
 import { collectTextblocks } from '@/lib/prosemirror/blockIds'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
 
 /**
  * Document dependency graph — the retrieval index the cascade queries instead
@@ -354,7 +355,8 @@ export async function augmentWithLlmEdges(
         maxTokens: 2000,
         temperature: 0.1,
       },
-      config,
+      // Edge extraction is utility work — route it to the cheap model.
+      { ...config, model: pickUtilityModel(config) },
     )
     toolCalls = res.toolCalls
   } catch {

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -4,7 +4,6 @@ import type { LLMConfig } from '@/stores/settingsStore'
 import type { CascadeEdgeType } from '@/lib/annotations/types'
 import { collectTextblocks } from '@/lib/prosemirror/blockIds'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
-import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
 
 /**
  * Document dependency graph — the retrieval index the cascade queries instead
@@ -355,8 +354,10 @@ export async function augmentWithLlmEdges(
         maxTokens: 2000,
         temperature: 0.1,
       },
-      // Edge extraction is utility work — route it to the cheap model.
-      { ...config, model: pickUtilityModel(config) },
+      // Edge extraction is the cascade's RECALL mechanism — paraphrase
+      // dependencies only surface if this pass finds them, so it runs on the
+      // user's selected model, never a silent cheap-model downgrade.
+      config,
     )
     toolCalls = res.toolCalls
   } catch {


### PR DESCRIPTION
## Why

The v8.4 cascade (PR #4) derives severity from graph structure + verbatim-conflict checks, but its `must` gate verified that a citation *exists* — not that it *conflicts*. Nothing ever measured a real model, transient provider errors killed cascade attempts outright, and mechanical LLM passes ran on whatever expensive model the user selected.

## What

**Relevance judge gating `must`** (`src/lib/ai/relevanceJudge.ts`): one batched structured call on a cheap pinned model verifies each must-candidate's citation *genuinely conflicts* with the target — including the target block's surrounding text as context, so a coincidental repeated figure ("the 2019 renovation also cost $50,000") is distinguishable from a stale claim. Non-confirmed musts demote to `probably` with the judge's reason appended. The judge can only lower severity, never raise it; its prompt contains no severity vocabulary (unit-tested).

Robustness semantics, hardened by adversarial review before this PR was opened:
- A judge **malfunction** (thrown call, or a "successful" response with zero valid verdicts — prose reply, truncation) preserves the derived severities untouched. Only real per-candidate verdicts demote.
- `maxTokens` scales with candidate count (a fixed 1000 silently truncated verdicts past ~9 musts, demoting the tail).
- Duplicate verdict indexes: deny always wins.

**Cheap-model routing** (`pickUtilityModel` in `modelCapabilities.ts`): judge + context compaction pin to Haiku-class on the Claude provider. Graph-edge extraction deliberately stays on the **user's selected model** — it's the recall mechanism for paraphrase dependencies, not housekeeping.

**Retry with jittered backoff** (`fetchWithRetry` in `structuredClient.ts`): 429/5xx retried twice; other 4xx throw immediately; error contract unchanged.

**Live bench, opt-in, never in CI** (`editPropBench.live.test.ts`, `npm run bench:live`): runs the same EditPropBench-style fixtures against a **real model** through the real `/api/structured` route (two-terminal flow: `npm run dev`, then `BENCH_LIVE=1` with provider env). Fails fast on a dead transport and asserts at least one fixture produced proposals — a meaningless run cannot report green. Results dumped to gitignored `bench-results/`.

**Reverted in-branch**: an ephemeral prompt-caching change, after review demonstrated it was a cost regression (zero shared prefix between cascade and judge calls; identical rebuilds never reach the API; trigger threshold below Anthropic's minimum cacheable prefix). The revert rationale is preserved in the commit body.

## Testing

322 passed + 10 skipped (live suite properly skips without `BENCH_LIVE=1`); was 287 on main. Typecheck 0 errors, lint clean, production build clean. Adversarial (Troublemaker) review ran pre-PR; all HIGH findings fixed in `534126a`, verified by new regression tests (zero-verdicts preserves musts, partial verdicts demote only missing indexes, judge receives block context, deny-wins merging).

## Notes for reviewers

- Cascades producing ≥1 `must` now make a second (cheap, batched) LLM round-trip. Failure never blocks or demotes.
- Known limitation, deliberate: the judge's live discrimination quality is measurable via `bench:live` but not asserted in CI — real-model behavior doesn't belong in a deterministic gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
