### PR TITLE
E2E cascade flow (catches a critical streaming-path bug) + portfolio README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ AI can one-shot a document that's 90% right. The unsolved problem is the last 10
 <!-- screenshot: main editor with annotations panel -->
 <!-- screenshot: multi-region cascade review with inline accept/reject -->
 <!-- screenshot: semantic commit modal with per-change diff toggles -->
+<!-- screenshot: history panel with version chain and restore confirmation -->
 
 ## How it works
 
@@ -36,7 +37,7 @@ AI can one-shot a document that's 90% right. The unsolved problem is the last 10
 
 ```
 src/app/              Next.js App Router pages + API routes
-  api/                classify | resolve | generate | structured | transcribe | audit
+  api/                classify | resolve | generate | structured | transcribe | audit | history
 src/components/       React components by feature
   Editor/             ProseMirror shell, commit modal, proposed-edit controls, toolbar
   Annotations/        cards, threads, cascade list, minimap, resolution actions
@@ -64,6 +65,39 @@ Engineering details a reviewer might care about:
 - **Validate-or-abort apply** — multi-region edits are fingerprint-validated against live document text and applied in a single descending transaction, so stale positions abort instead of corrupting
 - **Model capability gating** — `modelRejectsSampling()` centralizes per-model API quirks (newer Claude models reject `temperature`), so routes never hand-roll compatibility logic
 - **Hardened persistence** — persisted Zustand stores use `partialize` caps, quota-error handling with emergency pruning, and rehydration migrations for legacy data shapes
+
+### How the cascade works
+
+When an edit lands, other parts of the document can silently go stale — a figure quoted twice, a clause that depends on a definition you just changed. Instead of sending the whole document to a model and trusting whatever comes back, the cascade is a pipeline where the model only proposes and everything load-bearing is verified:
+
+```mermaid
+flowchart LR
+  A[Stable blockIds<br/>per textblock] --> B[Document dependency graph<br/>deterministic + LLM edges<br/>embedding pass planned]
+  B --> C[Graph-scoped proposals<br/>N-hop neighborhood only]
+  C --> D[Derived severity<br/>evidence-gated]
+  D --> E[Relevance judge<br/>on every 'must']
+  E --> F[HITL review<br/>decorations · list · commit modal]
+```
+
+1. **Stable block identity.** Every textblock carries a `blockId` attribute maintained by a ProseMirror plugin across splits, joins, and edits ([`src/lib/prosemirror/blockIds.ts`](src/lib/prosemirror/blockIds.ts)) — so graph edges and evidence citations keep pointing at the right text as the document changes.
+2. **Document dependency graph.** Blocks become nodes; typed edges (`defines`, `references`, `depends-on`, `contradicts`, `duplicates`, …) come from deterministic extractors (cross-references, defined terms, duplicated sentences) plus one cached LLM extraction pass, content-hash cached per document state ([`src/lib/graphrag/docGraph.ts`](src/lib/graphrag/docGraph.ts)). An embedding-similarity pass is the planned third edge source.
+3. **Graph-scoped proposals.** Only the primary edit's bounded N-hop neighborhood is sent to the model — never a truncated whole-document dump, so long documents cascade end to end. Returned `propose_edit` tool calls are anchored blockId-first with a fingerprint-search fallback, and anything landing outside the sent neighborhood is dropped ([`src/lib/ai/orchestrator.ts`](src/lib/ai/orchestrator.ts)).
+4. **Derived severity with evidence gating.** Severity is computed, never trusted from the model: a proposal with no locatable verbatim citation is `optional` (a lead); a cited proposal is `probably`; only a cited proposal whose target still verbatim-contains content the primary edit changed is `must`.
+5. **Relevance judge.** Every `must` candidate then gets a second, batched LLM cross-examination — matching strings are not matching meaning — and unconfirmed candidates are demoted with the judge's reason attached ([`src/lib/ai/relevanceJudge.ts`](src/lib/ai/relevanceJudge.ts)).
+6. **Human review, three surfaces, one source of truth.** Proposals render as read-line-aware inline decorations ([`src/lib/prosemirror/plugins/proposedChangePlugin.ts`](src/lib/prosemirror/plugins/proposedChangePlugin.ts)), a navigable cascade list with citations, and the semantic commit modal with per-change severity badges and accept/reject toggles ([`src/components/Editor/SemanticCommitModal.tsx`](src/components/Editor/SemanticCommitModal.tsx)). Accepted changes apply in one validated transaction.
+
+The whole pipeline (graph build, scoping, anchoring, severity, judge) runs unmodified under an EditPropBench-style regression eval — see [Evaluation](#evaluation).
+
+### Version history & compliance
+
+Document history follows the git model in accessible language ([`src/lib/history/`](src/lib/history), [`src/app/api/history/route.ts`](src/app/api/history/route.ts)):
+
+- **Two-level content addressing** — `contentHash` covers document content only (the "tree"); the primary-key `hash` also covers provenance (parent, kind, message, actor, annotation, audit links, model version), so versions with identical content but different provenance stay distinct records ([`src/lib/history/canonical.ts`](src/lib/history/canonical.ts)).
+- **Append-only, tamper-evident** — the API exposes no edit or delete operations, enforces one linear chain per document, and re-verifies both hashes server-side on every write.
+- **Captured at the moments that matter** — document creation (`import`), applied AI changes (`apply`, linked to the annotation and its audit records), edit-session saves (`direct`, content-deduped), and restores (`restore`).
+- **Restores never rewrite history** — restoring appends a new version linked to an EU AI Act Article 14 human-oversight record, written *before* the editor mutates; `apply` versions carry their Article 12 audit-record ids. The full compliance statement is in [docs/compliance.md](docs/compliance.md).
+
+The History tab ([`src/components/History/HistoryPanel.tsx`](src/components/History/HistoryPanel.tsx)) shows the chain with per-version diffs, two-version compare, and confirmation-gated restore.
 
 ## AI-augmented development
 
@@ -106,11 +140,13 @@ Without the graph stack, cascade checks fall back to keyword matching; everythin
 ## Testing
 
 ```bash
-npm run test         # Vitest — 194 unit tests (prompts, stores, migrations, model gates)
+npm run test         # Vitest — 370 unit tests (cascade pipeline, history, stores, prompts, model gates)
 npm run typecheck    # tsc --noEmit
 npm run lint         # ESLint (next/core-web-vitals)
-npx playwright test  # optional e2e (needs dev server; graph tests skip without FalkorDB)
+npm run test:e2e     # Playwright e2e (starts its own dev server)
 ```
+
+The main e2e spec ([`tests/cascade-review.spec.ts`](tests/cascade-review.spec.ts)) drives the full loop — paste document → annotate → cascade proposal → per-change review → apply → version history — against the real UI and the real audit/history SQLite routes, with the LLM endpoints network-intercepted so it needs **no API keys**. The legacy ingestion spec additionally expects FalkorDB and skips its graph assertion without it.
 
 CI runs typecheck, lint, unit tests, and a production build on every push.
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "bench:live": "BENCH_LIVE=1 vitest run src/lib/graphrag/__tests__/editPropBench.live.test.ts"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,11 @@
-import { defineConfig } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 
 export default defineConfig({
   testDir: './tests',
-  timeout: 30_000,
+  // First Next.js dev compile of the page can take well over 30s.
+  timeout: 120_000,
   retries: 0,
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   use: {
     baseURL: 'http://localhost:3000',
     headless: true,
@@ -12,5 +14,9 @@ export default defineConfig({
     command: 'npm run dev',
     port: 3000,
     reuseExistingServer: true,
+    timeout: 120_000,
+    // The audit + history API routes are real server-side SQLite (Prisma /
+    // libsql) — point them explicitly at the repo-local dev database.
+    env: { DATABASE_URL: 'file:./dev.db' },
   },
 })

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -334,6 +334,11 @@ export async function streamResolveAnnotation(
         madsResult.resolution.uncertaintyFlags = madsResult.uncertaintyFlags
       }
       onChunk(madsResult.resolution.content)
+      // Attach multi-region cascade edits (best-effort) — parity with the
+      // non-streaming MADS path above; without this, edit annotations (which
+      // always route through MADS) never cascaded on the streaming path the
+      // UI actually uses.
+      await attachCascadeEdits(madsResult.resolution, editorState, config, annotation.anchor.text)
       return madsResult.resolution
     }
   } catch {

--- a/tests/cascade-review.spec.ts
+++ b/tests/cascade-review.spec.ts
@@ -1,0 +1,274 @@
+import { test, expect, type Page } from '@playwright/test'
+
+/**
+ * Full cascade-review flow, end to end, with NO real LLM keys:
+ *
+ *   paste document → select text → annotate ("edit") → MADS resolution with a
+ *   suggested edit → graph-scoped cascade proposal in ANOTHER paragraph →
+ *   inline `.proposed-edit` decoration with derived severity → SemanticCommitModal
+ *   with per-change severity badges and Accept/Reject → apply both regions in one
+ *   transaction → Changes panel records the entries → History tab shows an
+ *   'apply' (AI change) version row.
+ *
+ * Intercepted vs real endpoints
+ * -----------------------------
+ * Intercepted (LLM-backed — would need provider keys):
+ *   - /api/classify     → canned { type: 'edit' }
+ *   - /api/resolve      → canned MADS transcripts, branched on the prompt's
+ *                         closing instruction (Troublemaker / Peacemaker / Judge)
+ *   - /api/structured   → branched on tools[0].name:
+ *                           link_blocks  → { toolCalls: [] }  (deterministic graph only)
+ *                           propose_edit → one cascade proposal WITHOUT a block_id,
+ *                                          so the orchestrator's findTextInDoc
+ *                                          fallback + neighborhood scope gate are
+ *                                          exercised; evidence cites the primary
+ *                                          block (id parsed from the request body,
+ *                                          since blockIds are runtime nanoids)
+ *                           verdict      → confirms the single 'must' candidate
+ *   - graphiti MCP (localhost:8000) → aborted (non-blocking best-effort anyway)
+ *
+ * Real (server-side SQLite via Prisma/libsql against the local dev.db — no
+ * external network, and exercising them end-to-end is the point of Wave E):
+ *   - /api/audit        → real append-only audit records
+ *   - /api/history      → real content-addressed version commits; the History
+ *                         tab assertion below reads them back through the UI
+ *
+ * Document + severity choreography
+ * --------------------------------
+ * Paragraph 1 defines "Total Budget" via the `"X" means ...` pattern, so the
+ * DETERMINISTIC graph pass links paragraph 3 (which uses the term) to it — the
+ * cascade neighborhood exists without any LLM edge extraction. The primary edit
+ * changes $50,000 → $75,000; paragraph 3 still verbatim-contains "$50,000", so
+ * the derived severity is 'must', which routes the candidate through the
+ * relevance judge (the 'verdict' interception).
+ */
+
+const PARA_1 = '"Total Budget" means $50,000 allocated for the 2026 pilot program.'
+const PARA_2 = 'Office logistics and facilities scheduling are handled by the operations team.'
+const PARA_3 =
+  'Marketing may spend at most ten percent of the Total Budget of $50,000 in any quarter.'
+
+const DOC_TEXT = `${PARA_1}\n\n${PARA_2}\n\n${PARA_3}`
+
+const INSTRUCTION = 'Raise the total budget to $75,000'
+
+const PRIMARY_NEW_TEXT = '"Total Budget" means $75,000 allocated for the 2026 pilot program.'
+const CASCADE_TARGET = '$50,000 in any quarter'
+const CASCADE_NEW_TEXT = '$75,000 in any quarter'
+
+const JUDGE_OUTPUT = [
+  'VERDICT: APPROVE',
+  '',
+  'The proposed change is internally consistent and matches the user instruction.',
+  '',
+  'SUGGESTED EDIT:',
+  PRIMARY_NEW_TEXT,
+  '',
+  'REASON:',
+  'The user explicitly asked to raise the total budget figure.',
+].join('\n')
+
+// Fallback content for the (unused-on-the-happy-path) single-agent resolver,
+// kept SUGGESTED EDIT-formatted so the flow still yields an edit if MADS is
+// ever bypassed.
+const SINGLE_AGENT_OUTPUT = `SUGGESTED EDIT:\n${PRIMARY_NEW_TEXT}\n\nREASON:\nRequested figure update.`
+
+async function interceptLlmEndpoints(page: Page) {
+  // Graphiti MCP ingestion is best-effort fire-and-forget; abort it so runs
+  // never depend on whether a local graph stack happens to be up.
+  await page.route('http://localhost:8000/**', (route) => route.abort())
+
+  await page.route('**/api/classify', (route) =>
+    route.fulfill({ json: { type: 'edit' } }),
+  )
+
+  await page.route('**/api/resolve', (route) => {
+    const body = route.request().postDataJSON() as {
+      messages: Array<{ role: string; content: string }>
+      stream?: boolean
+    }
+    const userContent = body.messages.map((m) => m.content).join('\n')
+
+    // MADS runs three sequential calls; branch on each agent prompt's
+    // distinctive closing instruction (see src/lib/ai/mads.ts).
+    let content: string
+    if (userContent.includes('Find every edge case')) {
+      content = 'No material risks found; the change is a simple figure update.'
+    } else if (userContent.includes('Find safe, accurate common ground')) {
+      content = 'Both perspectives agree the figure should be updated as asked.'
+    } else if (userContent.includes('Issue your verdict')) {
+      content = JUDGE_OUTPUT
+    } else {
+      content = SINGLE_AGENT_OUTPUT
+    }
+
+    if (body.stream) {
+      // streamResolveAnnotation parses SSE `data:` lines (defensive fallback —
+      // the MADS path above resolves before any streaming call happens).
+      return route.fulfill({
+        contentType: 'text/event-stream',
+        body: `data: ${JSON.stringify({ responseId: 'e2e-resp-1' })}\n\ndata: ${JSON.stringify({ text: content })}\n\n`,
+      })
+    }
+    return route.fulfill({
+      json: { content, responseId: 'e2e-resp-1', logprobs: null },
+    })
+  })
+
+  await page.route('**/api/structured', (route) => {
+    const body = route.request().postDataJSON() as {
+      messages: Array<{ role: string; content: string }>
+      tools: Array<{ name: string }>
+    }
+    const tool = body.tools?.[0]?.name
+
+    if (tool === 'link_blocks') {
+      // Deterministic graph only — the defined-term edge is enough.
+      return route.fulfill({ json: { toolCalls: [] } })
+    }
+
+    if (tool === 'propose_edit') {
+      // Block ids are runtime nanoids, so the citation's source block id is
+      // parsed out of the cascade request itself. The proposal deliberately
+      // OMITS block_id: the orchestrator must anchor it via the findTextInDoc
+      // fallback and then pass the neighborhood scope gate.
+      const userMsg = body.messages.find((m) => m.role === 'user')?.content ?? ''
+      const primaryBlockId = /PRIMARY EDIT \(in block \[([^\]]+)\]/.exec(userMsg)?.[1] ?? ''
+      return route.fulfill({
+        json: {
+          toolCalls: [
+            {
+              name: 'propose_edit',
+              input: {
+                target_text: CASCADE_TARGET,
+                new_text: CASCADE_NEW_TEXT,
+                reason: 'Quarterly marketing cap still cites the old total budget figure.',
+                source_block_id: primaryBlockId,
+                quoted_text: '$50,000',
+                edge_type: 'references',
+              },
+            },
+          ],
+        },
+      })
+    }
+
+    if (tool === 'verdict') {
+      // Relevance judge: confirm the single 'must' candidate (1-based index).
+      return route.fulfill({
+        json: {
+          toolCalls: [
+            {
+              name: 'verdict',
+              input: { index: 1, genuinely_conflicts: true, reason: 'stale figure' },
+            },
+          ],
+        },
+      })
+    }
+
+    return route.fulfill({ json: { toolCalls: [] } })
+  })
+}
+
+test.describe('cascade review flow', () => {
+  test('annotate → cascade → per-change review → apply → history', async ({ page }) => {
+    await interceptLlmEndpoints(page)
+    await page.goto('/')
+
+    // 1. First-run DocInputModal: paste the seeded document.
+    await expect(page.getByRole('heading', { name: 'Load Document' })).toBeVisible({
+      timeout: 60_000, // first dev-server compile
+    })
+    await page.getByRole('button', { name: 'Paste' }).click()
+    await page.getByPlaceholder('Paste your document here...').fill(DOC_TEXT)
+    await page.getByRole('button', { name: 'Load Document' }).click()
+
+    const editor = page.locator('.ProseMirror')
+    await expect(editor).toContainText('Marketing may spend at most ten percent')
+
+    // 2. Select paragraph 1 (triple-click selects the textblock) — the
+    //    FloatingIconBar annotation input appears on selection.
+    await editor
+      .locator('p')
+      .filter({ hasText: '$50,000 allocated' })
+      .click({ clickCount: 3 })
+    const composer = page.getByPlaceholder("What's on your mind?")
+    await expect(composer).toBeVisible()
+
+    // 3. Type the edit instruction and submit. classify → MADS resolve →
+    //    cascade propose_edit → relevance judge all hit the interceptions.
+    await composer.fill(INSTRUCTION)
+    await composer.press('Enter')
+
+    // 4. Resolution card is ready and shows the suggested primary edit.
+    await expect(page.getByText('Ready').first()).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByText(INSTRUCTION).first()).toBeVisible()
+
+    // 5. The cascade proposal renders as a called-out decoration in the OTHER
+    //    paragraph, carrying the derived 'must' severity class.
+    const cascadeDecoration = editor.locator('.proposed-edit.proposed-edit-cascade')
+    await expect(cascadeDecoration).toBeVisible()
+    await expect(cascadeDecoration).toHaveText(CASCADE_TARGET)
+    await expect(cascadeDecoration).toHaveClass(/proposed-severity-must/)
+    // Primary region is decorated too.
+    await expect(editor.locator('.proposed-edit.proposed-edit-primary')).toBeVisible()
+
+    // The navigable cascade list on the card shows the judged proposal with
+    // its severity and verbatim citation.
+    await expect(page.getByText('This change affects 1 other section')).toBeVisible()
+    await expect(page.getByText('cites “$50,000”')).toBeVisible()
+
+    // 6. Open the commit modal: 2 changes, per-change Accept/Reject toggles,
+    //    severity badges on both rows (primary is always 'must'; the cascade
+    //    was derived 'must' and judge-confirmed).
+    // Two Apply affordances exist (per-message inline + the resolution action
+    // row); the action-row button carries a title attribute.
+    await page.getByTitle('Apply', { exact: true }).click()
+    const modal = page.locator('.semantic-commit-modal')
+    await expect(modal.getByText('Review Semantic Commit')).toBeVisible()
+    await expect(modal.getByText('2 changes proposed.')).toBeVisible()
+    await expect(modal.getByRole('button', { name: 'Accept', exact: true })).toHaveCount(2)
+    await expect(modal.getByRole('button', { name: 'Reject', exact: true })).toHaveCount(2)
+    await expect(modal.getByText('Must', { exact: true })).toHaveCount(2)
+
+    // 7. Confirm with both changes accepted — one validated transaction
+    //    mutates BOTH regions.
+    await page.getByRole('button', { name: 'Apply 2 changes' }).click()
+    await expect(page.getByText('Review Semantic Commit')).toBeHidden()
+    await expect(editor).toContainText('$75,000 allocated')
+    await expect(editor).toContainText(CASCADE_NEW_TEXT)
+    await expect(editor).not.toContainText('$50,000')
+    await expect(page.getByText('Applied', { exact: true }).first()).toBeVisible()
+
+    // 8. Changes panel recorded both applied entries under the approved
+    //    change set. (The summary line is asserted as attached rather than
+    //    visible — its wrapping button reports a zero-size box to Playwright
+    //    even though the text renders.)
+    await page.getByRole('button', { name: 'Changes' }).click()
+    await expect(page.getByText('Change-set review')).toBeVisible()
+    await expect(page.getByText(/2 applied changes/)).toBeAttached()
+    await expect(page.getByText('approved', { exact: true }).first()).toBeVisible()
+    // (Trimmed: expanding the change set to count per-entry rows — the
+    // header button renders zero-height in headless Chromium so the expand
+    // click is unreliable; the "2 applied changes" summary plus the mutated
+    // document text above already prove both entries were recorded.)
+
+    // 9. History tab shows the real 'apply' version row (kind badge "AI change",
+    //    actor "AI + you") written through the real /api/history route. The
+    //    commit is fire-and-forget after apply, so poll via Refresh.
+    // dispatchEvent instead of click: with headless font metrics the 5-tab
+    // sidebar row overflows its 320px container and the History tab's hit
+    // area lands under the topbar, so a positional click never lands.
+    await page.getByRole('button', { name: 'History' }).dispatchEvent('click')
+    await expect(async () => {
+      await page.getByRole('button', { name: 'Refresh' }).click()
+      await expect(page.getByText('AI change', { exact: true })).toBeVisible({
+        timeout: 2_000,
+      })
+    }).toPass({ timeout: 20_000 })
+    await expect(page.getByText('AI + you').first()).toBeVisible()
+    // The version chain also holds the root 'import' version from the paste.
+    await expect(page.getByText('Created', { exact: true })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Why

Nothing tested the full UI loop — the jsdom mount smoke covers editor construction, unit suites cover pipeline logic, but no test drove annotate → cascade → review → apply → history through the real app. This PR adds that gate, and it justified itself immediately (see below). It also finishes the portfolio README.

## What

**E2E flow** (`tests/cascade-review.spec.ts`, `npm run test:e2e`): pastes a seeded document through the real DocInputModal, selects text, drives the real FloatingIconBar → classify → MADS resolution → graph-scoped cascade → relevance judge, and asserts: cascade decoration with severity class in the *other* paragraph, CascadeList citation, SemanticCommitModal with 2 changes + Must badges, both regions mutated after apply, change set recorded, and a real `apply` Version row in the History tab. LLM endpoints are intercepted with canned JSON (including three-shape branching on `/api/structured`: `link_blocks` / `propose_edit` / `verdict`); the audit and history routes run for real against SQLite. No API keys needed; green 3× consecutively.

The interception deliberately omits `block_id` so the flow exercises the orchestrator's fallback anchoring, scope gate, evidence verification, and derived-`must` path — not just the happy path.

**Critical production fix found by writing this test**: `streamResolveAnnotation` — the resolution path the UI actually uses — never called `attachCascadeEdits` on its MADS branch. Since `edit` annotations always route through MADS, **cascade edits never attached in the live app**; every unit test passed because they exercise the non-streaming path. Fixed with a parity call in `src/lib/ai/resolver.ts` (five lines), now covered end-to-end by this spec.

**README**: "How the cascade works" (mermaid pipeline + numbered stages with real file paths), "Version history & compliance" (two-level content addressing, Art. 12/14, link to `docs/compliance.md`), reconciled Evaluation section, refreshed test counts, screenshot placeholders marked with HTML comments.

## Testing

Unit suite unchanged and green (370 + 10 skipped — baseline preserved); e2e green 3× (`--repeat-each=3`, ~4.5s/run); typecheck/lint/build clean. Two pragmatic workarounds are documented in-spec (changeset expand row is zero-height in headless Chromium; History tab clicked via dispatchEvent due to sidebar overflow under headless font metrics) — neither weakens the core assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
