### PR TITLE
Git-model document history: content-addressed versions, append-only DAG, EU AI Act Art. 12 & 14 integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Generate Prisma client
         run: npx prisma generate
 
+      # Exercise the actual migration SQL against a fresh database — a broken
+      # migration fails CI here, not on the next dev machine.
+      - name: Apply database migrations
+        run: npx prisma migrate deploy
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project is both an AI product and an experiment in AI-augmented engineering
 - [`.claude/skills/`](.claude/skills) — reusable task recipes (add a ProseMirror plugin, add an API route, scaffold a cascade edit) that encode the codebase's conventions
 - [`memory-bank/`](memory-bank) — persistent project memory across AI sessions: [audit ledger](memory-bank/audit.md) of every architectural decision with human-approval records, [changelog](memory-bank/changelog.md), [progress tracker](memory-bank/progress.md), and distilled [system patterns](memory-bank/systemPatterns.md). (Session-scratch files — the active context window and raw reflection log — are local-only and created fresh on first session.)
 - [`docs/specs/`](docs/specs) — the design specs the agents build against
-- [`docs/compliance.md`](docs/compliance.md) — EU AI Act compliance statement (Articles 12 & 14): immutable, content-addressed version history linked to the audit trail, with human-gated restores
+- [`docs/compliance.md`](docs/compliance.md) — EU AI Act compliance statement (Articles 12 & 14): an append-only, hash-verified (tamper-evident) version history linked to the audit trail, with human-gated restores
 
 The same human-in-the-loop discipline the product enforces on document edits was applied to building it: agents propose, tests and adversarial review interrogate, a human approves.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ This project is both an AI product and an experiment in AI-augmented engineering
 - [`.claude/skills/`](.claude/skills) — reusable task recipes (add a ProseMirror plugin, add an API route, scaffold a cascade edit) that encode the codebase's conventions
 - [`memory-bank/`](memory-bank) — persistent project memory across AI sessions: [audit ledger](memory-bank/audit.md) of every architectural decision with human-approval records, [changelog](memory-bank/changelog.md), [progress tracker](memory-bank/progress.md), and distilled [system patterns](memory-bank/systemPatterns.md). (Session-scratch files — the active context window and raw reflection log — are local-only and created fresh on first session.)
 - [`docs/specs/`](docs/specs) — the design specs the agents build against
+- [`docs/compliance.md`](docs/compliance.md) — EU AI Act compliance statement (Articles 12 & 14): immutable, content-addressed version history linked to the audit trail, with human-gated restores
 
 The same human-in-the-loop discipline the product enforces on document edits was applied to building it: agents propose, tests and adversarial review interrogate, a human approves.
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,36 +1,58 @@
 # EU AI Act Compliance — Document History & Human Oversight
 
-Intent IDE keeps two linked, append-only records for every document: an immutable **version
-history** (content-addressed snapshots) and an immutable **audit trail** (the 14-field
-per-inference ledger). Together they satisfy the record-keeping and human-oversight duties of the
-EU AI Act for a high-risk-style document workflow.
+Intent IDE keeps two linked, append-only records for every document: a **version history**
+(content-addressed snapshots) and an **audit trail** (the 14-field per-inference ledger).
+Together they support the record-keeping and human-oversight duties of the EU AI Act for a
+high-risk-style document workflow.
+
+This document states precisely what the system enforces and how — including the boundaries of
+those guarantees. Precision over promotion.
 
 ## Article 12 — Record-keeping
 
-**Content-addressed, immutable versions.** Every version of a document is stored as a full
-snapshot whose primary key is a sha256 hash of its canonical content, its parent version, and its
-document id (`prisma/schema.prisma`, model `DocCommit`). Versions form an append-only linear chain
-via parent pointers; restoring an old version creates a *new* version — history is never
-rewritten or deleted.
+**Append-only, enforced at the application layer.** The only write path is
+`POST /api/history` (`src/app/api/history/route.ts`); the API exposes no update or delete
+operations, and restores are recorded as *new* versions — history is never rewritten through the
+application. This is an application-level guarantee, not a physical one: an actor with direct
+access to the local SQLite file could remove or alter rows. Hash verification (below) makes such
+partial modification *detectable* (tamper-evident), not impossible.
 
-**Server-side hash verification.** The only write path is `POST /api/history`
-(`src/app/api/history/route.ts`), which recomputes the hash from the canonical payload
-(`src/lib/history/canonical.ts`, shared verbatim by client and server) and rejects any mismatch.
-A stored hash therefore proves the stored content: tampering with a snapshot is detectable, and
-the API exposes no update or delete operations.
+**Two-level content addressing (git's design).** Every version stores a `contentHash` — sha256
+over the canonical document content only — and is keyed by a commit `hash` — sha256 over the
+canonical join of document id, parent version, content hash, kind, message, actor, annotation id,
+audit-record ids, and model version (`src/lib/history/canonical.ts`, shared verbatim by client
+and server). Because the commit hash covers attribution as well as content, two versions that
+agree on content but differ in provenance (an applied AI change and a manual edit session, say)
+are distinct records by construction and cannot be silently collapsed.
 
-**Per-version attribution and linkage.** Each version records its kind (created / AI change /
-edit session / restore), actor (`human` or `ai+human`), the model version in use for AI changes,
-the annotation that produced it, the document blocks it touched ("last changed by"), and the ids
-of the audit records covering the underlying AI inference — a direct join between the version
-history and the Article 12 audit ledger (`AuditLog`, written via the append-only
-`src/app/api/audit/route.ts` / `src/lib/audit/auditLogger.ts`).
+**Server-side hash verification.** The server recomputes both hashes from the submitted payload
+and rejects either mismatch, so a stored hash always proves the stored content and its recorded
+attribution against partial modification.
+
+**A parent-linked chain, kept linear by the server.** Versions form a parent-pointer chain. The
+server enforces linearity: one root per document and one child per parent; a write against a
+stale head is rejected (HTTP 409) and the client rebases onto the new head and retries once.
+History therefore cannot fork.
+
+**Attribution is client-supplied.** This is a local-first, bring-your-own-key application with no
+server-side authentication or signing. The attribution fields on a version (kind, actor, model
+version, annotation id, audit ids) are recorded faithfully by the application code, and the hash
+scheme prevents their after-the-fact modification — but they are asserted by the client at write
+time, not cryptographically signed by an independent authority. They are attribution records, not
+non-repudiable signatures.
+
+**Linkage to the audit ledger — including the failure path.** Versions of kind `apply` carry the
+ids of the audit records covering the underlying AI inference, a direct join to the Article 12
+audit ledger (`AuditLog`, written via the append-only `src/app/api/audit/route.ts` /
+`src/lib/audit/auditLogger.ts`). When an audit write fails at inference time, the resolution is
+flagged in the UI (`auditFailed`) and the linked version records **zero** audit ids — the gap is
+surfaced, not papered over.
 
 **Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years); document
 versions are retained indefinitely alongside them in the same SQLite database. Version capture
 happens contemporaneously with the action that produced it (document creation, approved AI apply,
-autosaved edit session, restore) — see `src/lib/history/commits.ts` and the capture points in
-`src/stores/documentStore.ts`, `src/components/Annotations/ResolutionActions.tsx`, and
+autosaved or flushed edit session, restore) — see `src/lib/history/commits.ts` and the capture
+points in `src/stores/documentStore.ts`, `src/components/Annotations/ResolutionActions.tsx`, and
 `src/components/Editor/EditorShell.tsx`.
 
 ## Article 14 — Human oversight
@@ -40,25 +62,29 @@ Semantic Commit modal (per-change accept/reject) and every AI output defaults to
 `PENDING_REVIEW`; human decisions are recorded as new override audit records
 (`src/lib/audit/approvalGate.ts`), never as mutations of the original.
 
-**Restores are explicit human actions.** Restoring a version is only reachable through a
-confirmation gate in the History panel (`src/components/History/HistoryPanel.tsx`). Each restore
-(1) creates a new version whose parent is the pre-restore head, so the full decision trail is
-preserved, and (2) writes a `HUMAN_RESTORE` / `APPROVED_HUMAN` oversight record to the audit
-ledger (`restoreCommit` in `src/lib/history/commits.ts`).
+**Restores are explicit human actions, persisted before they take effect.** Restoring a version
+is only reachable through a confirmation gate in the History panel
+(`src/components/History/HistoryPanel.tsx`). Each restore, in order: (0) flushes any pending
+unsaved edits as their own version, so restoring never discards recent typing from the record;
+(1) writes a `HUMAN_RESTORE` / `APPROVED_HUMAN` oversight record to the audit ledger; (2) records
+the new restore version carrying that audit record's id — a direct Article 12 link; and (3) only
+after all records are safely written, changes the document on screen (`restoreCommit` in
+`src/lib/history/commits.ts`). A failed write leaves the document untouched.
 
 **Transparency in the product.** The History panel presents the chain in plain language
 (Version / Compare / Restore / "Last changed by"), shows which versions carry audit records, and
-states that history is immutable and linked to the audit trail.
+describes the append-only guarantee in the same terms as this document.
 
 ## Reference
 
 | Concern | Location |
 | :--- | :--- |
-| Version schema (append-only) | `prisma/schema.prisma` (`DocCommit`) |
-| Append-only version API + hash verification | `src/app/api/history/route.ts` |
+| Version schema (append-only, two-level hashes) | `prisma/schema.prisma` (`DocCommit`) |
+| Append-only version API + hash verification + linearity | `src/app/api/history/route.ts` |
 | Canonical hashing (shared client/server) | `src/lib/history/canonical.ts` |
 | Version capture, blame, gated restore | `src/lib/history/commits.ts` |
 | Audit ledger (14-field schema) | `prisma/schema.prisma` (`AuditLog`), `src/app/api/audit/route.ts` |
+| Audit-failure surfacing (`auditFailed`) | `src/lib/ai/resolver.ts`, `src/lib/annotations/types.ts` |
 | Human oversight gates | `src/lib/audit/approvalGate.ts`, `src/components/ui/Confirmation.tsx` |
 | History UI | `src/components/History/HistoryPanel.tsx` |
 | Audit-layer design spec | `docs/specs/compliance-audit-layer.md` |

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,64 @@
+# EU AI Act Compliance — Document History & Human Oversight
+
+Intent IDE keeps two linked, append-only records for every document: an immutable **version
+history** (content-addressed snapshots) and an immutable **audit trail** (the 14-field
+per-inference ledger). Together they satisfy the record-keeping and human-oversight duties of the
+EU AI Act for a high-risk-style document workflow.
+
+## Article 12 — Record-keeping
+
+**Content-addressed, immutable versions.** Every version of a document is stored as a full
+snapshot whose primary key is a sha256 hash of its canonical content, its parent version, and its
+document id (`prisma/schema.prisma`, model `DocCommit`). Versions form an append-only linear chain
+via parent pointers; restoring an old version creates a *new* version — history is never
+rewritten or deleted.
+
+**Server-side hash verification.** The only write path is `POST /api/history`
+(`src/app/api/history/route.ts`), which recomputes the hash from the canonical payload
+(`src/lib/history/canonical.ts`, shared verbatim by client and server) and rejects any mismatch.
+A stored hash therefore proves the stored content: tampering with a snapshot is detectable, and
+the API exposes no update or delete operations.
+
+**Per-version attribution and linkage.** Each version records its kind (created / AI change /
+edit session / restore), actor (`human` or `ai+human`), the model version in use for AI changes,
+the annotation that produced it, the document blocks it touched ("last changed by"), and the ids
+of the audit records covering the underlying AI inference — a direct join between the version
+history and the Article 12 audit ledger (`AuditLog`, written via the append-only
+`src/app/api/audit/route.ts` / `src/lib/audit/auditLogger.ts`).
+
+**Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years); document
+versions are retained indefinitely alongside them in the same SQLite database. Version capture
+happens contemporaneously with the action that produced it (document creation, approved AI apply,
+autosaved edit session, restore) — see `src/lib/history/commits.ts` and the capture points in
+`src/stores/documentStore.ts`, `src/components/Annotations/ResolutionActions.tsx`, and
+`src/components/Editor/EditorShell.tsx`.
+
+## Article 14 — Human oversight
+
+**No AI change reaches the document without a human gate.** AI-proposed edits are reviewed in the
+Semantic Commit modal (per-change accept/reject) and every AI output defaults to
+`PENDING_REVIEW`; human decisions are recorded as new override audit records
+(`src/lib/audit/approvalGate.ts`), never as mutations of the original.
+
+**Restores are explicit human actions.** Restoring a version is only reachable through a
+confirmation gate in the History panel (`src/components/History/HistoryPanel.tsx`). Each restore
+(1) creates a new version whose parent is the pre-restore head, so the full decision trail is
+preserved, and (2) writes a `HUMAN_RESTORE` / `APPROVED_HUMAN` oversight record to the audit
+ledger (`restoreCommit` in `src/lib/history/commits.ts`).
+
+**Transparency in the product.** The History panel presents the chain in plain language
+(Version / Compare / Restore / "Last changed by"), shows which versions carry audit records, and
+states that history is immutable and linked to the audit trail.
+
+## Reference
+
+| Concern | Location |
+| :--- | :--- |
+| Version schema (append-only) | `prisma/schema.prisma` (`DocCommit`) |
+| Append-only version API + hash verification | `src/app/api/history/route.ts` |
+| Canonical hashing (shared client/server) | `src/lib/history/canonical.ts` |
+| Version capture, blame, gated restore | `src/lib/history/commits.ts` |
+| Audit ledger (14-field schema) | `prisma/schema.prisma` (`AuditLog`), `src/app/api/audit/route.ts` |
+| Human oversight gates | `src/lib/audit/approvalGate.ts`, `src/components/ui/Confirmation.tsx` |
+| History UI | `src/components/History/HistoryPanel.tsx` |
+| Audit-layer design spec | `docs/specs/compliance-audit-layer.md` |

--- a/prisma/migrations/20260709205301_add_doc_commit_history/migration.sql
+++ b/prisma/migrations/20260709205301_add_doc_commit_history/migration.sql
@@ -13,6 +13,7 @@ PRAGMA foreign_keys=on;
 -- CreateTable
 CREATE TABLE "DocCommit" (
     "hash" TEXT NOT NULL PRIMARY KEY,
+    "contentHash" TEXT NOT NULL,
     "documentId" TEXT NOT NULL,
     "parentHash" TEXT,
     "kind" TEXT NOT NULL,
@@ -45,3 +46,6 @@ PRAGMA defer_foreign_keys=OFF;
 
 -- CreateIndex
 CREATE INDEX "DocCommit_documentId_createdAt_idx" ON "DocCommit"("documentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "DocCommit_documentId_parentHash_idx" ON "DocCommit"("documentId", "parentHash");

--- a/prisma/migrations/20260709205301_add_doc_commit_history/migration.sql
+++ b/prisma/migrations/20260709205301_add_doc_commit_history/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the `DocumentSource` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the column `sourceId` on the `Annotation` table. All the data in the column will be lost.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "DocumentSource";
+PRAGMA foreign_keys=on;
+
+-- CreateTable
+CREATE TABLE "DocCommit" (
+    "hash" TEXT NOT NULL PRIMARY KEY,
+    "documentId" TEXT NOT NULL,
+    "parentHash" TEXT,
+    "kind" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "docJson" TEXT NOT NULL,
+    "blockIdsTouched" TEXT NOT NULL DEFAULT '[]',
+    "annotationId" TEXT,
+    "auditIds" TEXT NOT NULL DEFAULT '[]',
+    "actor" TEXT NOT NULL DEFAULT 'human',
+    "modelVersion" TEXT NOT NULL DEFAULT '',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Annotation" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "transcript" TEXT NOT NULL,
+    "intentType" TEXT NOT NULL,
+    "scopeStart" INTEGER NOT NULL,
+    "scopeEnd" INTEGER NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+INSERT INTO "new_Annotation" ("createdAt", "id", "intentType", "scopeEnd", "scopeStart", "transcript") SELECT "createdAt", "id", "intentType", "scopeEnd", "scopeStart", "transcript" FROM "Annotation";
+DROP TABLE "Annotation";
+ALTER TABLE "new_Annotation" RENAME TO "Annotation";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE INDEX "DocCommit_documentId_createdAt_idx" ON "DocCommit"("documentId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,12 +54,17 @@ model AuditLog {
   overrideReason      String?
 }
 
-/// Git-model document history — content-addressed snapshots in an append-only
-/// linear chain (parent pointers). Restore creates a NEW commit; history is
+/// Git-model document history — two-level content-addressed snapshots in an
+/// append-only linear chain (parent pointers). `contentHash` covers the
+/// document content only ("tree"); `hash` (the id) additionally covers
+/// attribution — parent, kind, message, actor, annotationId, auditIds,
+/// modelVersion ("commit") — so same-content versions with different
+/// provenance are distinct records. Restore creates a NEW commit; history is
 /// never rewritten. EU AI Act Article 12 record-keeping surface.
 /// Append-only: no update/delete operations permitted on history records.
 model DocCommit {
   hash            String   @id
+  contentHash     String
   documentId      String
   parentHash      String?
   kind            String   // 'import' | 'apply' | 'direct' | 'restore'
@@ -73,4 +78,5 @@ model DocCommit {
   createdAt       DateTime @default(now())
 
   @@index([documentId, createdAt])
+  @@index([documentId, parentHash])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,19 +7,8 @@ datasource db {
   provider = "sqlite"
 }
 
-model DocumentSource {
-  id          String       @id @default(cuid())
-  content     String
-  version     Int          @default(1)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  annotations Annotation[]
-}
-
 model Annotation {
   id          String        @id @default(cuid())
-  sourceId    String
-  source      DocumentSource @relation(fields: [sourceId], references: [id], onDelete: Cascade)
   transcript  String
   intentType  String
   scopeStart  Int
@@ -63,4 +52,25 @@ model AuditLog {
   graphNodesUsed      String     @default("[]")
   overrideOf          String?
   overrideReason      String?
+}
+
+/// Git-model document history — content-addressed snapshots in an append-only
+/// linear chain (parent pointers). Restore creates a NEW commit; history is
+/// never rewritten. EU AI Act Article 12 record-keeping surface.
+/// Append-only: no update/delete operations permitted on history records.
+model DocCommit {
+  hash            String   @id
+  documentId      String
+  parentHash      String?
+  kind            String   // 'import' | 'apply' | 'direct' | 'restore'
+  message         String
+  docJson         String
+  blockIdsTouched String   @default("[]")
+  annotationId    String?
+  auditIds        String   @default("[]")
+  actor           String   @default("human")
+  modelVersion    String   @default("")
+  createdAt       DateTime @default(now())
+
+  @@index([documentId, createdAt])
 }

--- a/src/app/api/history/__tests__/route.test.ts
+++ b/src/app/api/history/__tests__/route.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import {
+  computeCommitHash,
+  computeContentHash,
+} from '@/lib/history/canonical'
+
+// ---------------------------------------------------------------------------
+// In-memory Prisma double for the DocCommit table. The route only uses
+// findUnique / findFirst / findMany / create, so the double implements the
+// exact query shapes route.ts issues.
+// ---------------------------------------------------------------------------
+
+interface Row {
+  hash: string
+  contentHash: string
+  documentId: string
+  parentHash: string | null
+  kind: string
+  message: string
+  docJson: string
+  blockIdsTouched: string
+  annotationId: string | null
+  auditIds: string
+  actor: string
+  modelVersion: string
+  createdAt: Date
+}
+
+let rows: Row[] = []
+let clock = 0
+/** When true, the next create() simulates losing a race: a concurrent
+ *  identical request lands first, so ours hits the unique constraint. */
+let loseCreateRaceOnce = false
+let lastFindManyArgs: any = null
+
+function matches(row: Row, where: any): boolean {
+  if (where.hash !== undefined && row.hash !== where.hash) return false
+  if (where.documentId !== undefined && row.documentId !== where.documentId) return false
+  if (where.parentHash !== undefined && row.parentHash !== where.parentHash) return false
+  if (where.NOT?.hash !== undefined && row.hash === where.NOT.hash) return false
+  if (where.createdAt?.lt !== undefined && !(row.createdAt < where.createdAt.lt)) return false
+  return true
+}
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    docCommit: {
+      findUnique: async ({ where }: any) => rows.find((r) => r.hash === where.hash) ?? null,
+      findFirst: async ({ where }: any) => rows.find((r) => matches(r, where)) ?? null,
+      findMany: async (args: any) => {
+        lastFindManyArgs = args
+        return rows
+          .filter((r) => matches(r, args.where))
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, args.take)
+      },
+      create: async ({ data }: any) => {
+        const insert = (): Row => {
+          const row: Row = {
+            ...data,
+            annotationId: data.annotationId ?? null,
+            createdAt: new Date(1700000000000 + clock++ * 1000),
+          }
+          rows.push(row)
+          return row
+        }
+        if (loseCreateRaceOnce) {
+          loseCreateRaceOnce = false
+          insert() // the concurrent identical request wins first…
+          throw new Error('Unique constraint failed on the fields: (`hash`)')
+        }
+        if (rows.some((r) => r.hash === data.hash)) {
+          throw new Error('Unique constraint failed on the fields: (`hash`)')
+        }
+        return insert()
+      },
+    },
+  },
+}))
+
+// Import AFTER the mock so route.ts binds to the double.
+import { GET, POST } from '../route'
+
+beforeEach(() => {
+  rows = []
+  clock = 0
+  loseCreateRaceOnce = false
+  lastFindManyArgs = null
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function docJsonWithText(text: string) {
+  return JSON.stringify({
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  })
+}
+
+interface BodyOverrides {
+  documentId?: string
+  parentHash?: string | null
+  kind?: string
+  message?: string
+  actor?: string
+  annotationId?: string | null
+  auditIds?: string[]
+  modelVersion?: string
+}
+
+/** A fully valid, correctly hashed commit body. */
+async function validBody(docJson: string, over: BodyOverrides = {}) {
+  const documentId = over.documentId ?? 'doc-1'
+  const parentHash = over.parentHash ?? null
+  const kind = over.kind ?? 'direct'
+  const message = over.message ?? 'Edited document'
+  const actor = over.actor ?? 'human'
+  const annotationId = over.annotationId ?? null
+  const auditIds = over.auditIds ?? []
+  const modelVersion = over.modelVersion ?? ''
+  const contentHash = await computeContentHash(docJson)
+  const hash = await computeCommitHash({
+    documentId,
+    parentHash,
+    contentHash,
+    kind,
+    message,
+    actor,
+    annotationId,
+    auditIds,
+    modelVersion,
+  })
+  return {
+    action: 'commit',
+    hash,
+    contentHash,
+    documentId,
+    parentHash: parentHash ?? undefined,
+    kind,
+    message,
+    docJson,
+    blockIdsTouched: '[]',
+    annotationId: annotationId ?? undefined,
+    auditIds: JSON.stringify(auditIds),
+    actor,
+    modelVersion,
+  }
+}
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/history', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function getRequest(query: string) {
+  return new NextRequest(`http://localhost/api/history?${query}`)
+}
+
+async function seedRoot(text = 'root') {
+  const body = await validBody(docJsonWithText(text), { kind: 'import', message: 'Created' })
+  const res = await POST(postRequest(body))
+  expect(res.status).toBe(200)
+  return body.hash
+}
+
+// ---------------------------------------------------------------------------
+// POST — verification + linearity
+// ---------------------------------------------------------------------------
+
+describe('POST /api/history', () => {
+  it('accepts a valid root commit and stores both hashes', async () => {
+    const hash = await seedRoot()
+    expect(rows).toHaveLength(1)
+    expect(rows[0].hash).toBe(hash)
+    expect(rows[0].contentHash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('400s when the contentHash does not prove the content', async () => {
+    const body = await validBody(docJsonWithText('a'))
+    body.contentHash = await computeContentHash(docJsonWithText('tampered'))
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/Content hash mismatch/)
+  })
+
+  it('400s when the commit hash does not prove the attribution (tampered actor)', async () => {
+    const body = await validBody(docJsonWithText('a'), { actor: 'human' })
+    body.actor = 'ai+human' // provenance edit after hashing
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/Hash mismatch/)
+  })
+
+  it('409 stale-head: rejects a second root for the same document', async () => {
+    await seedRoot('first root')
+    const body = await validBody(docJsonWithText('second root'), {
+      kind: 'import',
+      message: 'Created again',
+    })
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ reason: 'stale-head' })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('409 stale-head: rejects a second child of the same parent (fork race)', async () => {
+    const root = await seedRoot()
+    const applyBody = await validBody(docJsonWithText('ai content'), {
+      parentHash: root,
+      kind: 'apply',
+      actor: 'ai+human',
+      message: 'AI change',
+    })
+    expect((await POST(postRequest(applyBody))).status).toBe(200)
+
+    // A 'direct' autosave still parenting the stale head must NOT fork.
+    const directBody = await validBody(docJsonWithText('typed content'), {
+      parentHash: root,
+      kind: 'direct',
+    })
+    const res = await POST(postRequest(directBody))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ reason: 'stale-head' })
+    expect(rows).toHaveLength(2)
+  })
+
+  it('200s an identical duplicate POST (idempotent re-send)', async () => {
+    const body = await validBody(docJsonWithText('a'), { kind: 'import', message: 'Created' })
+    expect((await POST(postRequest(body))).status).toBe(200)
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ hash: body.hash, existing: true })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('200s when two concurrent identical POSTs race into the unique constraint', async () => {
+    const body = await validBody(docJsonWithText('a'), { kind: 'import', message: 'Created' })
+    loseCreateRaceOnce = true // our create hits the PK collision
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ hash: body.hash, existing: true })
+    expect(rows).toHaveLength(1)
+  })
+
+  it('400s an unknown parent', async () => {
+    await seedRoot()
+    const body = await validBody(docJsonWithText('b'), { parentHash: 'nope'.repeat(16) })
+    const res = await POST(postRequest(body))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/parentHash/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET — limit sanitization + before cursor
+// ---------------------------------------------------------------------------
+
+describe('GET /api/history', () => {
+  async function seedChain(texts: string[]) {
+    let parent: string | null = null
+    for (const text of texts) {
+      const body = await validBody(docJsonWithText(text), {
+        parentHash: parent,
+        kind: parent ? 'direct' : 'import',
+        message: text,
+      })
+      const res = await POST(postRequest(body))
+      expect(res.status).toBe(200)
+      parent = body.hash
+    }
+  }
+
+  it('sanitizes a NaN limit to the default instead of passing take:NaN to Prisma', async () => {
+    await seedChain(['a', 'b'])
+    const res = await GET(getRequest('documentId=doc-1&limit=abc'))
+    expect(res.status).toBe(200)
+    expect(lastFindManyArgs.take).toBe(100)
+    expect((await res.json()).commits).toHaveLength(2)
+  })
+
+  it('clamps negative and oversized limits into 1..200', async () => {
+    await seedChain(['a', 'b', 'c'])
+    await GET(getRequest('documentId=doc-1&limit=-5'))
+    expect(lastFindManyArgs.take).toBe(1)
+    await GET(getRequest('documentId=doc-1&limit=99999'))
+    expect(lastFindManyArgs.take).toBe(200)
+  })
+
+  it('pages past the first batch with the ?before cursor', async () => {
+    await seedChain(['a', 'b', 'c'])
+    const first = await GET(getRequest('documentId=doc-1&limit=2'))
+    const page1 = (await first.json()).commits
+    expect(page1).toHaveLength(2)
+    expect(page1.map((c: any) => c.message)).toEqual(['c', 'b'])
+
+    const cursor = encodeURIComponent(new Date(page1[1].createdAt).toISOString())
+    const second = await GET(getRequest(`documentId=doc-1&limit=2&before=${cursor}`))
+    const page2 = (await second.json()).commits
+    expect(page2.map((c: any) => c.message)).toEqual(['a'])
+  })
+
+  it('ignores an invalid before cursor', async () => {
+    await seedChain(['a', 'b'])
+    const res = await GET(getRequest('documentId=doc-1&before=not-a-date'))
+    expect((await res.json()).commits).toHaveLength(2)
+  })
+})

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,25 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
-import { computeCommitHash } from '@/lib/history/canonical'
+import { computeCommitHash, computeContentHash } from '@/lib/history/canonical'
 
 /**
  * /api/history — append-only, content-addressed document version history.
  *
  * EU AI Act Article 12 record-keeping: every version of a document is kept as
- * an immutable snapshot in a linear parent-pointer chain. This endpoint ONLY
- * creates and reads records — no update or delete operations exist, and
- * restores are recorded as NEW versions (history is never rewritten).
+ * a snapshot in a linear parent-pointer chain. This endpoint ONLY creates and
+ * reads records — no update or delete operations exist, and restores are
+ * recorded as NEW versions (history is never rewritten). Append-only is
+ * enforced at the application layer; hash verification makes stored records
+ * tamper-evident against partial modification.
  *
- * Integrity: the server recomputes the sha256 hash from
- * (canonical docJson + parentHash + documentId) and rejects mismatches, so a
- * stored hash always proves the stored content.
+ * Integrity (two-level, git's design):
+ *   - contentHash = sha256(canonical docJson)               — the "tree"
+ *   - hash        = sha256(canonical join of documentId, parentHash,
+ *                    contentHash, kind, message, actor, annotationId,
+ *                    auditIds, modelVersion)                 — the "commit"
+ * The server recomputes BOTH from the payload and rejects either mismatch,
+ * so a stored hash proves the stored content AND its attribution.
+ *
+ * Linearity: one root per document, one child per parent. A write that would
+ * fork the chain is rejected with 409 { reason: 'stale-head' } so the client
+ * can rebase onto the new head and retry.
  */
 
 const VALID_KINDS = new Set(['import', 'apply', 'direct', 'restore'])
 
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 200
+
 // Metadata projection — docJson is only returned for single-version lookups.
 const COMMIT_META_SELECT = {
   hash: true,
+  contentHash: true,
   documentId: true,
   parentHash: true,
   kind: true,
@@ -37,7 +51,9 @@ const COMMIT_META_SELECT = {
  *
  * Query params:
  *   ?documentId=... — version metadata for a document (no docJson),
- *                     newest first, capped at 200 (?limit=N to narrow)
+ *                     newest first, default page of 100 (?limit=N, 1..200)
+ *   &before=<ISO>   — cursor: only versions strictly older than this
+ *                     createdAt (for paging past the first page)
  *   ?hash=...       — one version, including its full docJson
  */
 export async function GET(request: NextRequest) {
@@ -55,9 +71,19 @@ export async function GET(request: NextRequest) {
     }
 
     if (documentId) {
-      const limit = Math.min(Number(searchParams.get('limit') ?? 200), 200)
+      // Sanitize limit: NaN, negatives, and out-of-range values must never
+      // reach Prisma as take:NaN / take:-n.
+      const rawLimit = Number(searchParams.get('limit') ?? DEFAULT_LIMIT)
+      const limit = Number.isFinite(rawLimit)
+        ? Math.min(Math.max(Math.floor(rawLimit), 1), MAX_LIMIT)
+        : DEFAULT_LIMIT
+
+      const beforeParam = searchParams.get('before')
+      const before = beforeParam ? new Date(beforeParam) : null
+      const useBefore = before !== null && !Number.isNaN(before.getTime())
+
       const commits = await prisma.docCommit.findMany({
-        where: { documentId },
+        where: useBefore ? { documentId, createdAt: { lt: before } } : { documentId },
         orderBy: { createdAt: 'desc' },
         take: limit,
         select: COMMIT_META_SELECT,
@@ -81,15 +107,18 @@ export async function GET(request: NextRequest) {
 /**
  * POST /api/history — append-only version writer.
  *
- * Body: { action: 'commit', hash, documentId, parentHash, kind, message,
- *         docJson, blockIdsTouched?, annotationId?, auditIds?, actor?,
- *         modelVersion? }
+ * Body: { action: 'commit', hash, contentHash, documentId, parentHash, kind,
+ *         message, docJson, blockIdsTouched?, annotationId?, auditIds?,
+ *         actor?, modelVersion? }
  *
- * Rejections:
- *   400 — hash mismatch (server recomputes from canonical payload)
+ * Responses:
+ *   400 — contentHash mismatch (server recomputes from canonical docJson)
+ *   400 — hash mismatch (server recomputes from content + attribution)
  *   400 — parentHash given but no such version exists for the document
- *   409 — duplicate hash with a different payload
- *   200 — duplicate hash with an identical payload (idempotent re-send)
+ *   409 { reason: 'stale-head' } — the parent already has a child, or a root
+ *         already exists (a write that would fork the chain)
+ *   200 — duplicate hash (a true full duplicate by construction: the hash
+ *         covers content and attribution) — idempotent re-send
  */
 export async function POST(request: NextRequest) {
   try {
@@ -105,51 +134,88 @@ export async function POST(request: NextRequest) {
     const kind = typeof params.kind === 'string' ? params.kind : ''
     const message = typeof params.message === 'string' ? params.message : ''
     const hash = typeof params.hash === 'string' ? params.hash : ''
+    const contentHash = typeof params.contentHash === 'string' ? params.contentHash : ''
+    const actor = typeof params.actor === 'string' ? params.actor : 'human'
+    const modelVersion = typeof params.modelVersion === 'string' ? params.modelVersion : ''
+    const annotationId = typeof params.annotationId === 'string' ? params.annotationId : null
     const parentHash =
       typeof params.parentHash === 'string' && params.parentHash.length > 0
         ? params.parentHash
         : null
 
-    if (!documentId || !docJson || !hash || !message || !VALID_KINDS.has(kind)) {
+    if (!documentId || !docJson || !hash || !contentHash || !message || !VALID_KINDS.has(kind)) {
       return NextResponse.json(
-        { error: 'hash, documentId, docJson, message, and a valid kind are required' },
+        {
+          error:
+            'hash, contentHash, documentId, docJson, message, and a valid kind are required',
+        },
         { status: 400 },
       )
     }
 
-    // Integrity: the hash must prove the content. Recompute server-side.
-    let expectedHash: string
+    // auditIds arrives as a JSON string; its parsed array form is part of the
+    // commit-hash payload, so it must be a well-formed string array.
+    let auditIds: string[]
     try {
-      expectedHash = await computeCommitHash(docJson, parentHash, documentId)
+      const parsed: unknown = JSON.parse(
+        typeof params.auditIds === 'string' ? params.auditIds : '[]',
+      )
+      if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== 'string')) {
+        throw new Error('not a string array')
+      }
+      auditIds = parsed
+    } catch {
+      return NextResponse.json(
+        { error: 'auditIds must be a JSON array of strings' },
+        { status: 400 },
+      )
+    }
+
+    // Integrity level 1: the content hash must prove the content.
+    let expectedContentHash: string
+    try {
+      expectedContentHash = await computeContentHash(docJson)
     } catch {
       return NextResponse.json({ error: 'docJson is not valid JSON' }, { status: 400 })
     }
-    if (expectedHash !== hash) {
+    if (expectedContentHash !== contentHash) {
       return NextResponse.json(
-        { error: 'Hash mismatch: payload does not match its content address' },
+        { error: 'Content hash mismatch: docJson does not match its content address' },
         { status: 400 },
       )
     }
 
-    // Idempotency: same hash + same payload is a no-op re-send; same hash with
-    // a different payload is a conflict (never overwrite history).
-    const existing = await prisma.docCommit.findUnique({ where: { hash } })
-    if (existing) {
-      const identical =
-        existing.documentId === documentId &&
-        existing.parentHash === parentHash &&
-        existing.docJson === docJson
-      if (identical) {
-        return NextResponse.json({ hash: existing.hash, existing: true })
-      }
+    // Integrity level 2: the commit hash must prove content + attribution.
+    const expectedHash = await computeCommitHash({
+      documentId,
+      parentHash,
+      contentHash,
+      kind,
+      message,
+      actor,
+      annotationId,
+      auditIds,
+      modelVersion,
+    })
+    if (expectedHash !== hash) {
       return NextResponse.json(
-        { error: 'A different version with this hash already exists' },
-        { status: 409 },
+        { error: 'Hash mismatch: payload does not match its commit address' },
+        { status: 400 },
       )
     }
 
-    // The parent must be a real version of the same document (linear chain).
+    // Idempotency: the hash covers content AND attribution, so a duplicate
+    // hash is a true full duplicate — treat the re-send as a no-op.
+    const existing = await prisma.docCommit.findUnique({
+      where: { hash },
+      select: { hash: true },
+    })
+    if (existing) {
+      return NextResponse.json({ hash: existing.hash, existing: true })
+    }
+
     if (parentHash) {
+      // The parent must be a real version of the same document.
       const parent = await prisma.docCommit.findFirst({
         where: { hash: parentHash, documentId },
         select: { hash: true },
@@ -160,24 +226,71 @@ export async function POST(request: NextRequest) {
           { status: 400 },
         )
       }
+      // Linearity: one child per parent. A second child means the writer's
+      // head is stale — reject so it can rebase and retry. (A row with the
+      // SAME hash is not a fork — it's a concurrent identical re-send, which
+      // the unique-constraint catch below resolves idempotently.)
+      const sibling = await prisma.docCommit.findFirst({
+        where: { documentId, parentHash, NOT: { hash } },
+        select: { hash: true },
+      })
+      if (sibling) {
+        return NextResponse.json(
+          {
+            error: 'Stale head: this parent already has a newer version',
+            reason: 'stale-head',
+          },
+          { status: 409 },
+        )
+      }
+    } else {
+      // Linearity: one root per document (same identical-re-send carve-out).
+      const anyCommit = await prisma.docCommit.findFirst({
+        where: { documentId, NOT: { hash } },
+        select: { hash: true },
+      })
+      if (anyCommit) {
+        return NextResponse.json(
+          {
+            error: 'Stale head: this document already has a version history',
+            reason: 'stale-head',
+          },
+          { status: 409 },
+        )
+      }
     }
 
-    const record = await prisma.docCommit.create({
-      data: {
-        hash,
-        documentId,
-        parentHash,
-        kind,
-        message,
-        docJson,
-        blockIdsTouched: typeof params.blockIdsTouched === 'string' ? params.blockIdsTouched : '[]',
-        annotationId: typeof params.annotationId === 'string' ? params.annotationId : undefined,
-        auditIds: typeof params.auditIds === 'string' ? params.auditIds : '[]',
-        actor: typeof params.actor === 'string' ? params.actor : 'human',
-        modelVersion: typeof params.modelVersion === 'string' ? params.modelVersion : '',
-      },
-    })
-    return NextResponse.json({ hash: record.hash })
+    try {
+      const record = await prisma.docCommit.create({
+        data: {
+          hash,
+          contentHash,
+          documentId,
+          parentHash,
+          kind,
+          message,
+          docJson,
+          blockIdsTouched:
+            typeof params.blockIdsTouched === 'string' ? params.blockIdsTouched : '[]',
+          annotationId: annotationId ?? undefined,
+          auditIds: JSON.stringify(auditIds),
+          actor,
+          modelVersion,
+        },
+      })
+      return NextResponse.json({ hash: record.hash })
+    } catch (createErr) {
+      // Two concurrent IDENTICAL POSTs can race past the duplicate check and
+      // collide on the primary key — that is still an idempotent success.
+      const racedExisting = await prisma.docCommit.findUnique({
+        where: { hash },
+        select: { hash: true },
+      })
+      if (racedExisting) {
+        return NextResponse.json({ hash: racedExisting.hash, existing: true })
+      }
+      throw createErr
+    }
   } catch (err) {
     console.error('[/api/history] Error:', err)
     return NextResponse.json(

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { computeCommitHash } from '@/lib/history/canonical'
+
+/**
+ * /api/history — append-only, content-addressed document version history.
+ *
+ * EU AI Act Article 12 record-keeping: every version of a document is kept as
+ * an immutable snapshot in a linear parent-pointer chain. This endpoint ONLY
+ * creates and reads records — no update or delete operations exist, and
+ * restores are recorded as NEW versions (history is never rewritten).
+ *
+ * Integrity: the server recomputes the sha256 hash from
+ * (canonical docJson + parentHash + documentId) and rejects mismatches, so a
+ * stored hash always proves the stored content.
+ */
+
+const VALID_KINDS = new Set(['import', 'apply', 'direct', 'restore'])
+
+// Metadata projection — docJson is only returned for single-version lookups.
+const COMMIT_META_SELECT = {
+  hash: true,
+  documentId: true,
+  parentHash: true,
+  kind: true,
+  message: true,
+  blockIdsTouched: true,
+  annotationId: true,
+  auditIds: true,
+  actor: true,
+  modelVersion: true,
+  createdAt: true,
+} as const
+
+/**
+ * GET /api/history — read version history (read-only).
+ *
+ * Query params:
+ *   ?documentId=... — version metadata for a document (no docJson),
+ *                     newest first, capped at 200 (?limit=N to narrow)
+ *   ?hash=...       — one version, including its full docJson
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl
+    const hash = searchParams.get('hash')
+    const documentId = searchParams.get('documentId')
+
+    if (hash) {
+      const commit = await prisma.docCommit.findUnique({ where: { hash } })
+      if (!commit) {
+        return NextResponse.json({ error: 'Version not found' }, { status: 404 })
+      }
+      return NextResponse.json({ commit })
+    }
+
+    if (documentId) {
+      const limit = Math.min(Number(searchParams.get('limit') ?? 200), 200)
+      const commits = await prisma.docCommit.findMany({
+        where: { documentId },
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        select: COMMIT_META_SELECT,
+      })
+      return NextResponse.json({ commits })
+    }
+
+    return NextResponse.json(
+      { error: 'documentId or hash query param required' },
+      { status: 400 },
+    )
+  } catch (err) {
+    console.error('[/api/history GET] Error:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to fetch history' },
+      { status: 500 },
+    )
+  }
+}
+
+/**
+ * POST /api/history — append-only version writer.
+ *
+ * Body: { action: 'commit', hash, documentId, parentHash, kind, message,
+ *         docJson, blockIdsTouched?, annotationId?, auditIds?, actor?,
+ *         modelVersion? }
+ *
+ * Rejections:
+ *   400 — hash mismatch (server recomputes from canonical payload)
+ *   400 — parentHash given but no such version exists for the document
+ *   409 — duplicate hash with a different payload
+ *   200 — duplicate hash with an identical payload (idempotent re-send)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const { action, ...params } = body
+
+    if (action !== 'commit') {
+      return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+    }
+
+    const documentId = typeof params.documentId === 'string' ? params.documentId : ''
+    const docJson = typeof params.docJson === 'string' ? params.docJson : ''
+    const kind = typeof params.kind === 'string' ? params.kind : ''
+    const message = typeof params.message === 'string' ? params.message : ''
+    const hash = typeof params.hash === 'string' ? params.hash : ''
+    const parentHash =
+      typeof params.parentHash === 'string' && params.parentHash.length > 0
+        ? params.parentHash
+        : null
+
+    if (!documentId || !docJson || !hash || !message || !VALID_KINDS.has(kind)) {
+      return NextResponse.json(
+        { error: 'hash, documentId, docJson, message, and a valid kind are required' },
+        { status: 400 },
+      )
+    }
+
+    // Integrity: the hash must prove the content. Recompute server-side.
+    let expectedHash: string
+    try {
+      expectedHash = await computeCommitHash(docJson, parentHash, documentId)
+    } catch {
+      return NextResponse.json({ error: 'docJson is not valid JSON' }, { status: 400 })
+    }
+    if (expectedHash !== hash) {
+      return NextResponse.json(
+        { error: 'Hash mismatch: payload does not match its content address' },
+        { status: 400 },
+      )
+    }
+
+    // Idempotency: same hash + same payload is a no-op re-send; same hash with
+    // a different payload is a conflict (never overwrite history).
+    const existing = await prisma.docCommit.findUnique({ where: { hash } })
+    if (existing) {
+      const identical =
+        existing.documentId === documentId &&
+        existing.parentHash === parentHash &&
+        existing.docJson === docJson
+      if (identical) {
+        return NextResponse.json({ hash: existing.hash, existing: true })
+      }
+      return NextResponse.json(
+        { error: 'A different version with this hash already exists' },
+        { status: 409 },
+      )
+    }
+
+    // The parent must be a real version of the same document (linear chain).
+    if (parentHash) {
+      const parent = await prisma.docCommit.findFirst({
+        where: { hash: parentHash, documentId },
+        select: { hash: true },
+      })
+      if (!parent) {
+        return NextResponse.json(
+          { error: 'parentHash does not reference a version of this document' },
+          { status: 400 },
+        )
+      }
+    }
+
+    const record = await prisma.docCommit.create({
+      data: {
+        hash,
+        documentId,
+        parentHash,
+        kind,
+        message,
+        docJson,
+        blockIdsTouched: typeof params.blockIdsTouched === 'string' ? params.blockIdsTouched : '[]',
+        annotationId: typeof params.annotationId === 'string' ? params.annotationId : undefined,
+        auditIds: typeof params.auditIds === 'string' ? params.auditIds : '[]',
+        actor: typeof params.actor === 'string' ? params.actor : 'human',
+        modelVersion: typeof params.modelVersion === 'string' ? params.modelVersion : '',
+      },
+    })
+    return NextResponse.json({ hash: record.hash })
+  } catch (err) {
+    console.error('[/api/history] Error:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'History write failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { useChangesStore } from '@/stores/changesStore'
+import { useSettingsStore } from '@/stores/settingsStore'
 import { useToastStore } from '@/stores/toastStore'
 import { removeAnnotationDecoration } from '@/lib/prosemirror/plugins/annotationPlugin'
 import { generateId } from '@/lib/utils/id'
@@ -14,6 +15,8 @@ import { recordHumanDecision, handlerToApprovalAction } from '@/lib/audit/approv
 import { applyUncertaintyFromLogprobs, applyUncertaintyFromFlags } from '@/lib/ai/uncertainty'
 import { getProposedAnchors } from '@/lib/prosemirror/plugins/proposedChangePlugin'
 import { applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
+import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
+import { createCommit } from '@/lib/history/commits'
 import { SemanticCommitModal } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
@@ -83,6 +86,44 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     }
   }
 
+  // Version-history capture for applied AI changes (fire-and-forget — never
+  // blocks the apply path). Records the post-apply document as an 'apply'
+  // version linked to this annotation and its audit records, then stamps the
+  // change set with the resulting version hash.
+  const recordApplyCommit = (blockIdsTouched: string[]) => {
+    const currentView = useEditorStore.getState().view
+    if (!currentView) return
+    const auditIds =
+      changeSet && changeSet.auditRecordIds.length > 0
+        ? changeSet.auditRecordIds
+        : annotation.resolution?.auditId
+          ? [annotation.resolution.auditId]
+          : []
+    const transcript = annotation.transcript.trim()
+    const message = !transcript
+      ? 'AI change applied'
+      : transcript.length > 72
+        ? `${transcript.slice(0, 69)}...`
+        : transcript
+    createCommit({
+      docJson: currentView.state.doc.toJSON(),
+      documentId: annotation.documentId,
+      kind: 'apply',
+      message,
+      annotationId: annotation.id,
+      auditIds,
+      blockIdsTouched,
+      actor: 'ai+human',
+      modelVersion: useSettingsStore.getState().llmConfig.model,
+    })
+      .then((hash) => {
+        if (changeSetId) {
+          useChangesStore.getState().setChangeSetCommitHash(changeSetId, hash)
+        }
+      })
+      .catch((err) => console.warn('[history] Failed to record version:', err))
+  }
+
   const applyConfirmedEdit = (acceptedIds?: string[]) => {
     // Multi-region path: a cascade run produced several proposed edits. Apply the
     // user-accepted subset (from the commit modal) in one validated transaction
@@ -126,6 +167,11 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         useChangesStore.getState().updateChangeSetStatus(changeSetId, 'approved')
       }
       updateAnnotation(annotation.id, { status: 'applied' })
+      recordApplyCommit(
+        result.applied
+          .map((ap) => ap.blockId)
+          .filter((blockId): blockId is string => Boolean(blockId)),
+      )
       useToastStore.getState().addToast(
         `Applied ${result.applied.length} change${result.applied.length > 1 ? 's' : ''}`,
         'success',
@@ -145,6 +191,9 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
 
     const edit = annotation.resolution?.suggestedEdit
     if (!edit || !view) return
+
+    // Resolve the touched block before the positions shift under the apply.
+    const editedBlockId = blockIdAtPos(view.state.doc, edit.from)
 
     // Apply the edit to the document
     const tr = view.state.tr.replaceWith(
@@ -175,6 +224,7 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     }
 
     updateAnnotation(annotation.id, { status: 'applied' })
+    recordApplyCommit(editedBlockId ? [editedBlockId] : [])
 
     // Apply uncertainty highlights to the newly inserted text
     const newTo = edit.from + edit.newText.length

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -116,7 +116,7 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       actor: 'ai+human',
       modelVersion: useSettingsStore.getState().llmConfig.model,
     })
-      .then((hash) => {
+      .then(({ hash }) => {
         if (changeSetId) {
           useChangesStore.getState().setChangeSetCommitHash(changeSetId, hash)
         }

--- a/src/components/Editor/EditorShell.tsx
+++ b/src/components/Editor/EditorShell.tsx
@@ -111,7 +111,18 @@ export function EditorShell() {
         clearTimeout(saveTimerRef.current)
         const ds = useDocumentStore.getState()
         if (ds.activeDocumentId && ds.isDirty) {
-          ds.saveDocument(ds.activeDocumentId, view.state.doc.toJSON())
+          const docJson = view.state.doc.toJSON()
+          ds.saveDocument(ds.activeDocumentId, docJson)
+          // Keep history in step with localStorage: without this, an unmount
+          // flush leaves localStorage permanently ahead of the version chain.
+          // Content-hash dedupe makes it free when nothing changed.
+          recordCommit({
+            docJson,
+            documentId: ds.activeDocumentId,
+            kind: 'direct',
+            message: 'Edited document',
+            actor: 'human',
+          })
         }
       }
       cancelScheduledDocGraphRebuild()
@@ -135,7 +146,17 @@ export function EditorShell() {
         clearTimeout(saveTimerRef.current)
         saveTimerRef.current = null
       }
-      docStore.saveDocument(previousDocumentId, view.state.doc.toJSON())
+      const docJson = view.state.doc.toJSON()
+      docStore.saveDocument(previousDocumentId, docJson)
+      // Doc-switch flush must reach the version chain too (see unmount flush
+      // above) — dedupe makes it a no-op when the content is unchanged.
+      recordCommit({
+        docJson,
+        documentId: previousDocumentId,
+        kind: 'direct',
+        message: 'Edited document',
+        actor: 'human',
+      })
     }
 
     const json = activeDocumentId

--- a/src/components/Editor/EditorShell.tsx
+++ b/src/components/Editor/EditorShell.tsx
@@ -11,6 +11,7 @@ import { useDocumentStore } from '@/stores/documentStore'
 import { setChangeCallback } from '@/lib/prosemirror/plugins/changeTrackingPlugin'
 import { scheduleDocGraphRebuild, cancelScheduledDocGraphRebuild } from '@/lib/graphrag/docGraph'
 import { useChangesStore } from '@/stores/changesStore'
+import { recordCommit } from '@/lib/history/commits'
 import { ConflictTooltip } from './ConflictTooltip'
 import { UncertaintyTooltip } from './UncertaintyTooltip'
 import { ProposedEditControl } from './ProposedEditControl'
@@ -32,10 +33,17 @@ export function EditorShell() {
     saveTimerRef.current = setTimeout(() => {
       const docStore = useDocumentStore.getState()
       if (docStore.activeDocumentId) {
-        docStore.saveDocument(
-          docStore.activeDocumentId,
-          view.state.doc.toJSON()
-        )
+        const docJson = view.state.doc.toJSON()
+        docStore.saveDocument(docStore.activeDocumentId, docJson)
+        // Version-history capture (fire-and-forget). Content-hash dedupe
+        // makes flushes with unchanged content free.
+        recordCommit({
+          docJson,
+          documentId: docStore.activeDocumentId,
+          kind: 'direct',
+          message: 'Edited document',
+          actor: 'human',
+        })
       }
     }, AUTOSAVE_DELAY)
   }, [])

--- a/src/components/History/HistoryPanel.tsx
+++ b/src/components/History/HistoryPanel.tsx
@@ -1,0 +1,408 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useEditorStore } from '@/stores/editorStore'
+import { useToastStore } from '@/stores/toastStore'
+import {
+  getCommit,
+  listCommits,
+  restoreCommit,
+  type CommitKind,
+  type CommitMeta,
+} from '@/lib/history/commits'
+import { docJsonToText } from '@/lib/history/docText'
+import { DiffViewer } from '@/components/Editor/DiffViewer'
+import { DiffView } from '@/components/Changes/DiffView'
+import { Confirmation } from '@/components/ui/Confirmation'
+
+// Word-level diffs stay readable up to a point; long documents fall back to
+// the line-level view.
+const WORD_DIFF_MAX_CHARS = 15000
+
+const KIND_LABELS: Record<CommitKind, string> = {
+  import: 'Created',
+  apply: 'AI change',
+  direct: 'Edit session',
+  restore: 'Restored',
+}
+
+const KIND_STYLES: Record<CommitKind, string> = {
+  import: 'bg-blue-100 text-blue-800',
+  apply: 'bg-purple-100 text-purple-800',
+  direct: 'bg-gray-100 text-gray-700',
+  restore: 'bg-amber-100 text-amber-800',
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const seconds = Math.round((Date.now() - then) / 1000)
+  if (seconds < 45) return 'just now'
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.round(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  if (days < 14) return `${days}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+function parseCount(jsonArray: string): number {
+  try {
+    const parsed = JSON.parse(jsonArray || '[]')
+    return Array.isArray(parsed) ? parsed.length : 0
+  } catch {
+    return 0
+  }
+}
+
+interface DiffPair {
+  before: string
+  after: string
+  beforeLabel: string
+  afterLabel: string
+}
+
+function VersionDiff({ before, after, beforeLabel, afterLabel }: DiffPair) {
+  const useWordDiff = before.length < WORD_DIFF_MAX_CHARS && after.length < WORD_DIFF_MAX_CHARS
+  return (
+    <div className="mt-3 space-y-2">
+      <p className="text-[10px] font-mono uppercase tracking-[0.18em] text-muted-foreground">
+        {beforeLabel} → {afterLabel}
+      </p>
+      {useWordDiff ? (
+        <div className="rounded-xl border border-border/70 bg-white p-3 text-sm">
+          <DiffViewer before={before} after={after} />
+        </div>
+      ) : (
+        <DiffView before={before} after={after} />
+      )}
+    </div>
+  )
+}
+
+export function HistoryPanel() {
+  const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
+  const [commits, setCommits] = useState<CommitMeta[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [expandedHash, setExpandedHash] = useState<string | null>(null)
+  const [expandedDiff, setExpandedDiff] = useState<DiffPair | 'loading' | 'first' | null>(null)
+  const [compareMode, setCompareMode] = useState(false)
+  const [compareSelection, setCompareSelection] = useState<string[]>([])
+  const [compareDiff, setCompareDiff] = useState<DiffPair | 'loading' | null>(null)
+  const [restoreTarget, setRestoreTarget] = useState<CommitMeta | null>(null)
+  const [restoring, setRestoring] = useState(false)
+
+  const fetchHistory = useCallback(async () => {
+    if (!activeDocumentId) {
+      setCommits([])
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      setCommits(await listCommits(activeDocumentId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load version history')
+    } finally {
+      setLoading(false)
+    }
+  }, [activeDocumentId])
+
+  useEffect(() => {
+    fetchHistory()
+    setExpandedHash(null)
+    setExpandedDiff(null)
+    setCompareMode(false)
+    setCompareSelection([])
+    setCompareDiff(null)
+  }, [fetchHistory])
+
+  const shortLabel = (hash: string) => `version ${hash.slice(0, 8)}`
+
+  const loadRowDiff = async (commit: CommitMeta) => {
+    if (!commit.parentHash) {
+      setExpandedDiff('first')
+      return
+    }
+    setExpandedDiff('loading')
+    try {
+      const [current, previous] = await Promise.all([
+        getCommit(commit.hash),
+        getCommit(commit.parentHash),
+      ])
+      if (!current || !previous) throw new Error('Version content unavailable')
+      setExpandedDiff({
+        before: docJsonToText(previous.docJson),
+        after: docJsonToText(current.docJson),
+        beforeLabel: 'Previous version',
+        afterLabel: 'This version',
+      })
+    } catch (err) {
+      setExpandedDiff(null)
+      useToastStore.getState().addToast(
+        err instanceof Error ? err.message : 'Could not load the comparison',
+        'error',
+      )
+    }
+  }
+
+  const toggleExpanded = (commit: CommitMeta) => {
+    if (expandedHash === commit.hash) {
+      setExpandedHash(null)
+      setExpandedDiff(null)
+      return
+    }
+    setExpandedHash(commit.hash)
+    loadRowDiff(commit)
+  }
+
+  const toggleCompareSelection = async (hash: string) => {
+    const next = compareSelection.includes(hash)
+      ? compareSelection.filter((h) => h !== hash)
+      : [...compareSelection.slice(-1), hash]
+    setCompareSelection(next)
+    setCompareDiff(null)
+
+    if (next.length === 2) {
+      setCompareDiff('loading')
+      try {
+        const [a, b] = await Promise.all([getCommit(next[0]), getCommit(next[1])])
+        if (!a || !b) throw new Error('Version content unavailable')
+        const [older, newer] =
+          new Date(a.createdAt).getTime() <= new Date(b.createdAt).getTime() ? [a, b] : [b, a]
+        setCompareDiff({
+          before: docJsonToText(older.docJson),
+          after: docJsonToText(newer.docJson),
+          beforeLabel: shortLabel(older.hash),
+          afterLabel: shortLabel(newer.hash),
+        })
+      } catch (err) {
+        setCompareDiff(null)
+        useToastStore.getState().addToast(
+          err instanceof Error ? err.message : 'Could not load the comparison',
+          'error',
+        )
+      }
+    }
+  }
+
+  const handleRestore = async () => {
+    const target = restoreTarget
+    const view = useEditorStore.getState().view
+    if (!target || !view || !activeDocumentId || restoring) return
+    setRestoring(true)
+    try {
+      const full = await getCommit(target.hash)
+      if (!full) throw new Error('Version content unavailable')
+      await restoreCommit(view, full, activeDocumentId)
+      useToastStore.getState().addToast('Version restored — a new version was created', 'success')
+      setRestoreTarget(null)
+      setExpandedHash(null)
+      setExpandedDiff(null)
+      await fetchHistory()
+    } catch (err) {
+      useToastStore.getState().addToast(
+        err instanceof Error ? err.message : 'Restore failed',
+        'error',
+      )
+    } finally {
+      setRestoring(false)
+    }
+  }
+
+  if (!activeDocumentId) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-center px-6">
+        <p className="text-sm text-muted">No document selected</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 space-y-4 h-full overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xs font-mono uppercase tracking-[0.2em] text-muted">History</h2>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => {
+              setCompareMode((prev) => !prev)
+              setCompareSelection([])
+              setCompareDiff(null)
+            }}
+            className={`px-2.5 py-1 rounded-full text-xs transition-colors ${
+              compareMode
+                ? 'bg-accent text-white shadow-sm'
+                : 'status-chip hover:text-ink'
+            }`}
+          >
+            Compare
+          </button>
+          <button
+            onClick={fetchHistory}
+            className="status-chip px-2.5 py-1 rounded-full text-xs hover:text-ink transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+      <p className="text-xs text-muted">
+        Every saved version of this document. Restoring never deletes anything — it adds a new
+        version on top.
+      </p>
+
+      {compareMode && (
+        <div className="rounded-2xl border border-accent/30 bg-accent/5 px-3 py-2.5">
+          <p className="text-xs text-ink">
+            Pick two versions to compare
+            {compareSelection.length > 0 && (
+              <span className="text-muted-foreground"> — {compareSelection.length} of 2 selected</span>
+            )}
+          </p>
+          {compareDiff === 'loading' && <p className="mt-2 text-xs text-muted">Loading comparison...</p>}
+          {compareDiff && compareDiff !== 'loading' && <VersionDiff {...compareDiff} />}
+        </div>
+      )}
+
+      {loading && <p className="text-xs text-muted">Loading...</p>}
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {!loading && !error && commits.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-10 text-center px-4">
+          <div className="w-12 h-12 rounded-full bg-warm flex items-center justify-center mb-3">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-muted">
+              <circle cx="12" cy="12" r="9" />
+              <polyline points="12 7 12 12 15.5 13.5" />
+            </svg>
+          </div>
+          <p className="text-sm text-muted">No versions yet</p>
+          <p className="text-xs text-muted/60 mt-1 max-w-56">
+            Every version of this document is kept here — created, AI changes you approved, your
+            edit sessions, and restores.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        {commits.map((commit, index) => {
+          const isHead = index === 0
+          const auditCount = parseCount(commit.auditIds)
+          const expanded = expandedHash === commit.hash
+          const selectedForCompare = compareSelection.includes(commit.hash)
+          return (
+            <div
+              key={commit.hash}
+              className={`border rounded-2xl bg-white/80 text-xs shadow-sm transition-colors ${
+                selectedForCompare ? 'border-accent/60' : 'border-border/70 hover:border-accent/30'
+              }`}
+            >
+              <div
+                className="px-3 py-3 cursor-pointer"
+                onClick={() =>
+                  compareMode ? toggleCompareSelection(commit.hash) : toggleExpanded(commit)
+                }
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    {compareMode && (
+                      <span
+                        aria-hidden
+                        className={`w-3.5 h-3.5 shrink-0 rounded-full border ${
+                          selectedForCompare ? 'bg-accent border-accent' : 'border-border'
+                        }`}
+                      />
+                    )}
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-mono shrink-0 ${KIND_STYLES[commit.kind] ?? 'bg-gray-100 text-gray-600'}`}>
+                      {KIND_LABELS[commit.kind] ?? commit.kind}
+                    </span>
+                    <span className="text-ink font-medium truncate">{commit.message}</span>
+                  </div>
+                  <span className="status-chip px-2 py-0.5 rounded-full text-[10px] font-mono shrink-0">
+                    {relativeTime(commit.createdAt)}
+                  </span>
+                </div>
+                <div className="mt-1.5 flex items-center gap-2 flex-wrap">
+                  <span className="px-1.5 py-0.5 rounded-full bg-warm text-[10px] text-muted-foreground">
+                    {commit.actor === 'ai+human' ? 'AI + you' : 'You'}
+                  </span>
+                  {auditCount > 0 && (
+                    <span className="px-1.5 py-0.5 rounded-full bg-warm text-[10px] text-muted-foreground">
+                      {auditCount} audit record{auditCount > 1 ? 's' : ''}
+                    </span>
+                  )}
+                  {isHead && (
+                    <span className="px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-800 text-[10px]">
+                      Current
+                    </span>
+                  )}
+                  <span className="text-[10px] font-mono text-muted-foreground/60 ml-auto">
+                    {commit.hash.slice(0, 8)}
+                  </span>
+                </div>
+              </div>
+
+              {!compareMode && expanded && (
+                <div className="px-3 pb-3 border-t border-border/70 bg-warm/20">
+                  {expandedDiff === 'loading' && (
+                    <p className="pt-3 text-xs text-muted">Loading comparison...</p>
+                  )}
+                  {expandedDiff === 'first' && (
+                    <p className="pt-3 text-xs text-muted-foreground">
+                      This is the first version of the document — there is nothing earlier to
+                      compare against.
+                    </p>
+                  )}
+                  {expandedDiff && expandedDiff !== 'loading' && expandedDiff !== 'first' && (
+                    <VersionDiff {...expandedDiff} />
+                  )}
+                  <div className="mt-3 flex justify-end">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setRestoreTarget(commit)
+                      }}
+                      disabled={isHead}
+                      title={isHead ? 'This is already the current version' : 'Restore this version'}
+                      className={`px-3 py-1.5 text-xs font-medium rounded transition-colors ${
+                        isHead
+                          ? 'bg-muted/20 text-muted-foreground cursor-not-allowed opacity-50'
+                          : 'bg-ink text-white hover:bg-ink/80'
+                      }`}
+                    >
+                      Restore this version
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {commits.length > 0 && (
+        <p className="text-[10px] text-muted-foreground/70 pt-1">
+          Version history is immutable and linked to the audit trail (EU AI Act Art. 12 &amp; 14).
+        </p>
+      )}
+
+      {restoreTarget && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+            <Confirmation
+              title="Restore this version?"
+              description={`The document will go back to "${restoreTarget.message}" from ${relativeTime(restoreTarget.createdAt)}. A new version will be created on top of your history — nothing is deleted, and you can restore any other version later.`}
+              confirmLabel={restoring ? 'Restoring...' : 'Restore'}
+              cancelLabel="Cancel"
+              onConfirm={handleRestore}
+              onCancel={() => {
+                if (!restoring) setRestoreTarget(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/History/HistoryPanel.tsx
+++ b/src/components/History/HistoryPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -19,6 +19,10 @@ import { Confirmation } from '@/components/ui/Confirmation'
 // Word-level diffs stay readable up to a point; long documents fall back to
 // the line-level view.
 const WORD_DIFF_MAX_CHARS = 15000
+
+// One history page. When a page comes back full there may be older versions —
+// "Show earlier versions" fetches the next page via the ?before cursor.
+const PAGE_SIZE = 100
 
 const KIND_LABELS: Record<CommitKind, string> = {
   import: 'Created',
@@ -94,22 +98,52 @@ export function HistoryPanel() {
   const [compareDiff, setCompareDiff] = useState<DiffPair | 'loading' | null>(null)
   const [restoreTarget, setRestoreTarget] = useState<CommitMeta | null>(null)
   const [restoring, setRestoring] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  // Guards the expanded-row diff against out-of-order responses: a slow fetch
+  // for a previously expanded row must not overwrite the current row's diff.
+  const diffRequestRef = useRef(0)
 
   const fetchHistory = useCallback(async () => {
     if (!activeDocumentId) {
       setCommits([])
+      setHasMore(false)
       return
     }
     setLoading(true)
     setError(null)
     try {
-      setCommits(await listCommits(activeDocumentId))
+      const page = await listCommits(activeDocumentId, { limit: PAGE_SIZE })
+      setCommits(page)
+      setHasMore(page.length === PAGE_SIZE)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load version history')
     } finally {
       setLoading(false)
     }
   }, [activeDocumentId])
+
+  const loadEarlier = async () => {
+    if (!activeDocumentId || loadingMore) return
+    const oldest = commits[commits.length - 1]
+    if (!oldest) return
+    setLoadingMore(true)
+    try {
+      const page = await listCommits(activeDocumentId, {
+        limit: PAGE_SIZE,
+        before: oldest.createdAt,
+      })
+      setCommits((prev) => [...prev, ...page])
+      setHasMore(page.length === PAGE_SIZE)
+    } catch (err) {
+      useToastStore.getState().addToast(
+        err instanceof Error ? err.message : 'Could not load earlier versions',
+        'error',
+      )
+    } finally {
+      setLoadingMore(false)
+    }
+  }
 
   useEffect(() => {
     fetchHistory()
@@ -123,6 +157,7 @@ export function HistoryPanel() {
   const shortLabel = (hash: string) => `version ${hash.slice(0, 8)}`
 
   const loadRowDiff = async (commit: CommitMeta) => {
+    const token = ++diffRequestRef.current
     if (!commit.parentHash) {
       setExpandedDiff('first')
       return
@@ -133,6 +168,7 @@ export function HistoryPanel() {
         getCommit(commit.hash),
         getCommit(commit.parentHash),
       ])
+      if (diffRequestRef.current !== token) return // superseded by a newer expand
       if (!current || !previous) throw new Error('Version content unavailable')
       setExpandedDiff({
         before: docJsonToText(previous.docJson),
@@ -141,6 +177,7 @@ export function HistoryPanel() {
         afterLabel: 'This version',
       })
     } catch (err) {
+      if (diffRequestRef.current !== token) return
       setExpandedDiff(null)
       useToastStore.getState().addToast(
         err instanceof Error ? err.message : 'Could not load the comparison',
@@ -151,6 +188,7 @@ export function HistoryPanel() {
 
   const toggleExpanded = (commit: CommitMeta) => {
     if (expandedHash === commit.hash) {
+      diffRequestRef.current++ // invalidate any in-flight diff fetch
       setExpandedHash(null)
       setExpandedDiff(null)
       return
@@ -253,8 +291,8 @@ export function HistoryPanel() {
         </div>
       </div>
       <p className="text-xs text-muted">
-        Every saved version of this document. Restoring never deletes anything — it adds a new
-        version on top.
+        Versions captured as you work — created, applied AI changes, saved edit sessions, and
+        restores. Restoring adds a new version on top; earlier versions stay in the chain.
       </p>
 
       {compareMode && (
@@ -283,8 +321,8 @@ export function HistoryPanel() {
           </div>
           <p className="text-sm text-muted">No versions yet</p>
           <p className="text-xs text-muted/60 mt-1 max-w-56">
-            Every version of this document is kept here — created, AI changes you approved, your
-            edit sessions, and restores.
+            Versions appear here when a document is created, an AI change is applied, an edit
+            session is saved, or a version is restored.
           </p>
         </div>
       )}
@@ -385,9 +423,21 @@ export function HistoryPanel() {
         })}
       </div>
 
+      {hasMore && (
+        <button
+          onClick={loadEarlier}
+          disabled={loadingMore}
+          className="w-full px-3 py-2 text-xs rounded-xl border border-border/70 bg-white/60 text-muted hover:text-ink hover:border-accent/30 transition-colors disabled:opacity-50"
+        >
+          {loadingMore ? 'Loading earlier versions...' : 'Show earlier versions'}
+        </button>
+      )}
+
       {commits.length > 0 && (
         <p className="text-[10px] text-muted-foreground/70 pt-1">
-          Version history is immutable and linked to the audit trail (EU AI Act Art. 12 &amp; 14).
+          Version history is append-only at the application level (no edit or delete operations;
+          server-verified hashes make records tamper-evident) and is linked to the audit trail in
+          support of EU AI Act Art. 12 &amp; 14.
         </p>
       )}
 

--- a/src/components/History/HistoryPanel.tsx
+++ b/src/components/History/HistoryPanel.tsx
@@ -197,8 +197,12 @@ export function HistoryPanel() {
     try {
       const full = await getCommit(target.hash)
       if (!full) throw new Error('Version content unavailable')
-      await restoreCommit(view, full, activeDocumentId)
-      useToastStore.getState().addToast('Version restored — a new version was created', 'success')
+      const result = await restoreCommit(view, full, activeDocumentId)
+      if (result.noop) {
+        useToastStore.getState().addToast('Already at this version', 'info')
+      } else {
+        useToastStore.getState().addToast('Version restored — a new version was created', 'success')
+      }
       setRestoreTarget(null)
       setExpandedHash(null)
       setExpandedDiff(null)

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -11,6 +11,7 @@ import { ApiKeyModal } from '@/components/Settings/ApiKeyModal'
 import { AgentConfigPanel } from '@/components/Settings/AgentConfigPanel'
 import { DocumentHubSidebar } from '@/components/Layout/DocumentHubSidebar'
 import { AuditLogViewer } from '@/components/Annotations/AuditLogViewer'
+import { HistoryPanel } from '@/components/History/HistoryPanel'
 import { DocInputModal } from '@/components/DocInput/DocInputModal'
 import { ToastContainer } from '@/components/Layout/ToastContainer'
 import { FloatingIconBar } from '@/components/Editor/FloatingIconBar'
@@ -23,7 +24,7 @@ import { initHotkeyListener, registerHotkey } from '@/lib/utils/hotkeys'
 import { toggleVoiceCapture } from '@/lib/voice/pipeline'
 import { triggerFloatingBar } from '@/lib/prosemirror/plugins/contextMenuPlugin'
 
-type SidebarTab = 'annotations' | 'changes' | 'documents' | 'audit'
+type SidebarTab = 'annotations' | 'changes' | 'documents' | 'history' | 'audit'
 
 export function AppShell() {
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('annotations')
@@ -172,6 +173,16 @@ export function AppShell() {
               Documents
             </button>
             <button
+              onClick={() => setSidebarTab('history')}
+              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
+                sidebarTab === 'history'
+                  ? 'text-accent border-b-2 border-accent bg-white/80'
+                  : 'text-muted hover:text-ink hover:bg-white/40'
+              }`}
+            >
+              History
+            </button>
+            <button
               onClick={() => setSidebarTab('audit')}
               className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
                 sidebarTab === 'audit'
@@ -196,6 +207,8 @@ export function AppShell() {
               <AnnotationPanel />
             ) : sidebarTab === 'changes' ? (
               <ChangesPanel />
+            ) : sidebarTab === 'history' ? (
+              <HistoryPanel />
             ) : sidebarTab === 'audit' ? (
               <AuditLogViewer />
             ) : (

--- a/src/lib/changes/changeLog.ts
+++ b/src/lib/changes/changeLog.ts
@@ -25,6 +25,8 @@ export interface ChangeSet {
   title: string
   status: ChangeSetStatus
   updatedAt: number
+  /** Document version recorded when this change set was applied (see src/lib/history). */
+  commitHash?: string
 }
 
 export interface VersionSnapshot {

--- a/src/lib/history/__tests__/canonical.test.ts
+++ b/src/lib/history/__tests__/canonical.test.ts
@@ -3,7 +3,10 @@ import {
   canonicalStringify,
   commitPayload,
   computeCommitHash,
+  computeContentHash,
+  contentPayload,
   sha256Hex,
+  type CommitHashFields,
 } from '../canonical'
 
 describe('canonicalStringify', () => {
@@ -34,40 +37,90 @@ describe('canonicalStringify', () => {
   })
 })
 
-describe('commitPayload', () => {
+describe('contentPayload / computeContentHash (the "tree")', () => {
   it('normalizes string and object docJson to the same payload', () => {
     const doc = { type: 'doc', content: [{ type: 'paragraph' }] }
-    expect(commitPayload(JSON.stringify(doc), 'p1', 'doc-1')).toBe(
-      commitPayload(doc, 'p1', 'doc-1'),
-    )
+    expect(contentPayload(JSON.stringify(doc))).toBe(contentPayload(doc))
   })
 
-  it('separates documentId, parentHash and content', () => {
-    const doc = { type: 'doc' }
-    expect(commitPayload(doc, null, 'doc-1')).not.toBe(commitPayload(doc, 'p1', 'doc-1'))
-    expect(commitPayload(doc, null, 'doc-1')).not.toBe(commitPayload(doc, null, 'doc-2'))
+  it('is key-order independent', async () => {
+    const h1 = await computeContentHash({ b: 1, a: 2 })
+    const h2 = await computeContentHash({ a: 2, b: 1 })
+    expect(h1).toBe(h2)
+    expect(h1).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('covers ONLY the content — no attribution, no parent, no documentId', async () => {
+    // Same doc content always yields the same tree hash, whoever committed it.
+    const doc = { type: 'doc', content: [{ type: 'paragraph' }] }
+    expect(await computeContentHash(doc)).toBe(await computeContentHash({ ...doc }))
   })
 })
 
-describe('computeCommitHash / sha256Hex', () => {
+// ---------------------------------------------------------------------------
+// Commit hash ("commit"): must cover attribution, not just content — this is
+// the adversarial-review HIGH fix. Two commits that agree on content but
+// disagree on kind/actor/auditIds must be distinct records.
+// ---------------------------------------------------------------------------
+
+function fields(over: Partial<CommitHashFields> = {}): CommitHashFields {
+  return {
+    documentId: 'doc-1',
+    parentHash: 'p1',
+    contentHash: 'c1',
+    kind: 'direct',
+    message: 'Edited document',
+    actor: 'human',
+    annotationId: null,
+    auditIds: [],
+    modelVersion: '',
+    ...over,
+  }
+}
+
+describe('commitPayload / computeCommitHash (the "commit")', () => {
+  it('is deterministic for equal fields', async () => {
+    expect(await computeCommitHash(fields())).toBe(await computeCommitHash(fields()))
+  })
+
+  it('changes when attribution changes even though content is identical', async () => {
+    const base = await computeCommitHash(fields())
+    // The confirmed collapse race: 'apply' + 'direct' on the same head/content.
+    expect(await computeCommitHash(fields({ kind: 'apply' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ actor: 'ai+human' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ auditIds: ['a1'] }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ annotationId: 'ann-1' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ message: 'other' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ modelVersion: 'm2' }))).not.toBe(base)
+  })
+
+  it('changes when the parent or document changes (chain addressing)', async () => {
+    const base = await computeCommitHash(fields())
+    expect(await computeCommitHash(fields({ parentHash: 'p2' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ parentHash: null }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ documentId: 'doc-2' }))).not.toBe(base)
+    expect(await computeCommitHash(fields({ contentHash: 'c2' }))).not.toBe(base)
+  })
+
+  it('normalizes a missing annotationId to the empty string', () => {
+    expect(commitPayload(fields({ annotationId: null }))).toBe(
+      commitPayload(fields({ annotationId: '' })),
+    )
+  })
+
+  it('is unambiguous for hostile field values (canonical JSON join, not a delimiter join)', () => {
+    // A newline-delimited join would confuse these two; canonical JSON cannot.
+    const a = commitPayload(fields({ message: 'x\ny', actor: 'human' }))
+    const b = commitPayload(fields({ message: 'x', actor: 'y\nhuman' }))
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('sha256Hex', () => {
   it('produces a stable sha256 hex digest', async () => {
     // Known vector: sha256("abc")
     expect(await sha256Hex('abc')).toBe(
       'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
     )
-  })
-
-  it('is key-order independent for docJson', async () => {
-    const h1 = await computeCommitHash({ b: 1, a: 2 }, null, 'doc-1')
-    const h2 = await computeCommitHash({ a: 2, b: 1 }, null, 'doc-1')
-    expect(h1).toBe(h2)
-    expect(h1).toMatch(/^[0-9a-f]{64}$/)
-  })
-
-  it('changes when the parent changes (content-addressed chain)', async () => {
-    const doc = { type: 'doc' }
-    const h1 = await computeCommitHash(doc, null, 'doc-1')
-    const h2 = await computeCommitHash(doc, h1, 'doc-1')
-    expect(h1).not.toBe(h2)
   })
 })

--- a/src/lib/history/__tests__/canonical.test.ts
+++ b/src/lib/history/__tests__/canonical.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalStringify,
+  commitPayload,
+  computeCommitHash,
+  sha256Hex,
+} from '../canonical'
+
+describe('canonicalStringify', () => {
+  it('is independent of object key insertion order at every depth', () => {
+    const a = { b: 1, a: { d: [1, 2], c: 'x' }, e: null }
+    const b = { e: null, a: { c: 'x', d: [1, 2] }, b: 1 }
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b))
+  })
+
+  it('preserves array order (arrays are ordered content, not sets)', () => {
+    expect(canonicalStringify([1, 2])).not.toBe(canonicalStringify([2, 1]))
+  })
+
+  it('skips undefined values like JSON.stringify does', () => {
+    expect(canonicalStringify({ a: 1, b: undefined })).toBe('{"a":1}')
+  })
+
+  it('handles primitives and null', () => {
+    expect(canonicalStringify(null)).toBe('null')
+    expect(canonicalStringify('hi')).toBe('"hi"')
+    expect(canonicalStringify(3)).toBe('3')
+    expect(canonicalStringify(true)).toBe('true')
+  })
+
+  it('round-trips to structurally equal JSON', () => {
+    const value = { type: 'doc', content: [{ type: 'paragraph', attrs: { blockId: 'b1' } }] }
+    expect(JSON.parse(canonicalStringify(value))).toEqual(value)
+  })
+})
+
+describe('commitPayload', () => {
+  it('normalizes string and object docJson to the same payload', () => {
+    const doc = { type: 'doc', content: [{ type: 'paragraph' }] }
+    expect(commitPayload(JSON.stringify(doc), 'p1', 'doc-1')).toBe(
+      commitPayload(doc, 'p1', 'doc-1'),
+    )
+  })
+
+  it('separates documentId, parentHash and content', () => {
+    const doc = { type: 'doc' }
+    expect(commitPayload(doc, null, 'doc-1')).not.toBe(commitPayload(doc, 'p1', 'doc-1'))
+    expect(commitPayload(doc, null, 'doc-1')).not.toBe(commitPayload(doc, null, 'doc-2'))
+  })
+})
+
+describe('computeCommitHash / sha256Hex', () => {
+  it('produces a stable sha256 hex digest', async () => {
+    // Known vector: sha256("abc")
+    expect(await sha256Hex('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    )
+  })
+
+  it('is key-order independent for docJson', async () => {
+    const h1 = await computeCommitHash({ b: 1, a: 2 }, null, 'doc-1')
+    const h2 = await computeCommitHash({ a: 2, b: 1 }, null, 'doc-1')
+    expect(h1).toBe(h2)
+    expect(h1).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it('changes when the parent changes (content-addressed chain)', async () => {
+    const doc = { type: 'doc' }
+    const h1 = await computeCommitHash(doc, null, 'doc-1')
+    const h2 = await computeCommitHash(doc, h1, 'doc-1')
+    expect(h1).not.toBe(h2)
+  })
+})

--- a/src/lib/history/__tests__/commits.test.ts
+++ b/src/lib/history/__tests__/commits.test.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { Node } from 'prosemirror-model'
+import type { EditorView } from 'prosemirror-view'
+import { schema } from '@/lib/prosemirror/schema'
+import { computeCommitHash } from '../canonical'
+import {
+  blameBlock,
+  createCommit,
+  getCommit,
+  headCommit,
+  listCommits,
+  restoreCommit,
+  type CommitMeta,
+} from '../commits'
+
+// ---------------------------------------------------------------------------
+// In-memory append-only fake of /api/history (+ /api/audit), mirroring the
+// route's contract. Follows the fetch-stub precedent from
+// documentStore.phase8.test.ts.
+// ---------------------------------------------------------------------------
+
+interface StoredCommit {
+  hash: string
+  documentId: string
+  parentHash: string | null
+  kind: string
+  message: string
+  docJson: string
+  blockIdsTouched: string
+  annotationId: string | null
+  auditIds: string
+  actor: string
+  modelVersion: string
+  createdAt: string
+}
+
+let commits: StoredCommit[] = []
+let auditCalls: any[] = []
+let requestLog: { url: string; method: string }[] = []
+let clock = 0
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: String(status),
+    json: async () => body,
+  }
+}
+
+function meta({ docJson: _docJson, ...rest }: StoredCommit) {
+  return rest
+}
+
+async function fakeFetch(input: string, init?: { method?: string; body?: string }) {
+  const url = String(input)
+  const method = init?.method ?? 'GET'
+  requestLog.push({ url, method })
+
+  if (url.startsWith('/api/audit')) {
+    auditCalls.push(JSON.parse(init?.body ?? '{}'))
+    return jsonResponse({ id: `audit-${auditCalls.length}` })
+  }
+
+  if (url.startsWith('/api/history')) {
+    if (method === 'POST') {
+      const body = JSON.parse(init?.body ?? '{}')
+      const parentHash = body.parentHash ?? null
+      const expected = await computeCommitHash(body.docJson, parentHash, body.documentId)
+      if (expected !== body.hash) return jsonResponse({ error: 'Hash mismatch' }, 400)
+      const existing = commits.find((c) => c.hash === body.hash)
+      if (existing) return jsonResponse({ hash: existing.hash, existing: true })
+      if (parentHash && !commits.some((c) => c.hash === parentHash && c.documentId === body.documentId)) {
+        return jsonResponse({ error: 'Unknown parent' }, 400)
+      }
+      commits.push({
+        hash: body.hash,
+        documentId: body.documentId,
+        parentHash,
+        kind: body.kind,
+        message: body.message,
+        docJson: body.docJson,
+        blockIdsTouched: body.blockIdsTouched ?? '[]',
+        annotationId: body.annotationId ?? null,
+        auditIds: body.auditIds ?? '[]',
+        actor: body.actor ?? 'human',
+        modelVersion: body.modelVersion ?? '',
+        createdAt: new Date(1700000000000 + clock++ * 1000).toISOString(),
+      })
+      return jsonResponse({ hash: body.hash })
+    }
+
+    const params = new URLSearchParams(url.split('?')[1] ?? '')
+    const hash = params.get('hash')
+    if (hash) {
+      const found = commits.find((c) => c.hash === hash)
+      return found ? jsonResponse({ commit: found }) : jsonResponse({ error: 'not found' }, 404)
+    }
+    const documentId = params.get('documentId')
+    const limit = Number(params.get('limit') ?? 200)
+    const list = commits
+      .filter((c) => c.documentId === documentId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, limit)
+      .map(meta)
+    return jsonResponse({ commits: list })
+  }
+
+  return jsonResponse({ error: 'unknown route' }, 404)
+}
+
+beforeEach(() => {
+  commits = []
+  auditCalls = []
+  requestLog = []
+  clock = 0
+  vi.stubGlobal('fetch', vi.fn(fakeFetch))
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function docJsonWithText(text: string) {
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  }
+}
+
+function makeView(docJson: any): EditorView {
+  const view = {
+    state: EditorState.create({ schema, doc: Node.fromJSON(schema, docJson) }),
+    dispatch(tr: any) {
+      view.state = view.state.apply(tr)
+    },
+  } as unknown as EditorView & { state: EditorState }
+  return view
+}
+
+const historyPosts = () =>
+  requestLog.filter((r) => r.url.startsWith('/api/history') && r.method === 'POST')
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createCommit', () => {
+  it('creates a root version with a null parent and a server-verifiable hash', async () => {
+    const docJson = docJsonWithText('Hello')
+    const hash = await createCommit({
+      docJson,
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+
+    expect(hash).toBe(await computeCommitHash(docJson, null, 'doc-1'))
+    expect(commits).toHaveLength(1)
+    expect(commits[0].parentHash).toBeNull()
+    expect(commits[0].kind).toBe('import')
+  })
+
+  it('chains the next version onto the head (parent pointer correctness)', async () => {
+    const first = await createCommit({
+      docJson: docJsonWithText('v1'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+    const second = await createCommit({
+      docJson: docJsonWithText('v2'),
+      documentId: 'doc-1',
+      kind: 'direct',
+      message: 'Edited document',
+    })
+
+    expect(second).not.toBe(first)
+    expect(commits).toHaveLength(2)
+    expect(commits[1].parentHash).toBe(first)
+    expect(await headCommit('doc-1')).toMatchObject({ hash: second })
+  })
+
+  it('no-ops when content is unchanged (hash dedupe), returning the head hash', async () => {
+    // Key-order variation must not defeat the dedupe: canonicalization.
+    const first = await createCommit({
+      docJson: { type: 'doc', content: [{ content: [{ text: 'same', type: 'text' }], type: 'paragraph' }] },
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+    const postsBefore = historyPosts().length
+
+    const again = await createCommit({
+      docJson: docJsonWithText('same'),
+      documentId: 'doc-1',
+      kind: 'direct',
+      message: 'Edited document',
+    })
+
+    expect(again).toBe(first)
+    expect(commits).toHaveLength(1)
+    expect(historyPosts().length).toBe(postsBefore) // no new POST at all
+  })
+
+  it('keeps histories of different documents independent', async () => {
+    const sameDoc = docJsonWithText('shared')
+    const h1 = await createCommit({ docJson: sameDoc, documentId: 'doc-1', kind: 'import', message: 'a' })
+    const h2 = await createCommit({ docJson: sameDoc, documentId: 'doc-2', kind: 'import', message: 'b' })
+    expect(h1).not.toBe(h2)
+    expect(await listCommits('doc-1')).toHaveLength(1)
+    expect(await listCommits('doc-2')).toHaveLength(1)
+  })
+})
+
+describe('restoreCommit', () => {
+  it('replaces editor content, appends a restore version on the pre-restore head, then logs oversight', async () => {
+    const v1Json = docJsonWithText('version one')
+    const v2Json = docJsonWithText('version two')
+    const v1 = await createCommit({ docJson: v1Json, documentId: 'doc-1', kind: 'import', message: 'Created "Test"' })
+    const v2 = await createCommit({ docJson: v2Json, documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+
+    const view = makeView(v2Json)
+    const target = await getCommit(v1)
+    expect(target).not.toBeNull()
+
+    const restoredHash = await restoreCommit(view, target!, 'doc-1')
+
+    // 1. Editor now shows the old content.
+    expect((view as any).state.doc.textContent).toBe('version one')
+
+    // 2. History gained a NEW version — nothing rewritten, chain intact.
+    expect(commits).toHaveLength(3)
+    const restore = commits[2]
+    expect(restore.hash).toBe(restoredHash)
+    expect(restore.kind).toBe('restore')
+    expect(restore.parentHash).toBe(v2) // parent = pre-restore head
+    expect(restore.message).toBe(`Restored version ${v1.slice(0, 8)}`)
+    expect(restore.actor).toBe('human')
+    expect(JSON.parse(restore.docJson)).toEqual(v1Json)
+    expect(commits[0].hash).toBe(v1) // originals untouched
+    expect(commits[1].hash).toBe(v2)
+
+    // 3. Article 14 oversight record, written AFTER the version commit.
+    expect(auditCalls).toHaveLength(1)
+    expect(auditCalls[0]).toMatchObject({
+      action: 'log',
+      outputType: 'HUMAN_RESTORE',
+      approvalStatus: 'APPROVED_HUMAN',
+      modelName: 'human',
+      queryClassification: 'HUMAN_RESTORE',
+    })
+    const indexed = requestLog.map((r, i) => ({ ...r, i }))
+    const lastHistoryPost = indexed
+      .filter((r) => r.url.startsWith('/api/history') && r.method === 'POST')
+      .pop()!
+    const auditPost = indexed.find((r) => r.url.startsWith('/api/audit'))!
+    expect(lastHistoryPost.i).toBeLessThan(auditPost.i)
+  })
+})
+
+describe('blameBlock', () => {
+  const makeMeta = (hash: string, createdAt: string, blockIds: string[]): CommitMeta => ({
+    hash,
+    documentId: 'doc-1',
+    parentHash: null,
+    kind: 'apply',
+    message: hash,
+    blockIdsTouched: JSON.stringify(blockIds),
+    annotationId: null,
+    auditIds: '[]',
+    actor: 'ai+human',
+    modelVersion: 'm',
+    createdAt,
+  })
+
+  it('returns the newest version that touched the block', () => {
+    const older = makeMeta('older', '2026-01-01T00:00:00Z', ['b1', 'b2'])
+    const newer = makeMeta('newer', '2026-02-01T00:00:00Z', ['b2'])
+    expect(blameBlock([newer, older], 'b2')?.hash).toBe('newer')
+    expect(blameBlock([older, newer], 'b2')?.hash).toBe('newer') // order-insensitive
+    expect(blameBlock([newer, older], 'b1')?.hash).toBe('older')
+  })
+
+  it('returns null when no version touched the block', () => {
+    const only = makeMeta('only', '2026-01-01T00:00:00Z', ['b1'])
+    expect(blameBlock([only], 'zzz')).toBeNull()
+    expect(blameBlock([], 'b1')).toBeNull()
+  })
+
+  it('tolerates malformed blockIdsTouched metadata', () => {
+    const broken = { ...makeMeta('broken', '2026-03-01T00:00:00Z', []), blockIdsTouched: 'not-json' }
+    const good = makeMeta('good', '2026-01-01T00:00:00Z', ['b1'])
+    expect(blameBlock([broken, good], 'b1')?.hash).toBe('good')
+  })
+})

--- a/src/lib/history/__tests__/commits.test.ts
+++ b/src/lib/history/__tests__/commits.test.ts
@@ -3,7 +3,7 @@ import { EditorState } from 'prosemirror-state'
 import { Node } from 'prosemirror-model'
 import type { EditorView } from 'prosemirror-view'
 import { schema } from '@/lib/prosemirror/schema'
-import { computeCommitHash } from '../canonical'
+import { computeCommitHash, computeContentHash } from '../canonical'
 import {
   blameBlock,
   createCommit,
@@ -16,12 +16,14 @@ import {
 
 // ---------------------------------------------------------------------------
 // In-memory append-only fake of /api/history (+ /api/audit), mirroring the
-// route's contract. Follows the fetch-stub precedent from
-// documentStore.phase8.test.ts.
+// route's contract: two-level hash verification, idempotent duplicates,
+// linearity (one root, one child per parent → 409 stale-head). Follows the
+// fetch-stub precedent from documentStore.phase8.test.ts.
 // ---------------------------------------------------------------------------
 
 interface StoredCommit {
   hash: string
+  contentHash: string
   documentId: string
   parentHash: string | null
   kind: string
@@ -39,6 +41,10 @@ let commits: StoredCommit[] = []
 let auditCalls: any[] = []
 let requestLog: { url: string; method: string }[] = []
 let clock = 0
+/** How many incoming POSTs should first be beaten by a concurrent writer. */
+let raceInjectionsRemaining = 0
+/** When set, POSTs of this kind fail with HTTP 500 (server outage simulation). */
+let failPostForKind: string | null = null
 
 function jsonResponse(body: unknown, status = 200) {
   return {
@@ -51,6 +57,49 @@ function jsonResponse(body: unknown, status = 200) {
 
 function meta({ docJson: _docJson, ...rest }: StoredCommit) {
   return rest
+}
+
+function serverHead(documentId: string): StoredCommit | null {
+  return (
+    [...commits]
+      .filter((c) => c.documentId === documentId)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0] ??
+    null
+  )
+}
+
+/** Server-side helper: append a fully valid commit (simulates another writer winning). */
+async function pushServerCommit(documentId: string, docJson: unknown, message = 'concurrent writer') {
+  const head = serverHead(documentId)
+  const docJsonString = typeof docJson === 'string' ? docJson : JSON.stringify(docJson)
+  const contentHash = await computeContentHash(docJsonString)
+  const hash = await computeCommitHash({
+    documentId,
+    parentHash: head?.hash ?? null,
+    contentHash,
+    kind: 'direct',
+    message,
+    actor: 'human',
+    annotationId: null,
+    auditIds: [],
+    modelVersion: '',
+  })
+  commits.push({
+    hash,
+    contentHash,
+    documentId,
+    parentHash: head?.hash ?? null,
+    kind: 'direct',
+    message,
+    docJson: docJsonString,
+    blockIdsTouched: '[]',
+    annotationId: null,
+    auditIds: '[]',
+    actor: 'human',
+    modelVersion: '',
+    createdAt: new Date(1700000000000 + clock++ * 1000).toISOString(),
+  })
+  return hash
 }
 
 async function fakeFetch(input: string, init?: { method?: string; body?: string }) {
@@ -66,23 +115,73 @@ async function fakeFetch(input: string, init?: { method?: string; body?: string 
   if (url.startsWith('/api/history')) {
     if (method === 'POST') {
       const body = JSON.parse(init?.body ?? '{}')
+
+      if (failPostForKind && body.kind === failPostForKind) {
+        return jsonResponse({ error: 'History write failed' }, 500)
+      }
+      if (raceInjectionsRemaining > 0) {
+        raceInjectionsRemaining--
+        await pushServerCommit(body.documentId, {
+          type: 'doc',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: `racer ${clock}` }] },
+          ],
+        })
+      }
+
       const parentHash = body.parentHash ?? null
-      const expected = await computeCommitHash(body.docJson, parentHash, body.documentId)
-      if (expected !== body.hash) return jsonResponse({ error: 'Hash mismatch' }, 400)
+      const annotationId = body.annotationId ?? null
+      const auditIds = JSON.parse(body.auditIds ?? '[]')
+
+      // Two-level verification, exactly like the route.
+      const expectedContent = await computeContentHash(body.docJson)
+      if (expectedContent !== body.contentHash) {
+        return jsonResponse({ error: 'Content hash mismatch' }, 400)
+      }
+      const expectedHash = await computeCommitHash({
+        documentId: body.documentId,
+        parentHash,
+        contentHash: body.contentHash,
+        kind: body.kind,
+        message: body.message,
+        actor: body.actor ?? 'human',
+        annotationId,
+        auditIds,
+        modelVersion: body.modelVersion ?? '',
+      })
+      if (expectedHash !== body.hash) return jsonResponse({ error: 'Hash mismatch' }, 400)
+
       const existing = commits.find((c) => c.hash === body.hash)
       if (existing) return jsonResponse({ hash: existing.hash, existing: true })
-      if (parentHash && !commits.some((c) => c.hash === parentHash && c.documentId === body.documentId)) {
-        return jsonResponse({ error: 'Unknown parent' }, 400)
+
+      if (parentHash) {
+        if (!commits.some((c) => c.hash === parentHash && c.documentId === body.documentId)) {
+          return jsonResponse({ error: 'Unknown parent' }, 400)
+        }
+        if (
+          commits.some(
+            (c) =>
+              c.documentId === body.documentId &&
+              c.parentHash === parentHash &&
+              c.hash !== body.hash,
+          )
+        ) {
+          return jsonResponse({ error: 'Stale head', reason: 'stale-head' }, 409)
+        }
+      } else if (commits.some((c) => c.documentId === body.documentId && c.hash !== body.hash)) {
+        return jsonResponse({ error: 'Stale head', reason: 'stale-head' }, 409)
       }
+
       commits.push({
         hash: body.hash,
+        contentHash: body.contentHash,
         documentId: body.documentId,
         parentHash,
         kind: body.kind,
         message: body.message,
         docJson: body.docJson,
         blockIdsTouched: body.blockIdsTouched ?? '[]',
-        annotationId: body.annotationId ?? null,
+        annotationId,
         auditIds: body.auditIds ?? '[]',
         actor: body.actor ?? 'human',
         modelVersion: body.modelVersion ?? '',
@@ -98,9 +197,12 @@ async function fakeFetch(input: string, init?: { method?: string; body?: string 
       return found ? jsonResponse({ commit: found }) : jsonResponse({ error: 'not found' }, 404)
     }
     const documentId = params.get('documentId')
-    const limit = Number(params.get('limit') ?? 200)
+    const rawLimit = Number(params.get('limit') ?? 100)
+    const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(Math.floor(rawLimit), 1), 200) : 100
+    const before = params.get('before')
     const list = commits
       .filter((c) => c.documentId === documentId)
+      .filter((c) => (before ? new Date(c.createdAt) < new Date(before) : true))
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
       .slice(0, limit)
       .map(meta)
@@ -115,6 +217,8 @@ beforeEach(() => {
   auditCalls = []
   requestLog = []
   clock = 0
+  raceInjectionsRemaining = 0
+  failPostForKind = null
   vi.stubGlobal('fetch', vi.fn(fakeFetch))
 })
 
@@ -127,6 +231,15 @@ function docJsonWithText(text: string) {
     type: 'doc',
     content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
   }
+}
+
+/**
+ * Schema-normalized docJson, exactly what `view.state.doc.toJSON()` yields in
+ * production (includes default attrs like blockId). Restore tests must seed
+ * with this form so editor round-trips hash identically to stored versions.
+ */
+function pmDocJson(text: string) {
+  return Node.fromJSON(schema, docJsonWithText(text)).toJSON()
 }
 
 function makeView(docJson: any): EditorView {
@@ -147,18 +260,33 @@ const historyPosts = () =>
 // ---------------------------------------------------------------------------
 
 describe('createCommit', () => {
-  it('creates a root version with a null parent and a server-verifiable hash', async () => {
+  it('creates a root version with a null parent and server-verifiable two-level hashes', async () => {
     const docJson = docJsonWithText('Hello')
-    const hash = await createCommit({
+    const { hash, noop } = await createCommit({
       docJson,
       documentId: 'doc-1',
       kind: 'import',
       message: 'Created "Test"',
     })
 
-    expect(hash).toBe(await computeCommitHash(docJson, null, 'doc-1'))
+    const contentHash = await computeContentHash(docJson)
+    expect(noop).toBe(false)
+    expect(hash).toBe(
+      await computeCommitHash({
+        documentId: 'doc-1',
+        parentHash: null,
+        contentHash,
+        kind: 'import',
+        message: 'Created "Test"',
+        actor: 'human',
+        annotationId: null,
+        auditIds: [],
+        modelVersion: '',
+      }),
+    )
     expect(commits).toHaveLength(1)
     expect(commits[0].parentHash).toBeNull()
+    expect(commits[0].contentHash).toBe(contentHash)
     expect(commits[0].kind).toBe('import')
   })
 
@@ -176,13 +304,13 @@ describe('createCommit', () => {
       message: 'Edited document',
     })
 
-    expect(second).not.toBe(first)
+    expect(second.hash).not.toBe(first.hash)
     expect(commits).toHaveLength(2)
-    expect(commits[1].parentHash).toBe(first)
-    expect(await headCommit('doc-1')).toMatchObject({ hash: second })
+    expect(commits[1].parentHash).toBe(first.hash)
+    expect(await headCommit('doc-1')).toMatchObject({ hash: second.hash })
   })
 
-  it('no-ops when content is unchanged (hash dedupe), returning the head hash', async () => {
+  it("no-ops a 'direct' flush when the head already has this content (contentHash dedupe)", async () => {
     // Key-order variation must not defeat the dedupe: canonicalization.
     const first = await createCommit({
       docJson: { type: 'doc', content: [{ content: [{ text: 'same', type: 'text' }], type: 'paragraph' }] },
@@ -199,41 +327,132 @@ describe('createCommit', () => {
       message: 'Edited document',
     })
 
-    expect(again).toBe(first)
+    expect(again).toEqual({ hash: first.hash, noop: true })
     expect(commits).toHaveLength(1)
     expect(historyPosts().length).toBe(postsBefore) // no new POST at all
+  })
+
+  it("ALWAYS commits an 'apply' even when content matches the head — provenance is never collapsed", async () => {
+    // The confirmed adversarial-review race: an 'apply' and a 'direct'
+    // autosave land the same content on the same head. Under content-only
+    // hashing the second write silently vanished, discarding the AI
+    // provenance (kind/actor/auditIds). Two-level hashing makes them
+    // distinct commits by construction.
+    const doc = docJsonWithText('agreed content')
+    const direct = await createCommit({
+      docJson: doc,
+      documentId: 'doc-1',
+      kind: 'direct',
+      message: 'Edited document',
+    })
+    const apply = await createCommit({
+      docJson: doc,
+      documentId: 'doc-1',
+      kind: 'apply',
+      message: 'AI change applied',
+      annotationId: 'ann-1',
+      auditIds: ['audit-9'],
+      actor: 'ai+human',
+      modelVersion: 'claude-sonnet-4-6',
+    })
+
+    expect(apply.noop).toBe(false)
+    expect(apply.hash).not.toBe(direct.hash)
+    expect(commits).toHaveLength(2)
+    expect(commits[0].contentHash).toBe(commits[1].contentHash) // same tree
+    expect(commits[1]).toMatchObject({
+      kind: 'apply',
+      actor: 'ai+human',
+      annotationId: 'ann-1',
+      auditIds: JSON.stringify(['audit-9']),
+      parentHash: direct.hash,
+    })
   })
 
   it('keeps histories of different documents independent', async () => {
     const sameDoc = docJsonWithText('shared')
     const h1 = await createCommit({ docJson: sameDoc, documentId: 'doc-1', kind: 'import', message: 'a' })
     const h2 = await createCommit({ docJson: sameDoc, documentId: 'doc-2', kind: 'import', message: 'b' })
-    expect(h1).not.toBe(h2)
+    expect(h1.hash).not.toBe(h2.hash)
     expect(await listCommits('doc-1')).toHaveLength(1)
     expect(await listCommits('doc-2')).toHaveLength(1)
+  })
+
+  it('retries ONCE against the new head on a 409 stale-head, then succeeds', async () => {
+    await createCommit({
+      docJson: docJsonWithText('v1'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+
+    // The next POST is beaten by a concurrent writer → server 409s the first
+    // attempt; the client must refetch the head, rehash, and land on top.
+    raceInjectionsRemaining = 1
+    const postsBefore = historyPosts().length
+    const result = await createCommit({
+      docJson: docJsonWithText('mine'),
+      documentId: 'doc-1',
+      kind: 'direct',
+      message: 'Edited document',
+    })
+
+    expect(result.noop).toBe(false)
+    expect(historyPosts().length).toBe(postsBefore + 2) // 409 attempt + retry
+    expect(commits).toHaveLength(3) // v1, racer, mine
+    const mine = commits.find((c) => c.hash === result.hash)!
+    const racer = commits.find((c) => c.message.startsWith('concurrent writer'))!
+    expect(mine.parentHash).toBe(racer.hash) // rebased onto the interloper
+  })
+
+  it('gives up (throws) when the head keeps moving after one retry', async () => {
+    await createCommit({
+      docJson: docJsonWithText('v1'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+
+    raceInjectionsRemaining = 2 // both attempts get beaten
+    await expect(
+      createCommit({
+        docJson: docJsonWithText('mine'),
+        documentId: 'doc-1',
+        kind: 'direct',
+        message: 'Edited document',
+      }),
+    ).rejects.toThrow(/advancing concurrently/)
+    // Nothing of ours was written — only the two racers landed.
+    expect(commits.filter((c) => c.message === 'Edited document')).toHaveLength(0)
   })
 })
 
 describe('restoreCommit', () => {
-  it('replaces editor content, appends a restore version on the pre-restore head, then logs oversight', async () => {
-    const v1Json = docJsonWithText('version one')
-    const v2Json = docJsonWithText('version two')
+  async function seedTwoVersions() {
+    const v1Json = pmDocJson('version one')
+    const v2Json = pmDocJson('version two')
     const v1 = await createCommit({ docJson: v1Json, documentId: 'doc-1', kind: 'import', message: 'Created "Test"' })
     const v2 = await createCommit({ docJson: v2Json, documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    return { v1Json, v2Json, v1: v1.hash, v2: v2.hash }
+  }
+
+  it('persists FIRST (audit → restore version), and only then mutates the editor', async () => {
+    const { v1Json, v2Json, v1, v2 } = await seedTwoVersions()
 
     const view = makeView(v2Json)
     const target = await getCommit(v1)
     expect(target).not.toBeNull()
 
-    const restoredHash = await restoreCommit(view, target!, 'doc-1')
+    const result = await restoreCommit(view, target!, 'doc-1')
 
-    // 1. Editor now shows the old content.
+    // Editor shows the old content again.
+    expect(result.noop).toBe(false)
     expect((view as any).state.doc.textContent).toBe('version one')
 
-    // 2. History gained a NEW version — nothing rewritten, chain intact.
+    // History gained a NEW version — nothing rewritten, chain intact.
     expect(commits).toHaveLength(3)
     const restore = commits[2]
-    expect(restore.hash).toBe(restoredHash)
+    expect(restore.hash).toBe(result.hash)
     expect(restore.kind).toBe('restore')
     expect(restore.parentHash).toBe(v2) // parent = pre-restore head
     expect(restore.message).toBe(`Restored version ${v1.slice(0, 8)}`)
@@ -242,7 +461,8 @@ describe('restoreCommit', () => {
     expect(commits[0].hash).toBe(v1) // originals untouched
     expect(commits[1].hash).toBe(v2)
 
-    // 3. Article 14 oversight record, written AFTER the version commit.
+    // Article 14 oversight record written BEFORE the version, and the version
+    // carries its id — a real Article 12 link, not prose.
     expect(auditCalls).toHaveLength(1)
     expect(auditCalls[0]).toMatchObject({
       action: 'log',
@@ -251,18 +471,72 @@ describe('restoreCommit', () => {
       modelName: 'human',
       queryClassification: 'HUMAN_RESTORE',
     })
+    expect(JSON.parse(restore.auditIds)).toEqual(['audit-1'])
+
     const indexed = requestLog.map((r, i) => ({ ...r, i }))
-    const lastHistoryPost = indexed
+    const auditPost = indexed.find((r) => r.url.startsWith('/api/audit'))!
+    const restorePost = indexed
       .filter((r) => r.url.startsWith('/api/history') && r.method === 'POST')
       .pop()!
-    const auditPost = indexed.find((r) => r.url.startsWith('/api/audit'))!
-    expect(lastHistoryPost.i).toBeLessThan(auditPost.i)
+    expect(auditPost.i).toBeLessThan(restorePost.i)
+  })
+
+  it('flushes pending unsaved edits as a direct version BEFORE restoring (no typed tail lost)', async () => {
+    const { v2 , v1 } = await seedTwoVersions()
+
+    // The user typed after the last autosave: the editor is ahead of history.
+    const typedJson = pmDocJson('version two plus unsaved typing')
+    const view = makeView(typedJson)
+    const target = await getCommit(v1)
+
+    const result = await restoreCommit(view, target!, 'doc-1')
+
+    // v1, v2, flush, restore — the typed tail is preserved in the chain.
+    expect(commits).toHaveLength(4)
+    const flush = commits[2]
+    expect(flush.kind).toBe('direct')
+    expect(flush.parentHash).toBe(v2)
+    expect(JSON.parse(flush.docJson)).toEqual(typedJson)
+    const restore = commits[3]
+    expect(restore.hash).toBe(result.hash)
+    expect(restore.parentHash).toBe(flush.hash)
+    expect((view as any).state.doc.textContent).toBe('version one')
+  })
+
+  it('is a no-op when restoring to content identical to the head — no version, no audit record', async () => {
+    const { v2Json, v2 } = await seedTwoVersions()
+
+    const view = makeView(v2Json)
+    const target = await getCommit(v2)
+
+    const result = await restoreCommit(view, target!, 'doc-1')
+
+    expect(result).toEqual({ hash: v2, noop: true })
+    expect(commits).toHaveLength(2)
+    expect(auditCalls).toHaveLength(0)
+    expect((view as any).state.doc.textContent).toBe('version two')
+  })
+
+  it('throws WITHOUT touching the editor when the restore version cannot be persisted', async () => {
+    const { v2Json, v1 } = await seedTwoVersions()
+
+    const view = makeView(v2Json)
+    const target = await getCommit(v1)
+
+    failPostForKind = 'restore'
+    await expect(restoreCommit(view, target!, 'doc-1')).rejects.toThrow()
+
+    // Document unchanged on screen, history unchanged — the panel's
+    // "Restore failed" toast is now TRUE.
+    expect((view as any).state.doc.textContent).toBe('version two')
+    expect(commits).toHaveLength(2)
   })
 })
 
 describe('blameBlock', () => {
   const makeMeta = (hash: string, createdAt: string, blockIds: string[]): CommitMeta => ({
     hash,
+    contentHash: `content-${hash}`,
     documentId: 'doc-1',
     parentHash: null,
     kind: 'apply',

--- a/src/lib/history/__tests__/docText.test.ts
+++ b/src/lib/history/__tests__/docText.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { docJsonToText } from '../docText'
+
+const doc = {
+  type: 'doc',
+  content: [
+    { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: 'Title' }] },
+    {
+      type: 'paragraph',
+      content: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'text', text: 'world', marks: [{ type: 'strong' }] },
+      ],
+    },
+    {
+      type: 'blockquote',
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Quoted' }] }],
+    },
+    { type: 'paragraph' },
+  ],
+}
+
+describe('docJsonToText', () => {
+  it('joins textblocks with newlines and concatenates inline text', () => {
+    expect(docJsonToText(doc)).toBe('Title\nHello world\nQuoted\n')
+  })
+
+  it('descends into wrapper nodes without duplicating their text', () => {
+    expect(docJsonToText(doc).match(/Quoted/g)).toHaveLength(1)
+  })
+
+  it('accepts a JSON string (the API stores docJson as a string)', () => {
+    expect(docJsonToText(JSON.stringify(doc))).toBe(docJsonToText(doc))
+  })
+
+  it('is defensive about malformed input', () => {
+    expect(docJsonToText('not json')).toBe('')
+    expect(docJsonToText(null)).toBe('')
+    expect(docJsonToText({})).toBe('')
+  })
+})

--- a/src/lib/history/canonical.ts
+++ b/src/lib/history/canonical.ts
@@ -1,11 +1,19 @@
 /**
- * Canonical serialization for content-addressed document versions.
+ * Canonical serialization + two-level hashing for document versions.
  *
- * The version hash is a sha256 over a canonical string derived from
- * (documentId, parentHash, docJson). Both the client (crypto.subtle in the
- * browser) and the server (/api/history, Node's WebCrypto) import THIS module
- * so the payload is byte-identical on both sides — the server recomputes the
- * hash and rejects mismatches, which is what makes history tamper-evident.
+ * Git's actual design, deliberately:
+ *   - contentHash ("tree"): sha256 over the canonical docJson ONLY.
+ *   - hash ("commit", the primary key): sha256 over a canonical join of
+ *     documentId, parentHash, contentHash, kind, message, actor,
+ *     annotationId, auditIds and modelVersion.
+ *
+ * Because the commit hash covers attribution, two versions that agree on
+ * content but disagree on provenance (e.g. an AI 'apply' and a 'direct'
+ * autosave landing on the same head) are DISTINCT records by construction —
+ * provenance can never be silently collapsed into a single row. The server
+ * (/api/history) recomputes BOTH hashes from this same module, so client and
+ * server are byte-identical and stored records are tamper-evident against
+ * partial modification.
  *
  * Pure module: no React, no Prisma, no DOM. Safe to import anywhere.
  */
@@ -33,17 +41,56 @@ export function canonicalStringify(value: unknown): string {
 }
 
 /**
- * The exact string that gets hashed for a version. `docJson` may arrive as an
- * object or as a JSON string (the API stores it as a string) — both normalize
- * to the same canonical form.
+ * The exact string whose sha256 is the CONTENT hash ("tree"). `docJson` may
+ * arrive as an object or as a JSON string (the API stores it as a string) —
+ * both normalize to the same canonical form.
  */
-export function commitPayload(
-  docJson: unknown,
-  parentHash: string | null,
-  documentId: string,
-): string {
+export function contentPayload(docJson: unknown): string {
   const parsed = typeof docJson === 'string' ? JSON.parse(docJson) : docJson
-  return `${documentId}\n${parentHash ?? ''}\n${canonicalStringify(parsed)}`
+  return canonicalStringify(parsed)
+}
+
+/** Content address for a snapshot: sha256 over the canonical docJson only. */
+export async function computeContentHash(docJson: unknown): Promise<string> {
+  return sha256Hex(contentPayload(docJson))
+}
+
+/** Everything the COMMIT hash covers — content (via contentHash) plus attribution. */
+export interface CommitHashFields {
+  documentId: string
+  parentHash: string | null
+  contentHash: string
+  kind: string
+  message: string
+  actor: string
+  annotationId: string | null
+  /** Audit record ids as an array (its canonical JSON form is what gets hashed). */
+  auditIds: string[]
+  modelVersion: string
+}
+
+/**
+ * The exact string whose sha256 is the COMMIT hash. A canonical object
+ * stringify (sorted keys, JSON-escaped values) — unambiguous even when
+ * fields contain newlines or separators.
+ */
+export function commitPayload(fields: CommitHashFields): string {
+  return canonicalStringify({
+    documentId: fields.documentId,
+    parentHash: fields.parentHash ?? null,
+    contentHash: fields.contentHash,
+    kind: fields.kind,
+    message: fields.message,
+    actor: fields.actor,
+    annotationId: fields.annotationId ?? '',
+    auditIds: fields.auditIds,
+    modelVersion: fields.modelVersion,
+  })
+}
+
+/** Commit address for a version: sha256 over the canonical commit payload. */
+export async function computeCommitHash(fields: CommitHashFields): Promise<string> {
+  return sha256Hex(commitPayload(fields))
 }
 
 /**
@@ -56,13 +103,4 @@ export async function sha256Hex(input: string): Promise<string> {
   return Array.from(new Uint8Array(digest))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
-}
-
-/** Content-address for a version: sha256 over the canonical payload. */
-export async function computeCommitHash(
-  docJson: unknown,
-  parentHash: string | null,
-  documentId: string,
-): Promise<string> {
-  return sha256Hex(commitPayload(docJson, parentHash, documentId))
 }

--- a/src/lib/history/canonical.ts
+++ b/src/lib/history/canonical.ts
@@ -1,0 +1,68 @@
+/**
+ * Canonical serialization for content-addressed document versions.
+ *
+ * The version hash is a sha256 over a canonical string derived from
+ * (documentId, parentHash, docJson). Both the client (crypto.subtle in the
+ * browser) and the server (/api/history, Node's WebCrypto) import THIS module
+ * so the payload is byte-identical on both sides — the server recomputes the
+ * hash and rejects mismatches, which is what makes history tamper-evident.
+ *
+ * Pure module: no React, no Prisma, no DOM. Safe to import anywhere.
+ */
+
+/**
+ * Deterministic JSON stringify: object keys are emitted in sorted order at
+ * every depth, arrays keep their order. Two structurally-equal values always
+ * produce the same string regardless of key insertion order.
+ */
+export function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalStringify(item ?? null)).join(',')}]`
+  }
+  const record = value as Record<string, unknown>
+  const keys = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+  const body = keys
+    .map((key) => `${JSON.stringify(key)}:${canonicalStringify(record[key])}`)
+    .join(',')
+  return `{${body}}`
+}
+
+/**
+ * The exact string that gets hashed for a version. `docJson` may arrive as an
+ * object or as a JSON string (the API stores it as a string) — both normalize
+ * to the same canonical form.
+ */
+export function commitPayload(
+  docJson: unknown,
+  parentHash: string | null,
+  documentId: string,
+): string {
+  const parsed = typeof docJson === 'string' ? JSON.parse(docJson) : docJson
+  return `${documentId}\n${parentHash ?? ''}\n${canonicalStringify(parsed)}`
+}
+
+/**
+ * sha256 hex digest via WebCrypto — available in browsers and Node 18+
+ * (globalThis.crypto.subtle), so client and server share one implementation.
+ */
+export async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Content-address for a version: sha256 over the canonical payload. */
+export async function computeCommitHash(
+  docJson: unknown,
+  parentHash: string | null,
+  documentId: string,
+): Promise<string> {
+  return sha256Hex(commitPayload(docJson, parentHash, documentId))
+}

--- a/src/lib/history/commits.ts
+++ b/src/lib/history/commits.ts
@@ -1,0 +1,231 @@
+/**
+ * Client-side document version layer (git model, accessible language).
+ *
+ * Every version is a content-addressed snapshot in an append-only linear
+ * chain: createCommit fetches the current head, hashes the new content
+ * against it, and POSTs to /api/history (which re-verifies the hash).
+ * Restoring an old version NEVER rewrites history — it dispatches the old
+ * content into the editor and records a NEW 'restore' version on top,
+ * plus an Article 14 human-oversight audit record.
+ *
+ * All capture points go through `recordCommit`, a fire-and-forget wrapper
+ * that can never block or throw into UI paths.
+ */
+
+import type { EditorView } from 'prosemirror-view'
+import { Node } from 'prosemirror-model'
+import { computeCommitHash } from './canonical'
+import { logAuditEvent } from '@/lib/audit/auditLogger'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CommitKind = 'import' | 'apply' | 'direct' | 'restore'
+
+export interface CommitMeta {
+  hash: string
+  documentId: string
+  parentHash: string | null
+  kind: CommitKind
+  message: string
+  blockIdsTouched: string // JSON string[]
+  annotationId: string | null
+  auditIds: string // JSON string[]
+  actor: string
+  modelVersion: string
+  createdAt: string
+}
+
+export interface CommitWithDoc extends CommitMeta {
+  docJson: string
+}
+
+export interface CreateCommitParams {
+  docJson: unknown
+  documentId: string
+  kind: CommitKind
+  message: string
+  annotationId?: string | null
+  auditIds?: string[]
+  blockIdsTouched?: string[]
+  actor?: string
+  modelVersion?: string
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/** Version metadata for a document, newest first (no content). */
+export async function listCommits(documentId: string): Promise<CommitMeta[]> {
+  const res = await fetch(`/api/history?documentId=${encodeURIComponent(documentId)}`)
+  if (!res.ok) throw new Error(`Failed to load history (HTTP ${res.status})`)
+  const data = await res.json()
+  return data.commits ?? []
+}
+
+/** One version including its full document content. */
+export async function getCommit(hash: string): Promise<CommitWithDoc | null> {
+  const res = await fetch(`/api/history?hash=${encodeURIComponent(hash)}`)
+  if (res.status === 404) return null
+  if (!res.ok) throw new Error(`Failed to load version (HTTP ${res.status})`)
+  const data = await res.json()
+  return data.commit ?? null
+}
+
+/** The newest version of a document, or null when it has no history yet. */
+export async function headCommit(documentId: string): Promise<CommitMeta | null> {
+  const res = await fetch(
+    `/api/history?documentId=${encodeURIComponent(documentId)}&limit=1`,
+  )
+  if (!res.ok) throw new Error(`Failed to load history head (HTTP ${res.status})`)
+  const data = await res.json()
+  return data.commits?.[0] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Hashing + writes
+// ---------------------------------------------------------------------------
+
+function toDocJsonString(docJson: unknown): string {
+  return typeof docJson === 'string' ? docJson : JSON.stringify(docJson)
+}
+
+/** Content-address for a candidate version (sha256 hex via crypto.subtle). */
+export async function hashCommit(
+  docJson: unknown,
+  parentHash: string | null,
+  documentId: string,
+): Promise<string> {
+  return computeCommitHash(docJson, parentHash, documentId)
+}
+
+/**
+ * Append a new version. Chains onto the current head; when the content is
+ * identical to the head (hashing the candidate against the head's parent
+ * reproduces the head's own hash), this is a no-op that returns the existing
+ * head hash — which is what makes idle autosave flushes free.
+ */
+export async function createCommit(params: CreateCommitParams): Promise<string> {
+  const docJsonString = toDocJsonString(params.docJson)
+  const head = await headCommit(params.documentId)
+
+  if (head) {
+    const unchanged = await hashCommit(docJsonString, head.parentHash, params.documentId)
+    if (unchanged === head.hash) return head.hash
+  }
+
+  const parentHash = head?.hash ?? null
+  const hash = await hashCommit(docJsonString, parentHash, params.documentId)
+
+  const res = await fetch('/api/history', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      action: 'commit',
+      hash,
+      documentId: params.documentId,
+      parentHash,
+      kind: params.kind,
+      message: params.message,
+      docJson: docJsonString,
+      blockIdsTouched: JSON.stringify(params.blockIdsTouched ?? []),
+      annotationId: params.annotationId ?? undefined,
+      auditIds: JSON.stringify(params.auditIds ?? []),
+      actor: params.actor ?? 'human',
+      modelVersion: params.modelVersion ?? '',
+    }),
+  })
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error ?? `Failed to save version (HTTP ${res.status})`)
+  }
+  const data = await res.json()
+  return data.hash ?? hash
+}
+
+/**
+ * Fire-and-forget version capture for UI paths: never throws, never blocks.
+ * Server-side renders and non-browser test environments are a silent no-op.
+ */
+export function recordCommit(params: CreateCommitParams): void {
+  if (typeof window === 'undefined') return
+  createCommit(params).catch((err) => {
+    console.warn('[history] Failed to record version:', err)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Blame + restore
+// ---------------------------------------------------------------------------
+
+/**
+ * "Last changed by" for a block: newest-first scan of each version's
+ * blockIdsTouched. `commits` is expected newest first (as listCommits
+ * returns); defensively re-sorted by createdAt.
+ */
+export function blameBlock(commits: CommitMeta[], blockId: string): CommitMeta | null {
+  const newestFirst = [...commits].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+  for (const commit of newestFirst) {
+    try {
+      const touched: unknown = JSON.parse(commit.blockIdsTouched || '[]')
+      if (Array.isArray(touched) && touched.includes(blockId)) return commit
+    } catch {
+      // Malformed metadata never breaks blame — skip the record.
+    }
+  }
+  return null
+}
+
+/**
+ * Restore an old version (git-checkout semantics, append-only):
+ *   1. Replace the editor content with the old snapshot — outside undo
+ *      history, so Cmd-Z cannot half-revert a restore.
+ *   2. Record a NEW 'restore' version whose parent is the pre-restore head.
+ *      Nothing is deleted; the versions in between stay in the chain.
+ *   3. Log an EU AI Act Article 14 human-oversight record: a restore is an
+ *      explicit human decision about document content.
+ *
+ * Must only be invoked from behind a Confirmation gate.
+ */
+export async function restoreCommit(
+  view: EditorView,
+  commit: CommitWithDoc,
+  documentId: string,
+): Promise<string> {
+  const restoredDoc = Node.fromJSON(view.state.schema, JSON.parse(commit.docJson))
+
+  const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, restoredDoc.content)
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
+
+  const shortHash = commit.hash.slice(0, 8)
+  const newHash = await createCommit({
+    docJson: commit.docJson,
+    documentId,
+    kind: 'restore',
+    message: `Restored version ${shortHash}`,
+    actor: 'human',
+  })
+
+  await logAuditEvent({
+    userId: 'local',
+    modelName: 'human',
+    modelVersion: 'human',
+    promptVersion: 'N/A',
+    promptHash: 'N/A',
+    queryClassification: 'HUMAN_RESTORE',
+    sourceDocuments: JSON.stringify([documentId]),
+    confidenceScore: null,
+    responseId: crypto.randomUUID(),
+    outputType: 'HUMAN_RESTORE',
+    approvalStatus: 'APPROVED_HUMAN',
+    overrideReason: `Restored version ${shortHash} (new version ${newHash.slice(0, 8)})`,
+  })
+
+  return newHash
+}

--- a/src/lib/history/commits.ts
+++ b/src/lib/history/commits.ts
@@ -1,20 +1,30 @@
 /**
  * Client-side document version layer (git model, accessible language).
  *
- * Every version is a content-addressed snapshot in an append-only linear
- * chain: createCommit fetches the current head, hashes the new content
- * against it, and POSTs to /api/history (which re-verifies the hash).
- * Restoring an old version NEVER rewrites history — it dispatches the old
- * content into the editor and records a NEW 'restore' version on top,
- * plus an Article 14 human-oversight audit record.
+ * Every version is a two-level content-addressed snapshot in an append-only
+ * linear chain: `contentHash` covers the document content only (the "tree"),
+ * `hash` — the primary key — covers content PLUS attribution (parent, kind,
+ * message, actor, annotationId, auditIds, modelVersion), so versions that
+ * share content but differ in provenance stay distinct records.
  *
- * All capture points go through `recordCommit`, a fire-and-forget wrapper
+ * createCommit fetches the current head, hashes the candidate against it,
+ * and POSTs to /api/history (which re-verifies both hashes and enforces
+ * linearity — one root, one child per parent). On a stale-head conflict it
+ * refetches the head and retries exactly once.
+ *
+ * Restoring an old version NEVER rewrites history — it (0) flushes any
+ * pending edits as a 'direct' version, (1) writes the Article 14 oversight
+ * record, (2) appends a 'restore' version linked to that record, and (3)
+ * only then mutates the editor. A failure before (3) leaves the document
+ * untouched.
+ *
+ * UI capture points go through `recordCommit`, a fire-and-forget wrapper
  * that can never block or throw into UI paths.
  */
 
 import type { EditorView } from 'prosemirror-view'
 import { Node } from 'prosemirror-model'
-import { computeCommitHash } from './canonical'
+import { computeCommitHash, computeContentHash } from './canonical'
 import { logAuditEvent } from '@/lib/audit/auditLogger'
 
 // ---------------------------------------------------------------------------
@@ -25,6 +35,7 @@ export type CommitKind = 'import' | 'apply' | 'direct' | 'restore'
 
 export interface CommitMeta {
   hash: string
+  contentHash: string
   documentId: string
   parentHash: string | null
   kind: CommitKind
@@ -53,13 +64,31 @@ export interface CreateCommitParams {
   modelVersion?: string
 }
 
+export interface CreateCommitResult {
+  hash: string
+  /** True when nothing was written because the head already has this content. */
+  noop: boolean
+}
+
 // ---------------------------------------------------------------------------
 // Reads
 // ---------------------------------------------------------------------------
 
+export interface ListCommitsOptions {
+  limit?: number
+  /** ISO createdAt cursor: return only versions strictly older than this. */
+  before?: string
+}
+
 /** Version metadata for a document, newest first (no content). */
-export async function listCommits(documentId: string): Promise<CommitMeta[]> {
-  const res = await fetch(`/api/history?documentId=${encodeURIComponent(documentId)}`)
+export async function listCommits(
+  documentId: string,
+  options?: ListCommitsOptions,
+): Promise<CommitMeta[]> {
+  const params = new URLSearchParams({ documentId })
+  if (options?.limit != null) params.set('limit', String(options.limit))
+  if (options?.before) params.set('before', options.before)
+  const res = await fetch(`/api/history?${params.toString()}`)
   if (!res.ok) throw new Error(`Failed to load history (HTTP ${res.status})`)
   const data = await res.json()
   return data.commits ?? []
@@ -85,39 +114,52 @@ export async function headCommit(documentId: string): Promise<CommitMeta | null>
 }
 
 // ---------------------------------------------------------------------------
-// Hashing + writes
+// Writes
 // ---------------------------------------------------------------------------
 
 function toDocJsonString(docJson: unknown): string {
   return typeof docJson === 'string' ? docJson : JSON.stringify(docJson)
 }
 
-/** Content-address for a candidate version (sha256 hex via crypto.subtle). */
-export async function hashCommit(
-  docJson: unknown,
-  parentHash: string | null,
-  documentId: string,
-): Promise<string> {
-  return computeCommitHash(docJson, parentHash, documentId)
-}
+/** Sentinel: the server rejected the write because the head moved under us. */
+const STALE_HEAD = Symbol('stale-head')
 
-/**
- * Append a new version. Chains onto the current head; when the content is
- * identical to the head (hashing the candidate against the head's parent
- * reproduces the head's own hash), this is a no-op that returns the existing
- * head hash — which is what makes idle autosave flushes free.
- */
-export async function createCommit(params: CreateCommitParams): Promise<string> {
-  const docJsonString = toDocJsonString(params.docJson)
+async function attemptCommit(
+  params: CreateCommitParams,
+  docJsonString: string,
+  contentHash: string,
+): Promise<CreateCommitResult | typeof STALE_HEAD> {
   const head = await headCommit(params.documentId)
 
-  if (head) {
-    const unchanged = await hashCommit(docJsonString, head.parentHash, params.documentId)
-    if (unchanged === head.hash) return head.hash
+  // Content dedupe (tree-level): 'direct' autosave flushes and 'restore'
+  // no-op when the head already has this exact content. 'apply' and 'import'
+  // ALWAYS commit — their provenance (actor, auditIds, annotation) matters
+  // even when the content coincides with the head.
+  if (
+    head &&
+    head.contentHash === contentHash &&
+    (params.kind === 'direct' || params.kind === 'restore')
+  ) {
+    return { hash: head.hash, noop: true }
   }
 
   const parentHash = head?.hash ?? null
-  const hash = await hashCommit(docJsonString, parentHash, params.documentId)
+  const annotationId = params.annotationId ?? null
+  const auditIds = params.auditIds ?? []
+  const actor = params.actor ?? 'human'
+  const modelVersion = params.modelVersion ?? ''
+
+  const hash = await computeCommitHash({
+    documentId: params.documentId,
+    parentHash,
+    contentHash,
+    kind: params.kind,
+    message: params.message,
+    actor,
+    annotationId,
+    auditIds,
+    modelVersion,
+  })
 
   const res = await fetch('/api/history', {
     method: 'POST',
@@ -125,25 +167,51 @@ export async function createCommit(params: CreateCommitParams): Promise<string> 
     body: JSON.stringify({
       action: 'commit',
       hash,
+      contentHash,
       documentId: params.documentId,
       parentHash,
       kind: params.kind,
       message: params.message,
       docJson: docJsonString,
       blockIdsTouched: JSON.stringify(params.blockIdsTouched ?? []),
-      annotationId: params.annotationId ?? undefined,
-      auditIds: JSON.stringify(params.auditIds ?? []),
-      actor: params.actor ?? 'human',
-      modelVersion: params.modelVersion ?? '',
+      annotationId: annotationId ?? undefined,
+      auditIds: JSON.stringify(auditIds),
+      actor,
+      modelVersion,
     }),
   })
 
+  if (res.status === 409) {
+    const data = await res.json().catch(() => null)
+    if (data?.reason === 'stale-head') return STALE_HEAD
+    throw new Error(data?.error ?? 'Failed to save version (HTTP 409)')
+  }
   if (!res.ok) {
     const data = await res.json().catch(() => null)
     throw new Error(data?.error ?? `Failed to save version (HTTP ${res.status})`)
   }
   const data = await res.json()
-  return data.hash ?? hash
+  return { hash: data.hash ?? hash, noop: false }
+}
+
+/**
+ * Append a new version. Chains onto the current head; on a stale-head
+ * conflict (the server saw another child arrive first) the head is refetched
+ * and the write retried exactly once, then gives up with an error.
+ */
+export async function createCommit(params: CreateCommitParams): Promise<CreateCommitResult> {
+  const docJsonString = toDocJsonString(params.docJson)
+  const contentHash = await computeContentHash(docJsonString)
+
+  const first = await attemptCommit(params, docJsonString, contentHash)
+  if (first !== STALE_HEAD) return first
+
+  // The head advanced between our read and our write (e.g. an 'apply' and an
+  // autosave racing). Refetch, rehash against the new head, retry ONCE.
+  const second = await attemptCommit(params, docJsonString, contentHash)
+  if (second !== STALE_HEAD) return second
+
+  throw new Error('Failed to save version: the document history is advancing concurrently')
 }
 
 /**
@@ -181,14 +249,30 @@ export function blameBlock(commits: CommitMeta[], blockId: string): CommitMeta |
   return null
 }
 
+export interface RestoreResult {
+  hash: string
+  /** True when the document was already at this content — nothing was written. */
+  noop: boolean
+}
+
 /**
- * Restore an old version (git-checkout semantics, append-only):
- *   1. Replace the editor content with the old snapshot — outside undo
- *      history, so Cmd-Z cannot half-revert a restore.
- *   2. Record a NEW 'restore' version whose parent is the pre-restore head.
- *      Nothing is deleted; the versions in between stay in the chain.
- *   3. Log an EU AI Act Article 14 human-oversight record: a restore is an
- *      explicit human decision about document content.
+ * Restore an old version (git-checkout semantics, append-only). Persistence
+ * comes FIRST; the editor is only mutated after every record is safely
+ * written, so a failed write leaves the document exactly as it was and the
+ * UI's "Restore failed" message is true:
+ *
+ *   0. Flush any pending, unsaved editor content as a 'direct' version
+ *      (a free no-op when unchanged) — restoring seconds after typing must
+ *      not discard the typed tail from history.
+ *   1. Log the EU AI Act Article 14 human-oversight record and CAPTURE its
+ *      id: a restore is an explicit human decision about document content.
+ *   2. Record the NEW 'restore' version — parent = pre-restore head,
+ *      auditIds = [the oversight record], a real Article 12 link.
+ *   3. Only on success, replace the editor content with the old snapshot —
+ *      outside undo history, so Cmd-Z cannot half-revert a restore.
+ *
+ * Restoring to content identical to the head is a no-op: no version, no
+ * audit record, `{ noop: true }` so the UI can say "Already at this version".
  *
  * Must only be invoked from behind a Confirmation gate.
  */
@@ -196,23 +280,30 @@ export async function restoreCommit(
   view: EditorView,
   commit: CommitWithDoc,
   documentId: string,
-): Promise<string> {
-  const restoredDoc = Node.fromJSON(view.state.schema, JSON.parse(commit.docJson))
-
-  const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, restoredDoc.content)
-  tr.setMeta('addToHistory', false)
-  view.dispatch(tr)
-
-  const shortHash = commit.hash.slice(0, 8)
-  const newHash = await createCommit({
-    docJson: commit.docJson,
+): Promise<RestoreResult> {
+  // (0) Flush pending edits so they exist in history before we move off them.
+  await createCommit({
+    docJson: view.state.doc.toJSON(),
     documentId,
-    kind: 'restore',
-    message: `Restored version ${shortHash}`,
+    kind: 'direct',
+    message: 'Edited document',
     actor: 'human',
   })
 
-  await logAuditEvent({
+  // Already at this content? Then there is nothing to restore.
+  const targetContentHash = await computeContentHash(commit.docJson)
+  const head = await headCommit(documentId)
+  if (head && head.contentHash === targetContentHash) {
+    return { hash: head.hash, noop: true }
+  }
+
+  const shortHash = commit.hash.slice(0, 8)
+
+  // (1) Article 14 oversight record, id captured for the version linkage.
+  // logAuditEvent is designed never to throw; a failed audit write yields
+  // null and the restore version then records zero audit ids (surfaced
+  // honestly in docs/compliance.md).
+  const auditId = await logAuditEvent({
     userId: 'local',
     modelName: 'human',
     modelVersion: 'human',
@@ -224,8 +315,25 @@ export async function restoreCommit(
     responseId: crypto.randomUUID(),
     outputType: 'HUMAN_RESTORE',
     approvalStatus: 'APPROVED_HUMAN',
-    overrideReason: `Restored version ${shortHash} (new version ${newHash.slice(0, 8)})`,
+    overrideReason: `Restored version ${shortHash}`,
   })
 
-  return newHash
+  // (2) The restore version, linked to the oversight record. Throws on
+  // failure — and the editor has not been touched yet.
+  const { hash: newHash } = await createCommit({
+    docJson: commit.docJson,
+    documentId,
+    kind: 'restore',
+    message: `Restored version ${shortHash}`,
+    actor: 'human',
+    auditIds: auditId ? [auditId] : [],
+  })
+
+  // (3) Persistence succeeded — now, and only now, mutate the editor.
+  const restoredDoc = Node.fromJSON(view.state.schema, JSON.parse(commit.docJson))
+  const tr = view.state.tr.replaceWith(0, view.state.doc.content.size, restoredDoc.content)
+  tr.setMeta('addToHistory', false)
+  view.dispatch(tr)
+
+  return { hash: newHash, noop: false }
 }

--- a/src/lib/history/docText.ts
+++ b/src/lib/history/docText.ts
@@ -1,0 +1,50 @@
+/**
+ * Plain-text extraction from a stored document snapshot (ProseMirror docJson).
+ * Used by the History panel to compare versions: one line per textblock,
+ * blocks joined with newlines. Pure JSON walk — no schema required, so it
+ * works on snapshots regardless of schema evolution.
+ */
+
+const TEXTBLOCK_TYPES = new Set(['paragraph', 'heading', 'code_block'])
+
+interface DocJsonNode {
+  type?: string
+  text?: string
+  content?: DocJsonNode[]
+}
+
+function inlineText(node: DocJsonNode): string {
+  if (typeof node.text === 'string') return node.text
+  if (Array.isArray(node.content)) return node.content.map(inlineText).join('')
+  return ''
+}
+
+/** Concatenate text nodes per block, blocks separated by newlines. */
+export function docJsonToText(docJson: unknown): string {
+  const parsed: DocJsonNode | null =
+    typeof docJson === 'string' ? safeParse(docJson) : (docJson as DocJsonNode | null)
+  if (!parsed || typeof parsed !== 'object') return ''
+
+  const lines: string[] = []
+  const visit = (node: DocJsonNode) => {
+    if (!node || typeof node !== 'object') return
+    if (node.type && TEXTBLOCK_TYPES.has(node.type)) {
+      lines.push(inlineText(node))
+      return
+    }
+    for (const child of node.content ?? []) visit(child)
+  }
+  visit(parsed)
+
+  // Fallback for snapshots with unknown block types: raw inline text.
+  if (lines.length === 0) return inlineText(parsed)
+  return lines.join('\n')
+}
+
+function safeParse(raw: string): DocJsonNode | null {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}

--- a/src/lib/prosemirror/__tests__/changeTrackingPlugin.test.ts
+++ b/src/lib/prosemirror/__tests__/changeTrackingPlugin.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { Node } from 'prosemirror-model'
+import { history, undo } from 'prosemirror-history'
+import { schema } from '@/lib/prosemirror/schema'
+import {
+  createChangeTrackingPlugin,
+  setChangeCallback,
+} from '../plugins/changeTrackingPlugin'
+
+function docWithText(text: string): Node {
+  return Node.fromJSON(schema, {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  })
+}
+
+describe('changeTrackingPlugin', () => {
+  let calls: any[]
+
+  beforeEach(() => {
+    calls = []
+    setChangeCallback((change) => calls.push(change))
+  })
+
+  afterEach(() => {
+    setChangeCallback(() => {})
+  })
+
+  it('tracks a normal typing transaction', () => {
+    const state = EditorState.create({
+      schema,
+      doc: docWithText('Hello'),
+      plugins: [createChangeTrackingPlugin()],
+    })
+
+    const tr = state.tr.insertText(' world', state.doc.content.size - 1)
+    state.apply(tr)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].id).toBeTruthy()
+    expect(calls[0].steps).toHaveLength(1)
+  })
+
+  it('skips state loads: a full-document replaceWith with addToHistory:false is not an edit', () => {
+    // Restore and document-switch both dispatch this shape. Before the fix it
+    // pushed a full-document beforeSlice/afterSlice "Direct edit" entry into
+    // the persisted changes store on every restore/switch.
+    const state = EditorState.create({
+      schema,
+      doc: docWithText('current document'),
+      plugins: [createChangeTrackingPlugin()],
+    })
+
+    const restored = docWithText('restored snapshot')
+    const tr = state.tr.replaceWith(0, state.doc.content.size, restored.content)
+    tr.setMeta('addToHistory', false)
+    const next = state.apply(tr)
+
+    expect(next.doc.textContent).toBe('restored snapshot') // load happened…
+    expect(calls).toHaveLength(0) // …but no phantom "Direct edit" was logged
+  })
+
+  it('still tracks ordinary edits made after a state load', () => {
+    let state = EditorState.create({
+      schema,
+      doc: docWithText('current'),
+      plugins: [createChangeTrackingPlugin()],
+    })
+
+    const loadTr = state.tr.replaceWith(0, state.doc.content.size, docWithText('loaded').content)
+    loadTr.setMeta('addToHistory', false)
+    state = state.apply(loadTr)
+    expect(calls).toHaveLength(0)
+
+    state = state.apply(state.tr.insertText('!', state.doc.content.size - 1))
+    expect(calls).toHaveLength(1)
+  })
+})
+
+describe('prosemirror-history after a restore-style state load', () => {
+  it('undo immediately after a full-document replaceWith with addToHistory:false does not throw; the pre-load edit is no longer undoable', () => {
+    // Documents the interaction between the undo stack and a restore:
+    // the load transaction is excluded from history (addToHistory:false), so
+    // prosemirror-history rebases the stored undo steps through the
+    // full-document replace mapping. Because the replace covers the entire
+    // document, the earlier typing step cannot be mapped back into the new
+    // content — undo becomes a safe no-op rather than half-reverting the
+    // restore or corrupting positions.
+    let state = EditorState.create({
+      schema,
+      doc: docWithText('Hello'),
+      plugins: [history(), createChangeTrackingPlugin()],
+    })
+
+    // An undoable edit…
+    state = state.apply(state.tr.insertText(' world', state.doc.content.size - 1))
+    expect(state.doc.textContent).toBe('Hello world')
+
+    // …then a restore-style load, outside undo history.
+    const loadTr = state.tr.replaceWith(0, state.doc.content.size, docWithText('restored').content)
+    loadTr.setMeta('addToHistory', false)
+    state = state.apply(loadTr)
+    expect(state.doc.textContent).toBe('restored')
+
+    // Cmd-Z straight after the restore: must not throw, must not resurrect
+    // the pre-restore document.
+    let dispatched = false
+    expect(() =>
+      undo(state, (tr) => {
+        dispatched = true
+        state = state.apply(tr)
+      }),
+    ).not.toThrow()
+
+    expect(state.doc.textContent).toBe('restored')
+    // Whether or not prosemirror-history dispatched a (mapped, contentless)
+    // transaction, the visible document is unchanged.
+    if (dispatched) {
+      expect(state.doc.textContent).toBe('restored')
+    }
+  })
+})

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -21,6 +21,7 @@ export interface AppliedEdit {
   to: number
   newText: string
   targetText: string
+  blockId?: string | null
 }
 
 export type ApplyProposedResult =
@@ -59,7 +60,7 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
     const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
 
     if (current === a.targetText) {
-      resolved.push({ from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText })
+      resolved.push({ from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
       continue
     }
 
@@ -75,7 +76,7 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
         reason: `Could not safely place an edit — the text "${a.targetText.slice(0, 40)}…" has changed. Re-run the annotation.`,
       }
     }
-    resolved.push({ from: found.from, to: found.to, newText: a.newText, targetText: a.targetText })
+    resolved.push({ from: found.from, to: found.to, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
   }
 
   // Apply descending by `from` so each replace leaves earlier positions valid.

--- a/src/lib/prosemirror/plugins/changeTrackingPlugin.ts
+++ b/src/lib/prosemirror/plugins/changeTrackingPlugin.ts
@@ -46,14 +46,19 @@ export function createChangeTrackingPlugin(): Plugin {
       const docChanged = transactions.some(tr => tr.docChanged)
       if (!docChanged) return null
 
-      // Skip undo/redo, our own tracking transactions, and blockId stamping
-      // (attr-only stamps would otherwise log phantom "Direct edit" entries)
-      const isUndo = transactions.some(tr =>
+      // Skip undo/redo, our own tracking transactions, blockId stamping
+      // (attr-only stamps would otherwise log phantom "Direct edit" entries),
+      // and state loads: restore and document-switch dispatch a full-document
+      // replaceWith with addToHistory:false — those are not edits, and must
+      // not push full-document beforeSlice/afterSlice entries into the
+      // persisted changes store.
+      const skip = transactions.some(tr =>
         tr.getMeta('history$') ||
         tr.getMeta(changeTrackingPluginKey) ||
-        tr.getMeta(blockIdPluginKey)
+        tr.getMeta(blockIdPluginKey) ||
+        tr.getMeta('addToHistory') === false
       )
-      if (isUndo) return null
+      if (skip) return null
 
       // Compute the changed range
       let changeFrom = newState.doc.content.size

--- a/src/stores/changesStore.ts
+++ b/src/stores/changesStore.ts
@@ -22,6 +22,7 @@ interface ChangesState {
   ensureChangeSetForAnnotation: (annotation: Annotation) => string | null
   linkAuditToAnnotation: (annotation: Annotation, auditRecordId: string) => void
   updateChangeSetStatus: (id: string, status: ChangeSetStatus) => void
+  setChangeSetCommitHash: (id: string, commitHash: string) => void
   getChangeSetByAnnotationId: (annotationId: string) => ChangeSet | undefined
   clear: () => void
 }
@@ -183,6 +184,13 @@ export const useChangesStore = create<ChangesState>()(
             changeSet.id === id
               ? { ...changeSet, status, updatedAt: Date.now() }
               : changeSet
+          ),
+        })),
+
+      setChangeSetCommitHash: (id, commitHash) =>
+        set((s) => ({
+          changeSets: s.changeSets.map((changeSet) =>
+            changeSet.id === id ? { ...changeSet, commitHash } : changeSet
           ),
         })),
 

--- a/src/stores/documentStore.ts
+++ b/src/stores/documentStore.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { generateId } from '@/lib/utils/id'
+import { recordCommit } from '@/lib/history/commits'
 
 export interface DocumentMeta {
   id: string
@@ -105,6 +106,7 @@ export const useDocumentStore = create<DocumentStoreState>()(
         const id = generateId()
         const now = Date.now()
         const collectionIds = [...new Set(options?.collectionIds ?? EMPTY_COLLECTIONS)]
+        const documentTitle = title.trim() || 'Untitled'
 
         try {
           localStorage.setItem(getDocumentStorageKey(id), JSON.stringify(docJson))
@@ -116,7 +118,7 @@ export const useDocumentStore = create<DocumentStoreState>()(
           documents: [
             {
               id,
-              title: title.trim() || 'Untitled',
+              title: documentTitle,
               createdAt: now,
               updatedAt: now,
               collectionIds,
@@ -127,6 +129,16 @@ export const useDocumentStore = create<DocumentStoreState>()(
           lastSavedAt: now,
           isDirty: false,
         }))
+
+        // Root entry in the document's version history (fire-and-forget —
+        // covers blank/paste/generate/import and duplicates alike).
+        recordCommit({
+          docJson,
+          documentId: id,
+          kind: 'import',
+          message: `Created "${documentTitle}"`,
+          actor: 'human',
+        })
 
         return id
       },


### PR DESCRIPTION
## Why

Intent IDE's data model has always been pitched as "version control, not chat," but the tracking layer was ephemeral: snapshots deliberately unpersisted (localStorage quota), timestamp IDs instead of content addressing, "undo" as a display flag, quota pruning that destroys history. Meanwhile the unused `DocumentSource` Prisma model sat exactly where durable version control belongs. This PR adds a git-model document history layer that strengthens — not just preserves — EU AI Act Articles 12 & 14 compliance.

## What — git's actual logic, applied

**Two-level content addressing (like git's tree + commit objects).** `contentHash` = SHA-256 of the canonicalized document snapshot (the "tree"); the commit `hash` covers `documentId + parent + contentHash + kind + message + actor + annotationId + auditIds + modelVersion` (the "commit"). Attribution is inside the address — two commits agreeing on content but disagreeing on who/what/why are distinct by construction. This closed the sharpest adversarial-review finding: with content-only hashing, an AI apply-commit and a racing autosave collapsed to one hash and the AI provenance was silently discarded.

**Append-only DAG, server-enforced linear** (`/api/history`, modeled on the audit route's discipline): POST create-only; the server recomputes both hashes and rejects mismatches; unknown or cross-document parents rejected; a second child of any parent or a second root → 409 `stale-head` (client rebases on the refetched head and retries once); duplicate identical commits are idempotent 200s; concurrent-create unique races resolve to the existing row. No update or delete endpoint exists.

**Restore is transactional and honest** — history is never rewritten (git-without-rebase): pending edits are flushed as a version first (nothing typed is ever lost), the Article 14 human-override audit record is written and its id embedded in the restore commit's `auditIds`, and only then does the editor mutate. A failed restore leaves the document untouched, so "Restore failed" is true when shown.

**Capture points**: root version on create/import, `apply` versions on accepted AI changes (carrying `blockIdsTouched` from the v8.4 blockIds, linked audit ids, actor `ai+human`, model version), and session-granular `direct` versions on autosave/doc-switch/unmount flushes — content-hash dedupe makes unchanged flushes free.

**History panel** — accessible language throughout (Version / Compare / Restore / "Last changed by"; no git jargon): version list with kind icons, actor chips, audit-count chips, short hashes; compare-vs-previous and compare-any-two using the existing diff viewers; Confirmation-gated restore; pagination past 200 versions.

**Compliance, stated precisely** (`docs/compliance.md`): application-enforced append-only; tamper-*evident* via server-verified hashing (not cryptographically signed — client-supplied attribution in a local-first BYOK app, said plainly); the `auditFailed` → zero-audit-links path disclosed. Precision over promotion.

**Also**: the unused `DocumentSource` model is removed (migration verified against a populated pre-existing database — all audit-chain rows preserved); CI now runs `prisma migrate deploy` so migration SQL is actually exercised; state-load transactions (restore, document switch) no longer log phantom full-document "Direct edit" entries.

## Testing

335 passing (was 287 on main; +48), typecheck 0 errors, lint clean, production build clean. Adversarial (Troublemaker) review ran pre-PR; both HIGH findings (attribution outside the hash; restore mutating before recording) and the linearity race are fixed in `48ab51e`/`dfb2c3c` with regression tests, including the exact provenance-collapse interleaving. The reviewer independently executed the migration against a populated database.

## Notes for reviewers

- `blockIdsTouched` stays outside the commit hash deliberately (advisory blame metadata; hashing it would break idempotent re-sends).
- A failed audit write does not block a human's restore — the version records zero audit links and the posture is documented, matching the existing `auditFailed` behavior for resolutions.
- Retention: `direct` versions are kept indefinitely for now; collapse policy is documented as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
