### PR TITLE
Vercel + Turso deployment prep: public-exposure hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ DATABASE_URL="file:./dev.db"
 # Generate with `openssl rand -hex 32`. Leave unset locally for open access.
 # AUDIT_ADMIN_TOKEN=
 
+# Server-side version history stores full document snapshots — disabled in
+# production by default. Opt in on private self-hosts only.
+# HISTORY_ENABLED=1
+
 # --- FalkorDB (Graph Database) ---
 FALKORDB_HOST=localhost
 FALKORDB_PORT=6379

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
 # Copy to .env and fill in real values. .env is gitignored — never commit secrets.
 
-# Prisma (SQLite audit/compliance DB)
+# Prisma audit/compliance DB (libSQL adapter)
+# Local dev: SQLite file. Production (Vercel): Turso, e.g. libsql://intent-ide-audit-<org>.turso.io
 DATABASE_URL="file:./dev.db"
+# Required only for Turso (create with `turso db tokens create <db>`)
+# DATABASE_AUTH_TOKEN=
+
+# Production only: bearer token that gates unscoped GET /api/audit reads.
+# Generate with `openssl rand -hex 32`. Leave unset locally for open access.
+# AUDIT_ADMIN_TOKEN=
 
 # --- FalkorDB (Graph Database) ---
 FALKORDB_HOST=localhost

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ To deploy your own:
 | `DATABASE_AUTH_TOKEN` | `turso db tokens create <db>` |
 | `AUDIT_ADMIN_TOKEN` | random secret; gates unscoped `GET /api/audit` reads |
 
-Known limits on Vercel: LLM/transcription routes cap at 60s (`maxDuration`), and voice uploads are limited to ~4.5 MB — very long recordings may fail to transcribe. In production, custom OpenAI-compatible base URLs must be public `https` endpoints (private/loopback addresses are rejected), and each visitor's audit trail is scoped to an anonymous per-browser ID.
+Known limits on Vercel: LLM/transcription routes cap at 60s (`maxDuration`), and voice uploads are limited to ~4.5 MB — very long recordings may fail to transcribe. In production, custom OpenAI-compatible base URLs must be public `https` endpoints (private/loopback addresses are rejected), and each visitor's audit trail is scoped to an anonymous per-browser ID. Server-side version history (`/api/history`) is **disabled in production** by default — it stores full document snapshots, which the shared public demo must not do; private self-hosts can opt in with `HISTORY_ENABLED=1`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 AI can one-shot a document that's 90% right. The unsolved problem is the last 10%: today's tools force you to re-prompt and regenerate the whole thing, destroying the 90% you already liked. Intent IDE treats review as the product — you read, you react (by voice or text), and scoped AI agents make **targeted, auditable, human-approved edits** without touching anything else.
 
+**[Live demo →](https://intent-ide.vercel.app)** Bring your own API key (Settings → API Keys): it stays in your browser's localStorage and is forwarded per-request — never stored server-side. Documents never leave your browser except as LLM prompt context.
+
 <!-- screenshot: main editor with annotations panel -->
 <!-- screenshot: multi-region cascade review with inline accept/reject -->
 <!-- screenshot: semantic commit modal with per-change diff toggles -->
@@ -30,7 +32,7 @@ AI can one-shot a document that's 90% right. The unsolved problem is the last 10
 - **Structured tool-calling** — agents emit edits through a provider-agnostic `propose_edit` tool (`/api/structured`), not regex-parsed prose
 - **Annotation threads, drilling, and verbosity control** — follow-up conversations per annotation, paragraph-level drill-down into AI responses, per-annotation response length (concise/normal/detailed)
 - **Annotation minimap** — spatial overview of every annotation in the document, click-to-scroll
-- **BYOK, local-first** — bring your own Anthropic/OpenAI-compatible/Ollama keys; documents persist locally; the audit ledger is SQLite via Prisma
+- **BYOK, local-first** — bring your own Anthropic/OpenAI-compatible/Ollama keys; documents persist locally; the audit ledger is libSQL via Prisma (a local SQLite file in dev, [Turso](https://turso.tech) in production)
 
 ## Architecture
 
@@ -101,7 +103,24 @@ pip install -r requirements.txt
 python graphiti_mcp_server.py                 # MCP server on :8000
 ```
 
-Without the graph stack, cascade checks fall back to keyword matching; everything else works.
+Without the graph stack, cascade checks fall back to keyword matching; everything else works. The knowledge graph is a **local-dev-only** enhancement — the deployed demo runs without it, using the in-memory document graph and keyword fallback automatically.
+
+## Deployment
+
+The live demo runs on **Vercel** with the audit ledger on **Turso** (hosted libSQL — same Prisma adapter as local SQLite). Everything else is stateless: user documents and keys live in the browser, and the API routes are thin BYOK proxies.
+
+To deploy your own:
+
+1. Create a Turso database and apply the schema: `turso db create intent-ide-audit`, then pipe each `prisma/migrations/*/migration.sql` through `turso db shell intent-ide-audit`.
+2. Import the repo into Vercel (Node 22) and set the environment variables below. The build runs `prisma generate` automatically.
+
+| Env var | Value |
+| :--- | :--- |
+| `DATABASE_URL` | `libsql://<db>-<org>.turso.io` |
+| `DATABASE_AUTH_TOKEN` | `turso db tokens create <db>` |
+| `AUDIT_ADMIN_TOKEN` | random secret; gates unscoped `GET /api/audit` reads |
+
+Known limits on Vercel: LLM/transcription routes cap at 60s (`maxDuration`), and voice uploads are limited to ~4.5 MB — very long recordings may fail to transcribe. In production, custom OpenAI-compatible base URLs must be public `https` endpoints (private/loopback addresses are rejected), and each visitor's audit trail is scoped to an anonymous per-browser ID.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "https://github.com/Vinylfigure/intent-ide.git"
   },
+  "engines": {
+    "node": ">=20"
+  },
   "keywords": [
     "ai",
     "document-review",
@@ -22,7 +25,8 @@
   ],
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
     path: "prisma/migrations",
   },
   datasource: {
+    // CLI/migrate runs against a local SQLite file only. The hosted Turso DB
+    // can't be reached by `prisma migrate` (no driver-adapter hook in this
+    // Prisma version) — apply prisma/migrations/*/migration.sql there via
+    // `turso db shell <db> < migration.sql` instead.
     url: process.env["DATABASE_URL"],
   },
 });

--- a/src/app/api/audit/__tests__/route.test.ts
+++ b/src/app/api/audit/__tests__/route.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Route-level tests for the hardened /api/audit endpoint:
+//   POST — 16KB content-length cap (413), per-IP soft rate limit 30/min (429),
+//          per-field string caps, numeric coercion.
+//   GET  — per-visitor scoping via ?userId=, unscoped reads gated behind
+//          Bearer AUDIT_ADMIN_TOKEN when the env var is set, limit clamping.
+//
+// Prisma is mocked; vi.hoisted keeps the same fn refs across vi.resetModules
+// (needed because the rate-limit Map is module-level state).
+
+const { createMock, findManyMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  findManyMock: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    auditLog: {
+      create: createMock,
+      findMany: findManyMock,
+    },
+  },
+}))
+
+/** Fresh module instance per test so the per-IP rate-limit Map starts empty. */
+async function loadRoute() {
+  vi.resetModules()
+  return import('@/app/api/audit/route')
+}
+
+function postRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/audit', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  })
+}
+
+function getRequest(query = '', headers: Record<string, string> = {}) {
+  return new NextRequest(`http://localhost/api/audit${query}`, { headers })
+}
+
+beforeEach(() => {
+  createMock.mockReset().mockResolvedValue({ id: 'rec-1' })
+  findManyMock.mockReset().mockResolvedValue([])
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// ── POST: body size cap ───────────────────────────────────────────────────────
+
+describe('POST /api/audit — content-length cap', () => {
+  it('rejects a body over 16KB with 413 before touching the database', async () => {
+    const { POST } = await loadRoute()
+    const res = await POST(
+      postRequest({ action: 'log' }, { 'content-length': String(16 * 1024 + 1) }),
+    )
+    expect(res.status).toBe(413)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a body exactly at the 16KB boundary', async () => {
+    const { POST } = await loadRoute()
+    const res = await POST(
+      postRequest({ action: 'log' }, { 'content-length': String(16 * 1024) }),
+    )
+    expect(res.status).toBe(200)
+    expect(createMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ── POST: rate limiting ───────────────────────────────────────────────────────
+
+describe('POST /api/audit — per-IP rate limit', () => {
+  it('allows 30 writes per window, rejects the 31st with 429', async () => {
+    const { POST } = await loadRoute()
+    const headers = { 'x-forwarded-for': '203.0.113.5' }
+
+    for (let i = 0; i < 30; i++) {
+      const res = await POST(postRequest({ action: 'log' }, headers))
+      expect(res.status).toBe(200)
+    }
+    const blocked = await POST(postRequest({ action: 'log' }, headers))
+    expect(blocked.status).toBe(429)
+    expect(createMock).toHaveBeenCalledTimes(30)
+  })
+
+  it('rate limits per IP — a different IP is unaffected', async () => {
+    const { POST } = await loadRoute()
+    for (let i = 0; i < 31; i++) {
+      await POST(postRequest({ action: 'log' }, { 'x-forwarded-for': '203.0.113.5' }))
+    }
+    const other = await POST(postRequest({ action: 'log' }, { 'x-forwarded-for': '198.51.100.7' }))
+    expect(other.status).toBe(200)
+  })
+
+  it('prefers x-real-ip (edge-set) over the spoofable x-forwarded-for', async () => {
+    const { POST } = await loadRoute()
+    // Same real IP rotating fake XFF values must still hit the limit.
+    for (let i = 0; i < 30; i++) {
+      await POST(
+        postRequest(
+          { action: 'log' },
+          { 'x-real-ip': '203.0.113.5', 'x-forwarded-for': `198.51.100.${i}` },
+        ),
+      )
+    }
+    const blocked = await POST(
+      postRequest(
+        { action: 'log' },
+        { 'x-real-ip': '203.0.113.5', 'x-forwarded-for': '198.51.100.99' },
+      ),
+    )
+    expect(blocked.status).toBe(429)
+  })
+
+  it('uses the FIRST hop of a multi-hop x-forwarded-for chain', async () => {
+    const { POST } = await loadRoute()
+    // 30 writes as client 203.0.113.5 behind different proxies
+    for (let i = 0; i < 30; i++) {
+      await POST(
+        postRequest({ action: 'log' }, { 'x-forwarded-for': `203.0.113.5, 10.0.0.${i}` }),
+      )
+    }
+    const blocked = await POST(
+      postRequest({ action: 'log' }, { 'x-forwarded-for': '203.0.113.5, 10.0.0.99' }),
+    )
+    expect(blocked.status).toBe(429)
+  })
+
+  it('resets the window after 60 seconds', async () => {
+    vi.useFakeTimers()
+    try {
+      const { POST } = await loadRoute()
+      const headers = { 'x-forwarded-for': '203.0.113.5' }
+      for (let i = 0; i < 31; i++) {
+        await POST(postRequest({ action: 'log' }, headers))
+      }
+      expect((await POST(postRequest({ action: 'log' }, headers))).status).toBe(429)
+
+      vi.advanceTimersByTime(60_001)
+      expect((await POST(postRequest({ action: 'log' }, headers))).status).toBe(200)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+// ── POST: field capping and coercion (capString behavior) ────────────────────
+
+describe('POST /api/audit — field caps and numeric validation', () => {
+  // Oversize fields REJECT rather than truncate: sourceDocuments/graphNodesUsed
+  // hold JSON arrays, and a mid-string cut would store corrupt provenance.
+  it('rejects oversize fields with 400 instead of silently truncating', async () => {
+    const { POST } = await loadRoute()
+
+    for (const params of [
+      { modelName: 'm'.repeat(513) },
+      { sourceDocuments: 's'.repeat(4097) },
+      { graphNodesUsed: 'g'.repeat(4097) },
+      { overrideReason: 'r'.repeat(1025) },
+    ]) {
+      const res = await POST(postRequest({ action: 'log', ...params }))
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/Field too long/)
+    }
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts fields exactly at their limits', async () => {
+    const { POST } = await loadRoute()
+    const res = await POST(
+      postRequest({
+        action: 'log',
+        modelName: 'm'.repeat(512),
+        sourceDocuments: 's'.repeat(4096),
+        overrideReason: 'r'.repeat(1024),
+      }),
+    )
+    expect(res.status).toBe(200)
+    const data = createMock.mock.calls[0][0].data
+    expect(data.modelName).toHaveLength(512)
+    expect(data.sourceDocuments).toHaveLength(4096)
+    expect(data.overrideReason).toHaveLength(1024)
+  })
+
+  it('leaves strings at or under the limit untouched', async () => {
+    const { POST } = await loadRoute()
+    await POST(postRequest({ action: 'log', modelName: 'claude-sonnet-4-6' }))
+    expect(createMock.mock.calls[0][0].data.modelName).toBe('claude-sonnet-4-6')
+  })
+
+  it('replaces non-string fields with their fallbacks (type confusion guard)', async () => {
+    const { POST } = await loadRoute()
+    await POST(
+      postRequest({
+        action: 'log',
+        userId: 12345, // number, not string
+        modelName: { evil: true }, // object
+        sourceDocuments: ['a', 'b'], // array
+        outputType: null,
+        resolutionId: 42, // non-string -> undefined
+        overrideOf: false, // non-string -> undefined
+      }),
+    )
+
+    const data = createMock.mock.calls[0][0].data
+    expect(data.userId).toBe('local')
+    expect(data.modelName).toBe('')
+    expect(data.sourceDocuments).toBe('[]')
+    expect(data.outputType).toBe('RESOLUTION')
+    expect(data.resolutionId).toBeUndefined()
+    expect(data.overrideOf).toBeUndefined()
+  })
+
+  it('nulls non-finite confidenceScore and keeps valid numbers', async () => {
+    const { POST } = await loadRoute()
+    await POST(postRequest({ action: 'log', confidenceScore: 'high' }))
+    await POST(postRequest({ action: 'log', confidenceScore: Number.NaN }))
+    await POST(postRequest({ action: 'log', confidenceScore: 0.87 }))
+
+    expect(createMock.mock.calls[0][0].data.confidenceScore).toBeNull()
+    expect(createMock.mock.calls[1][0].data.confidenceScore).toBeNull()
+    expect(createMock.mock.calls[2][0].data.confidenceScore).toBe(0.87)
+  })
+
+  it('truncates fractional dataRetentionDays and falls back on junk', async () => {
+    const { POST } = await loadRoute()
+    await POST(postRequest({ action: 'log', dataRetentionDays: 30.9 }))
+    await POST(postRequest({ action: 'log', dataRetentionDays: 'forever' }))
+    await POST(postRequest({ action: 'log', dataRetentionDays: Infinity }))
+
+    expect(createMock.mock.calls[0][0].data.dataRetentionDays).toBe(30)
+    expect(createMock.mock.calls[1][0].data.dataRetentionDays).toBe(2555)
+    expect(createMock.mock.calls[2][0].data.dataRetentionDays).toBe(2555)
+  })
+
+  it('returns 400 for an unknown action', async () => {
+    const { POST } = await loadRoute()
+    const res = await POST(postRequest({ action: 'drop-tables' }))
+    expect(res.status).toBe(400)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+// ── GET: visitor scoping and admin gate ──────────────────────────────────────
+
+describe('GET /api/audit — scoping and admin token', () => {
+  it('scopes to the requested userId', async () => {
+    const { GET } = await loadRoute()
+    const res = await GET(getRequest('?userId=visitor-abc'))
+    expect(res.status).toBe(200)
+    expect(findManyMock.mock.calls[0][0].where).toEqual({ userId: 'visitor-abc' })
+  })
+
+  it('combines userId scoping with a status filter', async () => {
+    const { GET } = await loadRoute()
+    await GET(getRequest('?userId=visitor-abc&status=PENDING_REVIEW'))
+    expect(findManyMock.mock.calls[0][0].where).toEqual({
+      userId: 'visitor-abc',
+      approvalStatus: 'PENDING_REVIEW',
+    })
+  })
+
+  it('allows unscoped reads when AUDIT_ADMIN_TOKEN is unset (local dev)', async () => {
+    const { GET } = await loadRoute()
+    const res = await GET(getRequest())
+    expect(res.status).toBe(200)
+    expect(findManyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails CLOSED in production: unscoped reads are denied when no token is configured', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const { GET } = await loadRoute()
+    const res = await GET(getRequest())
+    expect(res.status).toBe(401)
+    expect(findManyMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects unscoped reads with 401 when the admin token is set and absent/wrong', async () => {
+    vi.stubEnv('AUDIT_ADMIN_TOKEN', 'secret-token')
+    const { GET } = await loadRoute()
+
+    const noAuth = await GET(getRequest())
+    expect(noAuth.status).toBe(401)
+
+    const wrongAuth = await GET(getRequest('', { authorization: 'Bearer wrong-token' }))
+    expect(wrongAuth.status).toBe(401)
+
+    expect(findManyMock).not.toHaveBeenCalled()
+  })
+
+  it('allows unscoped reads with the correct bearer token', async () => {
+    vi.stubEnv('AUDIT_ADMIN_TOKEN', 'secret-token')
+    const { GET } = await loadRoute()
+    const res = await GET(getRequest('', { authorization: 'Bearer secret-token' }))
+    expect(res.status).toBe(200)
+    expect(findManyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT require the token for scoped (userId) reads even in production', async () => {
+    vi.stubEnv('AUDIT_ADMIN_TOKEN', 'secret-token')
+    const { GET } = await loadRoute()
+    const res = await GET(getRequest('?userId=visitor-abc'))
+    expect(res.status).toBe(200)
+  })
+
+  it('clamps limit to 200 and defaults to 50', async () => {
+    const { GET } = await loadRoute()
+    await GET(getRequest('?userId=v&limit=99999'))
+    await GET(getRequest('?userId=v'))
+    expect(findManyMock.mock.calls[0][0].take).toBe(200)
+    expect(findManyMock.mock.calls[1][0].take).toBe(50)
+  })
+})

--- a/src/app/api/audit/route.ts
+++ b/src/app/api/audit/route.ts
@@ -1,23 +1,97 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
 
+// Public-deployment guards: the demo shares one audit table across anonymous
+// visitors, so reads are scoped per visitor, unscoped reads need the admin
+// token, and writes are size-capped and softly rate limited.
+//
+// Known limitation (no auth on the demo): the visitor userId is client-supplied
+// and unauthenticated — per-visitor scoping is a courtesy partition, not a
+// security boundary. Real attribution requires accounts (future work).
+
+const MAX_BODY_BYTES = 16 * 1024
+const DEFAULT_FIELD_LIMIT = 512
+const FIELD_LIMITS: Record<string, number> = {
+  sourceDocuments: 4096,
+  graphNodesUsed: 4096,
+  overrideReason: 1024,
+}
+
+// Best-effort spam friction only: per-lambda-instance, resets on cold start.
+const RATE_WINDOW_MS = 60_000
+const RATE_MAX_WRITES = 30
+const writeCounts = new Map<string, { count: number; windowStart: number }>()
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now()
+  if (writeCounts.size > 1000) {
+    for (const [key, entry] of writeCounts) {
+      if (now - entry.windowStart > RATE_WINDOW_MS) writeCounts.delete(key)
+    }
+    // Spoofed-IP flood within one window: cap memory over per-key fairness.
+    if (writeCounts.size > 5000) writeCounts.clear()
+  }
+  const entry = writeCounts.get(ip)
+  if (!entry || now - entry.windowStart > RATE_WINDOW_MS) {
+    writeCounts.set(ip, { count: 1, windowStart: now })
+    return false
+  }
+  entry.count += 1
+  return entry.count > RATE_MAX_WRITES
+}
+
+function clientIp(request: NextRequest): string {
+  // x-real-ip is set by the Vercel edge and not client-spoofable there; the
+  // leftmost x-forwarded-for hop is a client claim, so it's only the fallback.
+  return (
+    request.headers.get('x-real-ip') ||
+    (request.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() ||
+    'unknown'
+  )
+}
+
 /**
  * GET /api/audit — Read audit log entries (read-only).
  *
  * Query params:
  *   ?limit=50 — max records to return (default 50, max 200)
  *   ?status=PENDING_REVIEW — filter by approvalStatus
+ *   ?userId=<visitor-id> — scope to one visitor's records
+ *
+ * Unscoped reads (no userId) require `Authorization: Bearer $AUDIT_ADMIN_TOKEN`.
+ * Fail closed: in production an unset token denies unscoped reads entirely;
+ * only local dev (non-production, no token) keeps open access.
  */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = request.nextUrl
     const limit = Math.min(Number(searchParams.get('limit') ?? 50), 200)
     const status = searchParams.get('status') || undefined
+    const userId = searchParams.get('userId') || undefined
+
+    if (!userId) {
+      const adminToken = process.env.AUDIT_ADMIN_TOKEN
+      const auth = request.headers.get('authorization') ?? ''
+      const authorized = adminToken
+        ? auth === `Bearer ${adminToken}`
+        : process.env.NODE_ENV !== 'production'
+      if (!authorized) {
+        return NextResponse.json(
+          { error: 'Unscoped audit reads require the admin token' },
+          { status: 401 },
+        )
+      }
+    }
+
+    const where = {
+      ...(status ? { approvalStatus: status } : {}),
+      ...(userId ? { userId } : {}),
+    }
 
     const records = await prisma.auditLog.findMany({
       orderBy: { timestampUTC: 'desc' },
       take: limit,
-      ...(status ? { where: { approvalStatus: status } } : {}),
+      ...(Object.keys(where).length ? { where } : {}),
     })
 
     return NextResponse.json({ records })
@@ -35,32 +109,92 @@ export async function GET(request: NextRequest) {
  *
  * EU AI Act Article 12 compliance: every AI transaction is logged.
  * This endpoint ONLY creates records — no update or delete operations.
+ * Oversize fields are rejected (400), never silently truncated: several fields
+ * hold JSON arrays, and a mid-string cut would store corrupt provenance.
  */
 export async function POST(request: NextRequest) {
   try {
-    const body = await request.json()
+    // Fast-path on the declared size, then enforce on the actual body —
+    // chunked transfers carry no content-length header.
+    const declaredBytes = Number(request.headers.get('content-length') ?? 0)
+    if (declaredBytes > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+    }
+    const raw = await request.text()
+    if (raw.length > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+    }
+
+    if (isRateLimited(clientIp(request))) {
+      return NextResponse.json({ error: 'Too many audit writes' }, { status: 429 })
+    }
+
+    const body = JSON.parse(raw)
     const { action, ...params } = body
 
     if (action === 'log') {
+      // Required-shape string fields: non-strings fall back, oversize rejects.
+      const stringDefs: Array<[field: string, fallback: string]> = [
+        ['userId', 'local'],
+        ['modelName', ''],
+        ['modelVersion', ''],
+        ['promptVersion', ''],
+        ['promptHash', ''],
+        ['queryClassification', ''],
+        ['sourceDocuments', '[]'],
+        ['responseId', ''],
+        ['outputType', 'RESOLUTION'],
+        ['regulatoryContext', 'EU_AI_ACT'],
+        ['approvalStatus', 'PENDING_REVIEW'],
+        ['graphNodesUsed', '[]'],
+      ]
+      const fields: Record<string, string> = {}
+      for (const [field, fallback] of stringDefs) {
+        const value = typeof params[field] === 'string' ? params[field] : fallback
+        const limit = FIELD_LIMITS[field] ?? DEFAULT_FIELD_LIMIT
+        if (value.length > limit) {
+          return NextResponse.json(
+            { error: `Field too long: ${field} (max ${limit} chars)` },
+            { status: 400 },
+          )
+        }
+        fields[field] = value
+      }
+
+      const overrideReason =
+        typeof params.overrideReason === 'string' ? params.overrideReason : undefined
+      if (overrideReason && overrideReason.length > FIELD_LIMITS.overrideReason) {
+        return NextResponse.json(
+          { error: `Field too long: overrideReason (max ${FIELD_LIMITS.overrideReason} chars)` },
+          { status: 400 },
+        )
+      }
+
       const record = await prisma.auditLog.create({
         data: {
-          resolutionId: params.resolutionId ?? undefined,
-          userId: params.userId ?? 'local',
-          modelName: params.modelName ?? '',
-          modelVersion: params.modelVersion ?? '',
-          promptVersion: params.promptVersion ?? '',
-          promptHash: params.promptHash ?? '',
-          queryClassification: params.queryClassification ?? '',
-          sourceDocuments: params.sourceDocuments ?? '[]',
-          confidenceScore: params.confidenceScore ?? null,
-          responseId: params.responseId ?? '',
-          outputType: params.outputType ?? 'RESOLUTION',
-          regulatoryContext: params.regulatoryContext ?? 'EU_AI_ACT',
-          approvalStatus: params.approvalStatus ?? 'PENDING_REVIEW',
-          dataRetentionDays: params.dataRetentionDays ?? 2555,
-          graphNodesUsed: params.graphNodesUsed ?? '[]',
-          overrideOf: params.overrideOf ?? undefined,
-          overrideReason: params.overrideReason ?? undefined,
+          userId: fields.userId,
+          modelName: fields.modelName,
+          modelVersion: fields.modelVersion,
+          promptVersion: fields.promptVersion,
+          promptHash: fields.promptHash,
+          queryClassification: fields.queryClassification,
+          sourceDocuments: fields.sourceDocuments,
+          responseId: fields.responseId,
+          outputType: fields.outputType,
+          regulatoryContext: fields.regulatoryContext,
+          approvalStatus: fields.approvalStatus,
+          graphNodesUsed: fields.graphNodesUsed,
+          resolutionId: typeof params.resolutionId === 'string' ? params.resolutionId : undefined,
+          confidenceScore:
+            typeof params.confidenceScore === 'number' && Number.isFinite(params.confidenceScore)
+              ? params.confidenceScore
+              : null,
+          dataRetentionDays:
+            typeof params.dataRetentionDays === 'number' && Number.isFinite(params.dataRetentionDays)
+              ? Math.trunc(params.dataRetentionDays)
+              : 2555,
+          overrideOf: typeof params.overrideOf === 'string' ? params.overrideOf : undefined,
+          overrideReason,
         },
       })
       return NextResponse.json({ id: record.id })

--- a/src/app/api/classify/route.ts
+++ b/src/app/api/classify/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { CLASSIFICATION_PROMPT } from '@/lib/ai/prompts'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { validateBaseUrl } from '@/lib/server/validateBaseUrl'
 
 const VALID_TYPES = ['ask', 'edit', 'dig', 'flag']
+
+export const maxDuration = 60
 
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
@@ -13,6 +16,11 @@ export async function POST(request: NextRequest) {
   // Only require API key for non-Ollama providers
   if (provider !== 'ollama' && !apiKey) {
     return NextResponse.json({ error: 'No API key provided' }, { status: 401 })
+  }
+
+  const baseUrlError = validateBaseUrl(baseUrl)
+  if (baseUrlError) {
+    return NextResponse.json({ error: baseUrlError }, { status: 400 })
   }
 
   try {
@@ -66,6 +74,8 @@ export async function POST(request: NextRequest) {
       const response = await fetch(url, {
         method: 'POST',
         headers,
+        // A validated public base URL could still 3xx to a private address.
+        redirect: 'manual',
         body: JSON.stringify({
           model,
           max_tokens: 50,

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { DOC_GENERATION_PROMPT } from '@/lib/ai/prompts'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { validateBaseUrl } from '@/lib/server/validateBaseUrl'
+
+export const maxDuration = 60
 
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
@@ -10,6 +13,11 @@ export async function POST(request: NextRequest) {
 
   if (provider !== 'ollama' && !apiKey) {
     return NextResponse.json({ error: 'No API key provided' }, { status: 401 })
+  }
+
+  const baseUrlError = validateBaseUrl(baseUrl)
+  if (baseUrlError) {
+    return NextResponse.json({ error: baseUrlError }, { status: 400 })
   }
 
   try {
@@ -51,6 +59,8 @@ export async function POST(request: NextRequest) {
       const response = await fetch(url, {
         method: 'POST',
         headers,
+        // A validated public base URL could still 3xx to a private address.
+        redirect: 'manual',
         body: JSON.stringify({
           model,
           max_tokens: 4000,

--- a/src/app/api/history/__tests__/route.test.ts
+++ b/src/app/api/history/__tests__/route.test.ts
@@ -311,3 +311,32 @@ describe('GET /api/history', () => {
     expect((await res.json()).commits).toHaveLength(2)
   })
 })
+
+// ── Production gate ───────────────────────────────────────────────────────────
+// History stores full document snapshots server-side with no auth, so the
+// public deployment keeps it off unless the operator opts in (HISTORY_ENABLED).
+
+describe('/api/history — production gate', () => {
+  it('returns 403 for GET and POST in production without HISTORY_ENABLED', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    try {
+      expect((await GET(getRequest('documentId=doc-1'))).status).toBe(403)
+      expect((await POST(postRequest({ action: 'commit' }))).status).toBe(403)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('stays enabled in production when HISTORY_ENABLED=1', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('HISTORY_ENABLED', '1')
+    try {
+      await seedRoot()
+      const res = await GET(getRequest('documentId=doc-1'))
+      expect(res.status).toBe(200)
+      expect((await res.json()).commits).toHaveLength(1)
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+})

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -27,6 +27,23 @@ import { computeCommitHash, computeContentHash } from '@/lib/history/canonical'
 
 const VALID_KINDS = new Set(['import', 'apply', 'direct', 'restore'])
 
+/**
+ * Version history stores FULL document snapshots server-side, unauthenticated.
+ * On the public demo that would put visitor documents in the shared DB,
+ * readable by anyone holding a documentId — so it is off in production unless
+ * the operator opts in (HISTORY_ENABLED=1, e.g. a private self-host). Client
+ * writes are fire-and-forget (recordCommit) and degrade gracefully.
+ */
+function historyDisabled(): NextResponse | null {
+  if (process.env.NODE_ENV === 'production' && process.env.HISTORY_ENABLED !== '1') {
+    return NextResponse.json(
+      { error: 'Version history is disabled on this deployment' },
+      { status: 403 },
+    )
+  }
+  return null
+}
+
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 200
 
@@ -57,6 +74,8 @@ const COMMIT_META_SELECT = {
  *   ?hash=...       — one version, including its full docJson
  */
 export async function GET(request: NextRequest) {
+  const disabled = historyDisabled()
+  if (disabled) return disabled
   try {
     const { searchParams } = request.nextUrl
     const hash = searchParams.get('hash')
@@ -121,6 +140,8 @@ export async function GET(request: NextRequest) {
  *         covers content and attribution) — idempotent re-send
  */
 export async function POST(request: NextRequest) {
+  const disabled = historyDisabled()
+  if (disabled) return disabled
   try {
     const body = await request.json()
     const { action, ...params } = body

--- a/src/app/api/resolve/route.ts
+++ b/src/app/api/resolve/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { validateBaseUrl } from '@/lib/server/validateBaseUrl'
+
+// LLM calls (especially MADS rounds) can run long; Vercel default is too short.
+export const maxDuration = 60
 
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
@@ -9,6 +13,11 @@ export async function POST(request: NextRequest) {
 
   if (provider !== 'ollama' && !apiKey) {
     return NextResponse.json({ error: 'No API key provided' }, { status: 401 })
+  }
+
+  const baseUrlError = validateBaseUrl(baseUrl)
+  if (baseUrlError) {
+    return NextResponse.json({ error: baseUrlError }, { status: 400 })
   }
 
   try {
@@ -78,6 +87,8 @@ export async function POST(request: NextRequest) {
       const response = await fetch(url, {
         method: 'POST',
         headers,
+        // A validated public base URL could still 3xx to a private address.
+        redirect: 'manual',
         body: JSON.stringify(body),
       })
 
@@ -202,6 +213,7 @@ function handleStreamingRequest(params: StreamParams): Response {
           const response = await fetch(url, {
             method: 'POST',
             headers,
+            redirect: 'manual',
             body: JSON.stringify({
               model,
               max_tokens: maxTokens,

--- a/src/app/api/structured/route.ts
+++ b/src/app/api/structured/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { validateBaseUrl } from '@/lib/server/validateBaseUrl'
 
 /**
  * Provider-agnostic structured tool-calling endpoint.
@@ -26,6 +27,8 @@ interface ToolCall {
   input: unknown
 }
 
+export const maxDuration = 60
+
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key') || ''
   const provider = request.headers.get('x-provider') || 'claude'
@@ -34,6 +37,11 @@ export async function POST(request: NextRequest) {
 
   if (provider !== 'ollama' && !apiKey) {
     return NextResponse.json({ error: 'No API key provided' }, { status: 401 })
+  }
+
+  const baseUrlError = validateBaseUrl(baseUrl)
+  if (baseUrlError) {
+    return NextResponse.json({ error: baseUrlError }, { status: 400 })
   }
 
   try {
@@ -106,6 +114,8 @@ export async function POST(request: NextRequest) {
     const response = await fetch(url, {
       method: 'POST',
       headers,
+      // A validated public base URL could still 3xx to a private address.
+      redirect: 'manual',
       body: JSON.stringify({
         model,
         max_tokens: maxTokens,

--- a/src/app/api/transcribe/route.ts
+++ b/src/app/api/transcribe/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+// Whisper transcription of longer recordings can exceed Vercel's default timeout.
+export const maxDuration = 60
+
 export async function POST(request: NextRequest) {
   const apiKey = request.headers.get('x-api-key')
   if (!apiKey) {

--- a/src/components/Annotations/AuditLogViewer.tsx
+++ b/src/components/Annotations/AuditLogViewer.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { getVisitorId } from '@/lib/audit/auditLogger'
 
 interface AuditRecord {
   id: string
@@ -39,7 +40,8 @@ export function AuditLogViewer() {
     setLoading(true)
     setError(null)
     try {
-      const params = new URLSearchParams({ limit: '100' })
+      // Scope to this browser's records — unscoped reads are admin-only in prod.
+      const params = new URLSearchParams({ limit: '100', userId: getVisitorId() })
       if (statusFilter !== 'ALL') params.set('status', statusFilter)
       const res = await fetch(`/api/audit?${params}`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)

--- a/src/lib/audit/__tests__/auditLogger.test.ts
+++ b/src/lib/audit/__tests__/auditLogger.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getVisitorId, logAuditEvent, type AuditEventParams } from '@/lib/audit/auditLogger'
+
+// getVisitorId() is the anonymous per-browser identity used to scope each
+// visitor's audit trail on the shared public deployment. Contract:
+//   - no localStorage (SSR / node)      -> 'local'
+//   - storage throws (quota, disabled)  -> 'local' (never throws)
+//   - otherwise: generate UUID once, persist under 'intent-ide-visitor-id',
+//     and return the SAME id on every subsequent call.
+
+const VISITOR_ID_KEY = 'intent-ide-visitor-id'
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  clear() {
+    this.store.clear()
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('getVisitorId', () => {
+  it("returns 'local' when localStorage does not exist (SSR safety)", () => {
+    vi.stubGlobal('localStorage', undefined)
+    expect(getVisitorId()).toBe('local')
+  })
+
+  it('generates a UUID, persists it, and returns it', () => {
+    const storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+
+    const id = getVisitorId()
+    expect(id).toMatch(UUID_RE)
+    expect(storage.getItem(VISITOR_ID_KEY)).toBe(id)
+  })
+
+  it('is stable across calls (same id every time)', () => {
+    vi.stubGlobal('localStorage', new MemoryStorage())
+
+    const first = getVisitorId()
+    const second = getVisitorId()
+    const third = getVisitorId()
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+  })
+
+  it('returns a pre-existing stored id without regenerating', () => {
+    const storage = new MemoryStorage()
+    storage.setItem(VISITOR_ID_KEY, 'existing-visitor-id')
+    vi.stubGlobal('localStorage', storage)
+
+    expect(getVisitorId()).toBe('existing-visitor-id')
+    expect(storage.getItem(VISITOR_ID_KEY)).toBe('existing-visitor-id')
+  })
+
+  it("falls back to 'local' when getItem throws (storage disabled)", () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('SecurityError: storage disabled')
+      },
+      setItem: () => {},
+    })
+    expect(getVisitorId()).toBe('local')
+  })
+
+  it("falls back to 'local' when setItem throws (quota exceeded) instead of throwing", () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      },
+    })
+    expect(() => getVisitorId()).not.toThrow()
+    expect(getVisitorId()).toBe('local')
+  })
+})
+
+// logAuditEvent must attach the visitor id as userId on every write unless the
+// caller supplied an explicit userId, and must stay fire-and-forget safe.
+
+function makeParams(overrides: Partial<AuditEventParams> = {}): AuditEventParams {
+  return {
+    modelName: 'claude-sonnet-4-6',
+    modelVersion: '2026-01-01',
+    promptVersion: 'v1',
+    promptHash: 'abc',
+    queryClassification: 'EDIT',
+    sourceDocuments: '[]',
+    confidenceScore: null,
+    responseId: 'resp-1',
+    outputType: 'RESOLUTION',
+    ...overrides,
+  }
+}
+
+describe('logAuditEvent visitor scoping', () => {
+  it('injects the visitor id as userId when none is supplied', async () => {
+    const storage = new MemoryStorage()
+    storage.setItem(VISITOR_ID_KEY, 'visitor-123')
+    vi.stubGlobal('localStorage', storage)
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'audit-1' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await logAuditEvent(makeParams())
+
+    expect(result).toBe('audit-1')
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.action).toBe('log')
+    expect(body.userId).toBe('visitor-123')
+  })
+
+  it('preserves an explicitly supplied userId', async () => {
+    vi.stubGlobal('localStorage', new MemoryStorage())
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'audit-2' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await logAuditEvent(makeParams({ userId: 'explicit-user' }))
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.userId).toBe('explicit-user')
+  })
+
+  it('returns null (never throws) on a non-ok response', async () => {
+    vi.stubGlobal('localStorage', new MemoryStorage())
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, statusText: 'Too Many Requests' }),
+    )
+
+    await expect(logAuditEvent(makeParams())).resolves.toBeNull()
+  })
+
+  it('returns null (never throws) when fetch rejects', async () => {
+    vi.stubGlobal('localStorage', new MemoryStorage())
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+    await expect(logAuditEvent(makeParams())).resolves.toBeNull()
+  })
+})

--- a/src/lib/audit/auditLogger.ts
+++ b/src/lib/audit/auditLogger.ts
@@ -47,6 +47,30 @@ export type ApprovalStatus =
   | 'MODIFIED_HUMAN'
 
 // ---------------------------------------------------------------------------
+// Visitor identity
+// ---------------------------------------------------------------------------
+
+const VISITOR_ID_KEY = 'intent-ide-visitor-id'
+
+/**
+ * Stable anonymous ID for this browser. On the shared public deployment it
+ * scopes each visitor's audit trail to them (GET /api/audit filters on it).
+ */
+export function getVisitorId(): string {
+  if (typeof localStorage === 'undefined') return 'local'
+  try {
+    let id = localStorage.getItem(VISITOR_ID_KEY)
+    if (!id) {
+      id = crypto.randomUUID()
+      localStorage.setItem(VISITOR_ID_KEY, id)
+    }
+    return id
+  } catch {
+    return 'local'
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Core: Append-only write via API route
 // ---------------------------------------------------------------------------
 
@@ -59,7 +83,7 @@ export async function logAuditEvent(params: AuditEventParams): Promise<string | 
     const response = await fetch('/api/audit', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'log', ...params }),
+      body: JSON.stringify({ action: 'log', ...params, userId: params.userId ?? getVisitorId() }),
     })
 
     if (!response.ok) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,7 +1,11 @@
 import { PrismaClient } from "@/generated/prisma/client"
 import { PrismaLibSql } from "@prisma/adapter-libsql"
 
-const adapter = new PrismaLibSql({ url: process.env.DATABASE_URL ?? "file:dev.db" })
+// Local dev: file:dev.db (no token). Production: libsql://…turso.io + auth token.
+const adapter = new PrismaLibSql({
+  url: process.env.DATABASE_URL ?? "file:dev.db",
+  authToken: process.env.DATABASE_AUTH_TOKEN,
+})
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined

--- a/src/lib/server/__tests__/validateBaseUrl.test.ts
+++ b/src/lib/server/__tests__/validateBaseUrl.test.ts
@@ -1,0 +1,256 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { validateBaseUrl } from '@/lib/server/validateBaseUrl'
+
+// validateBaseUrl(raw) guards the client-supplied `x-base-url` header on the
+// LLM proxy routes. Contract:
+//   - empty string  -> null (no custom base URL = default provider endpoint)
+//   - non-production -> null always (local dev must keep hitting Ollama)
+//   - production    -> reject unparseable URLs, non-https, localhost-ish
+//                      hostnames, private/loopback/link-local IPv4 and IPv6
+//                      (including WHATWG-normalized and v4-mapped spellings)
+//
+// NOTE on normalization: Node's WHATWG URL parser canonicalizes hostnames
+// before this function ever sees them — `127.1`, `0x7f.0.0.1`, and decimal
+// `2130706433` all become `127.0.0.1`, and `[::ffff:127.0.0.1]` becomes the
+// hex-group form `[::ffff:7f00:1]`. The tests below feed the RAW attacker
+// strings so the guard is exercised against what the parser actually emits.
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// ── Non-production: everything passes (Ollama/local dev) ────────────────────
+
+describe('validateBaseUrl — non-production is a no-op', () => {
+  const permissive = [
+    'http://localhost:11434',
+    'http://127.0.0.1:11434/v1',
+    'https://[::1]:8443',
+    'http://192.168.1.50:8080',
+    'http://169.254.169.254/latest/meta-data',
+    'not a url at all',
+  ]
+
+  it('allows anything under vitest default NODE_ENV (test)', () => {
+    for (const raw of permissive) {
+      expect(validateBaseUrl(raw)).toBeNull()
+    }
+  })
+
+  it('allows anything under NODE_ENV=development', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    for (const raw of permissive) {
+      expect(validateBaseUrl(raw)).toBeNull()
+    }
+  })
+})
+
+// ── Production behavior ──────────────────────────────────────────────────────
+
+describe('validateBaseUrl — production', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production')
+  })
+
+  it('allows an empty string (no custom base URL supplied)', () => {
+    expect(validateBaseUrl('')).toBeNull()
+  })
+
+  it('allows legitimate public https BYOK endpoints', () => {
+    const allowed = [
+      'https://api.openai.com/v1',
+      'https://api.groq.com/openai/v1',
+      'https://api.together.xyz/v1',
+      'https://my-vllm.example.com:8443/v1',
+    ]
+    for (const raw of allowed) {
+      expect(validateBaseUrl(raw)).toBeNull()
+    }
+  })
+
+  it('rejects unparseable URLs', () => {
+    const invalid = ['not a url', 'api.example.com/v1', '//example.com', 'https://', ':::']
+    for (const raw of invalid) {
+      expect(validateBaseUrl(raw)).toBe('Invalid base URL')
+    }
+  })
+
+  it('rejects non-https schemes', () => {
+    const nonHttps = [
+      'http://api.example.com/v1',
+      'ftp://example.com',
+      'file:///etc/passwd',
+      'ws://example.com',
+    ]
+    for (const raw of nonHttps) {
+      expect(validateBaseUrl(raw)).toBe('Base URL must use https in production')
+    }
+  })
+
+  describe('localhost-ish hostnames', () => {
+    it('rejects localhost and blocked suffixes (case-insensitive via URL lowering)', () => {
+      const blocked = [
+        'https://localhost',
+        'https://LOCALHOST:11434',
+        'https://ollama.localhost',
+        'https://printer.local',
+        'https://db.internal',
+        'https://svc.prod.Internal',
+      ]
+      for (const raw of blocked) {
+        expect(validateBaseUrl(raw)).toBe('Base URL host is not allowed')
+      }
+    })
+
+    it('does not over-match hostnames that merely contain the suffix words', () => {
+      const allowed = [
+        'https://mylocalhost.com', // "localhost" not a label suffix
+        'https://internal.example.com', // ".internal" is a label, not the TLD
+        'https://foo.internal-api.com',
+      ]
+      for (const raw of allowed) {
+        expect(validateBaseUrl(raw)).toBeNull()
+      }
+    })
+
+    it('rejects FQDN trailing-dot spellings (localhost. resolves like localhost)', () => {
+      const blocked = [
+        'https://localhost.',
+        'https://metadata.google.internal.',
+        'https://printer.local.',
+      ]
+      for (const raw of blocked) {
+        expect(validateBaseUrl(raw)).toBe('Base URL host is not allowed')
+      }
+    })
+  })
+
+  describe('private IPv4 ranges', () => {
+    const blocked = [
+      'https://0.0.0.0', // unspecified (0.0.0.0/8)
+      'https://10.0.0.1', // 10/8 lower edge
+      'https://10.255.255.255', // 10/8 upper edge
+      'https://127.0.0.1', // loopback
+      'https://127.255.255.254', // loopback upper range
+      'https://169.254.0.1', // link-local lower
+      'https://169.254.169.254', // cloud metadata endpoint
+      'https://172.16.0.1', // 172.16/12 lower edge
+      'https://172.31.255.255', // 172.16/12 upper edge
+      'https://192.168.0.1', // 192.168/16 lower
+      'https://192.168.255.255', // 192.168/16 upper
+      'https://10.0.0.1:8443', // port must not defeat the check
+    ]
+
+    for (const raw of blocked) {
+      it(`rejects ${raw}`, () => {
+        expect(validateBaseUrl(raw)).toBe('Base URL must not point at a private network')
+      })
+    }
+
+    const allowed = [
+      'https://9.255.255.255', // just below 10/8
+      'https://11.0.0.1', // just above 10/8
+      'https://126.255.255.255', // just below loopback
+      'https://128.0.0.1', // just above loopback
+      'https://169.253.255.255', // just below link-local
+      'https://169.255.0.1', // just above link-local
+      'https://172.15.255.255', // just below 172.16/12
+      'https://172.32.0.1', // just above 172.16/12
+      'https://192.167.255.255', // just below 192.168/16
+      'https://192.169.0.1', // just above 192.168/16
+      'https://8.8.8.8:8443',
+      'https://1.1.1.1/v1',
+    ]
+
+    for (const raw of allowed) {
+      it(`allows public ${raw}`, () => {
+        expect(validateBaseUrl(raw)).toBeNull()
+      })
+    }
+  })
+
+  describe('IPv4 shorthand/encoding bypass vectors (WHATWG normalization)', () => {
+    // Node's URL parser canonicalizes all of these to 127.0.0.1 before the
+    // guard runs — assert the pipeline as a whole still blocks them.
+    const spellings = [
+      'https://127.1', // shorthand
+      'https://2130706433', // decimal
+      'https://0x7f.0.0.1', // hex octet
+      'https://017700000001', // octal
+    ]
+    for (const raw of spellings) {
+      it(`rejects loopback spelled as ${raw}`, () => {
+        expect(validateBaseUrl(raw)).toBe('Base URL must not point at a private network')
+      })
+    }
+  })
+
+  describe('private IPv6 (bracketed literals)', () => {
+    const blocked = [
+      'https://[::1]', // loopback
+      'https://[::]', // unspecified
+      'https://[0:0:0:0:0:0:0:1]', // loopback, uncompressed spelling
+      'https://[::1]:8443', // port must not defeat the check
+      'https://[fc00::1]', // unique-local fc00::/7 lower
+      'https://[fd12:3456:789a::1]', // unique-local fd
+      'https://[fe80::1]', // link-local fe80::/10 lower
+      'https://[FE80::1]', // case-insensitive
+      'https://[febf::1]', // link-local upper edge (fe80::/10 ends at febf)
+    ]
+
+    for (const raw of blocked) {
+      it(`rejects ${raw}`, () => {
+        expect(validateBaseUrl(raw)).toBe('Base URL must not point at a private network')
+      })
+    }
+
+    it('allows public IPv6 literals', () => {
+      expect(validateBaseUrl('https://[2001:4860:4860::8888]')).toBeNull()
+      expect(validateBaseUrl('https://[2607:f8b0:4004:800::200e]/v1')).toBeNull()
+    })
+
+    it('does not confuse fc/fd/fe-prefixed DNS hostnames with IPv6 literals', () => {
+      expect(validateBaseUrl('https://fcbarcelona.com')).toBeNull()
+      expect(validateBaseUrl('https://fdn.example.com')).toBeNull()
+      expect(validateBaseUrl('https://fe80.example.com')).toBeNull()
+    })
+  })
+
+  describe('v4-mapped IPv6 (::ffff:0:0/96)', () => {
+    // CRITICAL: WHATWG URL serializes v4-mapped addresses as hex groups —
+    // new URL('https://[::ffff:127.0.0.1]').hostname === '[::ffff:7f00:1]' —
+    // so the guard MUST handle the hex-group spelling, not just dotted-quad.
+    const blocked = [
+      'https://[::ffff:127.0.0.1]', // dotted input, normalized to hex by URL
+      'https://[::ffff:7f00:1]', // loopback, hex-group spelling direct
+      'https://[::ffff:10.0.0.1]', // 10/8 via mapping
+      'https://[::ffff:a00:1]', // 10.0.0.1 hex spelling
+      'https://[::ffff:169.254.169.254]', // cloud metadata via mapping
+      'https://[::ffff:a9fe:a9fe]', // 169.254.169.254 hex spelling
+      'https://[::ffff:192.168.1.1]', // 192.168/16 via mapping
+      'https://[::ffff:0:1]', // 0.0.0.1 (0/8) via mapping
+    ]
+
+    for (const raw of blocked) {
+      it(`rejects ${raw}`, () => {
+        expect(validateBaseUrl(raw)).toBe('Base URL must not point at a private network')
+      })
+    }
+
+    it('allows v4-mapped PUBLIC addresses in both spellings', () => {
+      expect(validateBaseUrl('https://[::ffff:8.8.8.8]')).toBeNull()
+      expect(validateBaseUrl('https://[::ffff:808:808]')).toBeNull()
+    })
+
+    it('boundary: 172.15 allowed, 172.16 and 172.31 blocked, 172.32 allowed — via mapping', () => {
+      expect(validateBaseUrl('https://[::ffff:172.15.0.1]')).toBeNull()
+      expect(validateBaseUrl('https://[::ffff:172.16.0.1]')).toBe(
+        'Base URL must not point at a private network',
+      )
+      expect(validateBaseUrl('https://[::ffff:172.31.255.255]')).toBe(
+        'Base URL must not point at a private network',
+      )
+      expect(validateBaseUrl('https://[::ffff:172.32.0.1]')).toBeNull()
+    })
+  })
+})

--- a/src/lib/server/validateBaseUrl.ts
+++ b/src/lib/server/validateBaseUrl.ts
@@ -1,0 +1,89 @@
+/**
+ * Guard for the client-supplied `x-base-url` header on the LLM proxy routes.
+ *
+ * BYOK deliberately allows arbitrary OpenAI-compatible endpoints (Groq,
+ * Together, self-hosted vLLM), so this is a private-network blocklist rather
+ * than a host allowlist. Enforced only in production builds — local dev must
+ * keep working against Ollama on localhost.
+ *
+ * Residual risk accepted: DNS rebinding of a public hostname to a private IP.
+ * Vercel functions have no privileged internal network behind them, so the
+ * realistic exposure (cloud metadata endpoints, egress port-scanning) is
+ * covered by the checks below.
+ */
+
+const BLOCKED_HOST_SUFFIXES = ['.localhost', '.local', '.internal']
+
+/** Returns an error message when the base URL must be rejected, else null. */
+export function validateBaseUrl(raw: string): string | null {
+  if (!raw) return null
+  if (process.env.NODE_ENV !== 'production') return null
+
+  let url: URL
+  try {
+    url = new URL(raw)
+  } catch {
+    return 'Invalid base URL'
+  }
+
+  if (url.protocol !== 'https:') {
+    return 'Base URL must use https in production'
+  }
+
+  // Strip FQDN trailing dots — `localhost.` resolves like `localhost` but
+  // would slip past the string checks below.
+  const host = url.hostname.toLowerCase().replace(/\.+$/, '')
+  const bare = host.replace(/^\[|\]$/g, '') // IPv6 literals arrive bracketed
+
+  if (host === 'localhost' || BLOCKED_HOST_SUFFIXES.some((s) => host.endsWith(s))) {
+    return 'Base URL host is not allowed'
+  }
+  if (isPrivateIPv4(bare) || isPrivateIPv6(bare)) {
+    return 'Base URL must not point at a private network'
+  }
+
+  return null
+}
+
+function isPrivateIPv4(host: string): boolean {
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (!m) return false
+  const a = Number(m[1])
+  const b = Number(m[2])
+  if (a === 0 || a === 10 || a === 127) return true // 0/8, 10/8, loopback
+  if (a === 169 && b === 254) return true // link-local / cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16/12
+  if (a === 192 && b === 168) return true // 192.168/16
+  return false
+}
+
+function isPrivateIPv6(host: string): boolean {
+  if (!host.includes(':')) return false
+  const h = host.toLowerCase()
+  if (h === '::' || h === '::1') return true // unspecified, loopback
+  if (h.startsWith('fc') || h.startsWith('fd')) return true // fc00::/7 unique-local
+  if (/^fe[89ab]/.test(h)) return true // fe80::/10 link-local
+  if (h.startsWith('::ffff:')) return isPrivateV4Mapped(h.slice(7)) // v4-mapped
+  return false
+}
+
+/**
+ * v4-mapped tail after the `::ffff:` prefix. WHATWG URL serializes these as
+ * hex groups (`new URL('https://[::ffff:127.0.0.1]').hostname` is
+ * `'[::ffff:7f00:1]'`), NOT dotted-quad, so both spellings must decode to the
+ * embedded IPv4 address. Anything unrecognizable fails closed.
+ */
+function isPrivateV4Mapped(tail: string): boolean {
+  if (tail.includes('.')) return isPrivateIPv4(tail) // dotted-quad spelling
+  const groups = tail.split(':')
+  if (
+    groups.length < 1 ||
+    groups.length > 2 ||
+    !groups.every((g) => /^[0-9a-f]{1,4}$/.test(g))
+  ) {
+    return true // not a decodable v4-mapped tail — fail closed
+  }
+  const hi = groups.length === 2 ? parseInt(groups[0], 16) : 0
+  const lo = parseInt(groups[groups.length - 1], 16)
+  return isPrivateIPv4(`${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`)
+}


### PR DESCRIPTION
## Why

Makes the app deployable as a live public demo (Vercel) plus the owner's own use, per the approved plan. The app was already nearly serverless-shaped — documents/keys live in the browser, LLM keys are BYOK per-request — so this PR (1) points the audit ledger at Turso, and (2) hardens everything a public deployment exposes.

## What

**Audit DB → Turso (hosted libSQL)**
- `src/lib/db.ts` passes `DATABASE_AUTH_TOKEN` to the existing `PrismaLibSql` adapter; local `file:dev.db` unchanged. No provider change, existing SQLite migrations apply as-is via `turso db shell`.
- `build` runs `prisma generate` (generated client is gitignored — Vercel needs this); `postinstall` too; `engines >= 20`.

**SSRF guard on `x-base-url`** (`src/lib/server/validateBaseUrl.ts`, wired into resolve/classify/generate/structured)
- Production-only private-network blocklist (preserves BYOK for Groq/Together/self-hosted vLLM): https-only, localhost/`.local`/`.internal` (incl. FQDN trailing dots), private/loopback/link-local IPv4+IPv6, and WHATWG hex-group v4-mapped IPv6 spellings (`[::ffff:a9fe:a9fe]`) — fails closed on undecodable tails.
- Proxy fetches use `redirect: 'manual'` so a validated public URL can't 3xx to a private address post-validation.

**`/api/audit` hardening**
- Body cap enforced on the actual body (chunked bodies carry no content-length); oversize fields reject with 400 rather than truncate (JSON provenance fields would corrupt).
- GET scoped by visitor `?userId=`; unscoped reads need `Bearer $AUDIT_ADMIN_TOKEN` and **fail closed in production** when the token is unset.
- Soft per-IP rate limit keyed on Vercel's `x-real-ip` (per-instance, spam friction only — not a security boundary).
- Anonymous per-browser visitor ID scopes each visitor's audit trail. Known limitation (documented in-code): `userId` is client-supplied — a courtesy partition until accounts exist.

**`/api/history` gated off in production** (new endpoint from #6)
- It stores full document snapshots server-side, unauthenticated — the shared public demo must not do that. 403 in production unless `HISTORY_ENABLED=1` (private self-hosts). Client writes are fire-and-forget and degrade gracefully; local dev unchanged.

**Other**: `maxDuration = 60` on the five LLM/transcription routes; README live-demo/BYOK/deployment/known-limits docs; `.env.example` updates.

**Excluded from deploy**: Graphiti/FalkorDB stays local-dev-only — verified all call sites are client-side with try/catch fallbacks to the in-memory doc graph.

## Tests

92 new tests (SSRF guard matrix incl. IPv4/IPv6 boundary pairs and encoding bypasses, auditLogger visitor ID, audit route caps/scoping/rate-limit, history production gate). **462 passing, typecheck/lint/build clean.** Adversarially reviewed (troublemaker agent): the v4-mapped IPv6 bypass, redirect vector, trailing-dot bypass, fail-open audit reads, and content-length lie found in review are all fixed here.

## Deploy steps after merge (operator)

1. `turso db create intent-ide-audit`; pipe each `prisma/migrations/*/migration.sql` through `turso db shell`.
2. Vercel project (Node 22) with `DATABASE_URL`, `DATABASE_AUTH_TOKEN`, `AUDIT_ADMIN_TOKEN`. No `GRAPHITI_*`, no LLM keys.
3. Smoke test on the preview deploy per plan (streaming resolve, transcribe, audit scoping, SSRF 400s).

Note: Supavisor/pgbouncer caveats from the earlier Supabase plan don't apply — Turso kept the libsql adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
