### PR TITLE
Cascade v2 Wave B: incremental dependency graph, honest chunked coverage, embeddings edge source

### DIFF
--- a/src/app/api/embed/route.ts
+++ b/src/app/api/embed/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Provider-agnostic embeddings endpoint backing the doc graph's paraphrase-
+ * recall edge source. Same BYOK header convention as /api/structured
+ * (x-provider / x-api-key / x-base-url), plus x-embed-model for the embedding
+ * model. Anthropic has NO embeddings API: provider 'claude' without a baseUrl
+ * override returns 501 {reason:'unsupported'} and the client treats it as a
+ * silent no-op — the graph just gets fewer edges.
+ *
+ * Request:  POST { texts: string[] }
+ * Response: { vectors: number[][] } (one vector per input text, same order)
+ */
+
+export async function POST(request: NextRequest) {
+  const apiKey = request.headers.get('x-api-key') || ''
+  const provider = request.headers.get('x-provider') || 'claude'
+  const baseUrl = request.headers.get('x-base-url') || ''
+  const embedModel = request.headers.get('x-embed-model') || ''
+
+  if (provider === 'claude' && !baseUrl) {
+    return NextResponse.json({ reason: 'unsupported' }, { status: 501 })
+  }
+  if (provider !== 'ollama' && !apiKey) {
+    return NextResponse.json({ error: 'No API key provided' }, { status: 401 })
+  }
+
+  try {
+    const { texts }: { texts: string[] } = await request.json()
+    if (!Array.isArray(texts) || texts.length === 0 || texts.some((t) => typeof t !== 'string')) {
+      return NextResponse.json(
+        { error: 'texts must be a non-empty array of strings' },
+        { status: 400 }
+      )
+    }
+
+    if (provider === 'ollama') {
+      // Ollama-native /api/embed: { model, input } → { embeddings }.
+      const url = `${(baseUrl || 'http://localhost:11434').replace(/\/$/, '')}/api/embed`
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: embedModel || 'nomic-embed-text', input: texts }),
+      })
+
+      if (!response.ok) {
+        const text = await response.text()
+        return NextResponse.json({ error: text }, { status: response.status })
+      }
+
+      const data = await response.json()
+      const vectors: number[][] = Array.isArray(data.embeddings) ? data.embeddings : []
+      return NextResponse.json({ vectors })
+    }
+
+    // OpenAI-compatible /v1/embeddings (OpenAI, or any base-URL override —
+    // including 'claude' pointed at a proxy that does serve embeddings).
+    const url = baseUrl
+      ? `${baseUrl.replace(/\/$/, '')}/v1/embeddings`
+      : 'https://api.openai.com/v1/embeddings'
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ model: embedModel || 'text-embedding-3-small', input: texts }),
+    })
+
+    if (!response.ok) {
+      const text = await response.text()
+      return NextResponse.json({ error: text }, { status: response.status })
+    }
+
+    const data = await response.json()
+    const vectors: number[][] = (data.data || []).map(
+      (d: { embedding: number[] }) => d.embedding
+    )
+    return NextResponse.json({ vectors })
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Embedding call failed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/lib/ai/__tests__/orchestrator.test.ts
+++ b/src/lib/ai/__tests__/orchestrator.test.ts
@@ -22,6 +22,10 @@ function p(blockId: string | null, text: string): PMNode {
   return schema.node('paragraph', { blockId }, [schema.text(text)])
 }
 
+function h(blockId: string, level: number, text: string): PMNode {
+  return schema.node('heading', { level, blockId }, [schema.text(text)])
+}
+
 function docOf(...blocks: PMNode[]): PMNode {
   return schema.node('doc', null, blocks)
 }
@@ -147,6 +151,26 @@ describe('proposeCascadeEdits — scoping', () => {
     expect(prompt).toContain('[b3]')
     expect(edits).toHaveLength(1)
     expect(edits[0].blockId).toBe('b3')
+  })
+
+  it('candidate lines carry (§ heading path) context; blocks outside any heading stay bare', async () => {
+    const doc = docOf(
+      p('b0', '"Launch Date" means March 1, 2026.'), // before any heading — empty path
+      h('hA', 1, 'Launch Plan'),
+      h('hB', 2, 'Timeline'),
+      p('b2', 'The beta program ends on March 1, 2026, just before the Launch Date.'),
+    )
+    const state = stateOf(doc)
+    const primary = primaryEditFor(doc, 'b0', 'March 1, 2026', 'June 1, 2026')
+    const captured: StructuredRequest[] = []
+    await proposeCascadeEdits(state, primary, CONFIG, {
+      graph: buildDeterministicGraph(doc),
+      callStructured: scripted([], captured),
+    })
+    const prompt = captured[0].messages.map((m) => m.content).join('\n')
+    expect(prompt).toContain('[b2] (§ Launch Plan › Timeline) The beta program ends')
+    expect(prompt).toContain('[b0] "Launch Date" means')
+    expect(prompt).not.toContain('[b0] (§')
   })
 
   it('returns [] without calling the model when the primary block is unstamped', async () => {

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -73,7 +73,7 @@ const PROPOSE_EDIT_TOOL = {
 }
 
 const CASCADE_SYSTEM =
-  'You keep a document internally consistent. You are given a primary edit and a set of document blocks, each listed as [blockId] text. Find blocks that become inconsistent, outdated, or contradictory because of the primary edit and call propose_edit once for each. Only edit listed blocks; reference them by their block_id. Copy target_text verbatim from the block. Never propose an edit to the primary block itself. Cite your evidence: source_block_id plus a verbatim quoted_text showing the conflict. If nothing needs to change, call nothing.'
+  'You keep a document internally consistent. You are given a primary edit and a set of document blocks, each listed as [blockId] text — optionally with a (§ Heading › Subheading) prefix locating the block in the document outline. Find blocks that become inconsistent, outdated, or contradictory because of the primary edit and call propose_edit once for each. Only edit listed blocks; reference them by their block_id. Copy target_text verbatim from the block. Never propose an edit to the primary block itself. Cite your evidence: source_block_id plus a verbatim quoted_text showing the conflict. If nothing needs to change, call nothing.'
 
 function newId(): string {
   try {
@@ -313,7 +313,14 @@ export async function proposeCascadeEdits(
     `- Now: "${primary.newText}"`,
     '',
     'CANDIDATE BLOCKS (the only blocks you may edit):',
-    ...sent.map((c) => `[${c.blockId}] ${c.text}`),
+    // Heading context comes from the graph node (build-time outline snapshot);
+    // block TEXT is always the live-doc resolve above, never the snapshot.
+    ...sent.map((c) => {
+      const headingPath = graph.nodes.get(c.blockId)?.headingPath ?? []
+      return headingPath.length
+        ? `[${c.blockId}] (§ ${headingPath.join(' › ')}) ${c.text}`
+        : `[${c.blockId}] ${c.text}`
+    }),
   ].join('\n')
 
   let toolCalls: { name: string; input: unknown }[]

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -285,7 +285,7 @@ describe('augmentWithLlmEdges — chunking (no silent large-doc skip)', () => {
     }
   }
 
-  it('one call for docs at or under the chunk size', async () => {
+  it('one call for small docs', async () => {
     const captured: StructuredRequest[] = []
     const graph = buildDeterministicGraph(mkDoc(40))
     await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
@@ -294,21 +294,48 @@ describe('augmentWithLlmEdges — chunking (no silent large-doc skip)', () => {
     expect(graph.llmPartial).toBe(false)
   })
 
-  it('60-block doc: two contiguous chunks with a 4-block overlap for cross-boundary stitching', async () => {
+  it('150-block doc (the single-call ceiling): exactly ONE whole-doc call — every pair co-visible', async () => {
+    // The core 5–20-page use case must never be chunked: chunking makes
+    // pairs more than ~40 blocks apart structurally unlinkable.
     const captured: StructuredRequest[] = []
-    const graph = buildDeterministicGraph(mkDoc(60))
+    const graph = buildDeterministicGraph(mkDoc(150))
     await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
-    expect(captured).toHaveLength(2)
+    expect(captured).toHaveLength(1)
+    const prompt = captured[0].messages.map((m) => m.content).join('\n')
+    expect(prompt).toContain('[b0]')
+    expect(prompt).toContain('[b149]')
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.llmPartial).toBe(false)
+  })
+
+  it('151-block doc: falls over to the chunked pass', async () => {
+    const captured: StructuredRequest[] = []
+    const graph = buildDeterministicGraph(mkDoc(151))
+    await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+    expect(captured.length).toBeGreaterThan(1)
+    expect(captured).toHaveLength(5) // ceil((151 - 40) / 36) + 1
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.llmPartial).toBe(false)
+  })
+
+  it('160-block doc: contiguous ≤40-block chunks with a 4-block overlap for cross-boundary stitching', async () => {
+    const captured: StructuredRequest[] = []
+    const graph = buildDeterministicGraph(mkDoc(160))
+    await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+    expect(captured).toHaveLength(5)
     const [first, second] = captured.map((r) => r.messages.map((m) => m.content).join('\n'))
     // Chunk 1: blocks 0–39.
     expect(first).toContain('[b0]')
     expect(first).toContain('[b39]')
     expect(first).not.toContain('[b40]')
-    // Chunk 2 starts 4 blocks back (36) and runs to the end.
+    // Chunk 2 starts 4 blocks back (36).
     expect(second).toContain('[b36]')
     expect(second).toContain('[b39]') // the shared overlap
-    expect(second).toContain('[b59]')
+    expect(second).toContain('[b75]')
     expect(second).not.toContain('[b35]')
+    // Last chunk runs to the end.
+    const last = captured[4].messages.map((m) => m.content).join('\n')
+    expect(last).toContain('[b159]')
     expect(graph.llmApplied).toBe(true)
     expect(graph.llmPartial).toBe(false)
   })
@@ -342,8 +369,8 @@ describe('augmentWithLlmEdges — chunking (no silent large-doc skip)', () => {
     }
   })
 
-  it('mid-pass chunk failure keeps earlier edges, leaves llmApplied false; retry dedupes', async () => {
-    const graph = buildDeterministicGraph(mkDoc(60)) // 2 chunks
+  it('a failed chunk keeps the other chunks’ edges (parallel calls), leaves llmApplied false; retry dedupes', async () => {
+    const graph = buildDeterministicGraph(mkDoc(160)) // 5 chunks
     let calls = 0
     const flaky: CallStructuredFn = async () => {
       calls++
@@ -359,9 +386,10 @@ describe('augmentWithLlmEdges — chunking (no silent large-doc skip)', () => {
     }
     await augmentWithLlmEdges(graph, CONFIG, flaky)
     expect(graph.llmApplied).toBe(false)
+    // The 4 successful chunks all reported the same edge — dedupe kept one.
     expect(graph.edges.filter((e) => e.source === 'llm')).toHaveLength(1)
 
-    await augmentWithLlmEdges(graph, CONFIG, flaky) // both chunks succeed now
+    await augmentWithLlmEdges(graph, CONFIG, flaky) // all chunks succeed now
     expect(graph.llmApplied).toBe(true)
     // The retry re-reported the same edge — dedupe kept exactly one.
     expect(graph.edges.filter((e) => e.source === 'llm')).toHaveLength(1)
@@ -417,6 +445,41 @@ describe('getDocGraph — incremental per-block updates', () => {
     expect(carried).toMatchObject({ from: 'b10', to: 'b11', type: 'depends-on' })
     expect(g2.llmApplied).toBe(true)
     expect(g2.llmPartial).toBe(false)
+  })
+
+  it('editing one endpoint of an LLM-only edge re-lists the FAR endpoint so the edge can be re-proposed (no monotonic decay)', async () => {
+    // Regression for the incremental-decay bug: carryForwardLlmEdges DROPS
+    // LLM edges touching changed blocks and rebuilds adjacency post-drop, so
+    // the far endpoint is invisible to the current adjacency. The 1-hop
+    // expansion must union in the PRIOR graph's adjacency or the model can
+    // never re-propose the link and the graph decays with every edit.
+    const propose = {
+      name: 'link_blocks',
+      input: { from_block_id: 'b10', to_block_id: 'b11', edge_type: 'depends-on' },
+    }
+    const doc1 = bigDoc('b', 30)
+    const g1 = await getDocGraph(doc1, CONFIG, { callStructured: scripted([propose]) })
+    // The b10↔b11 link exists ONLY as an LLM edge (no deterministic signal).
+    expect(
+      g1.edges.filter((e) => e.from === 'b10' && e.to === 'b11'),
+    ).toMatchObject([{ source: 'llm', type: 'depends-on' }])
+
+    // Edit b11 — the LLM edge touches it, so carry-forward drops the edge.
+    const doc2 = bigDoc('b', 30, { 11: 'Rewritten eleventh paragraph content.' })
+    const captured: StructuredRequest[] = []
+    const g2 = await getDocGraph(doc2, CONFIG, { callStructured: scripted([propose], captured) })
+
+    expect(captured).toHaveLength(1)
+    const prompt = captured[0].messages.map((m) => m.content).join('\n')
+    expect(prompt).toContain('[b11]') // the changed block
+    // b10 is reachable ONLY through the dropped LLM edge — the prior
+    // adjacency must seed it into the re-extraction listing.
+    expect(prompt).toContain('[b10]')
+    // The scripted re-proposal restored the edge.
+    expect(
+      g2.edges.filter((e) => e.source === 'llm' && e.from === 'b10' && e.to === 'b11'),
+    ).toHaveLength(1)
+    expect(g2.llmApplied).toBe(true)
   })
 
   it('overlap matching picks the RIGHT prior graph out of several cached ones', async () => {

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Node as PMNode } from 'prosemirror-model'
 import { schema } from '@/lib/prosemirror/schema'
 import type { LLMConfig } from '@/stores/settingsStore'
@@ -262,27 +262,6 @@ describe('augmentWithLlmEdges', () => {
     expect(graph.edges).toHaveLength(before)
   })
 
-  it('skips the pass above 200 textblocks but still runs at exactly 200 (cap boundary)', async () => {
-    const mkDoc = (n: number) =>
-      docOf(...Array.from({ length: n }, (_, i) => p(`b${i}`, `distinct sentence number ${i}.`)))
-    let calls = 0
-    const counting: CallStructuredFn = async () => {
-      calls++
-      return { toolCalls: [] }
-    }
-
-    const over = buildDeterministicGraph(mkDoc(201))
-    expect(over.nodes.size).toBe(201)
-    await augmentWithLlmEdges(over, CONFIG, counting)
-    expect(calls).toBe(0)
-    expect(over.llmApplied).toBe(false) // deterministic-only, never flips
-
-    const atCap = buildDeterministicGraph(mkDoc(200))
-    await augmentWithLlmEdges(atCap, CONFIG, counting)
-    expect(calls).toBe(1)
-    expect(atCap.llmApplied).toBe(true)
-  })
-
   it('skips silently when no API key is configured (non-ollama)', async () => {
     const graph = buildDeterministicGraph(doc)
     let called = false
@@ -292,6 +271,206 @@ describe('augmentWithLlmEdges', () => {
     })
     expect(called).toBe(false)
     expect(graph.llmApplied).toBe(false)
+  })
+})
+
+describe('augmentWithLlmEdges — chunking (no silent large-doc skip)', () => {
+  const mkDoc = (n: number) =>
+    docOf(...Array.from({ length: n }, (_, i) => p(`b${i}`, `distinct sentence number ${i}.`)))
+
+  function capturing(capture: StructuredRequest[]): CallStructuredFn {
+    return async (req) => {
+      capture.push(req)
+      return { toolCalls: [] }
+    }
+  }
+
+  it('one call for docs at or under the chunk size', async () => {
+    const captured: StructuredRequest[] = []
+    const graph = buildDeterministicGraph(mkDoc(40))
+    await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+    expect(captured).toHaveLength(1)
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.llmPartial).toBe(false)
+  })
+
+  it('60-block doc: two contiguous chunks with a 4-block overlap for cross-boundary stitching', async () => {
+    const captured: StructuredRequest[] = []
+    const graph = buildDeterministicGraph(mkDoc(60))
+    await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+    expect(captured).toHaveLength(2)
+    const [first, second] = captured.map((r) => r.messages.map((m) => m.content).join('\n'))
+    // Chunk 1: blocks 0–39.
+    expect(first).toContain('[b0]')
+    expect(first).toContain('[b39]')
+    expect(first).not.toContain('[b40]')
+    // Chunk 2 starts 4 blocks back (36) and runs to the end.
+    expect(second).toContain('[b36]')
+    expect(second).toContain('[b39]') // the shared overlap
+    expect(second).toContain('[b59]')
+    expect(second).not.toContain('[b35]')
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.llmPartial).toBe(false)
+  })
+
+  it('201-block doc (the old silent-skip regime) is now fully covered by chunked calls', async () => {
+    const captured: StructuredRequest[] = []
+    const graph = buildDeterministicGraph(mkDoc(201))
+    await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+    expect(captured).toHaveLength(6) // ceil((201 - 40) / 36) + 1
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.llmPartial).toBe(false)
+    const all = captured.flatMap((r) => r.messages).map((m) => m.content).join('\n')
+    expect(all).toContain('[b200]') // the last block IS analyzed
+  })
+
+  it('350-block doc: capped at 8 calls, llmPartial set, console.warn — never a silent truncation', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const captured: StructuredRequest[] = []
+      const graph = buildDeterministicGraph(mkDoc(350))
+      await augmentWithLlmEdges(graph, CONFIG, capturing(captured))
+      expect(captured).toHaveLength(8)
+      expect(graph.llmApplied).toBe(true)
+      expect(graph.llmPartial).toBe(true)
+      expect(warn).toHaveBeenCalledTimes(1)
+      // 8 chunks cover blocks 0–291 (7 × 36 stride + 40) → 58 skipped, named.
+      expect(String(warn.mock.calls[0][0])).toContain('58 of 350')
+      expect(String(warn.mock.calls[0][0])).toContain('[b292]')
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('mid-pass chunk failure keeps earlier edges, leaves llmApplied false; retry dedupes', async () => {
+    const graph = buildDeterministicGraph(mkDoc(60)) // 2 chunks
+    let calls = 0
+    const flaky: CallStructuredFn = async () => {
+      calls++
+      if (calls === 2) throw new Error('provider down')
+      return {
+        toolCalls: [
+          {
+            name: 'link_blocks',
+            input: { from_block_id: 'b0', to_block_id: 'b50', edge_type: 'references' },
+          },
+        ],
+      }
+    }
+    await augmentWithLlmEdges(graph, CONFIG, flaky)
+    expect(graph.llmApplied).toBe(false)
+    expect(graph.edges.filter((e) => e.source === 'llm')).toHaveLength(1)
+
+    await augmentWithLlmEdges(graph, CONFIG, flaky) // both chunks succeed now
+    expect(graph.llmApplied).toBe(true)
+    // The retry re-reported the same edge — dedupe kept exactly one.
+    expect(graph.edges.filter((e) => e.source === 'llm')).toHaveLength(1)
+  })
+})
+
+describe('getDocGraph — incremental per-block updates', () => {
+  /** n paragraphs `${prefix}0..n-1` with per-index text overrides. */
+  function bigDoc(prefix: string, n: number, overrides: Record<number, string> = {}) {
+    return docOf(
+      ...Array.from({ length: n }, (_, i) =>
+        p(`${prefix}${i}`, overrides[i] ?? `Unique filler paragraph number ${i} content.`),
+      ),
+    )
+  }
+
+  it('re-extracts ONLY the changed block + its 1-hop neighbors; unchanged LLM edges survive', async () => {
+    const base = {
+      2: '"Alpha" means the retention window for records.',
+      5: 'The Alpha applies to all backups made after launch.',
+    }
+    const doc1 = bigDoc('b', 30, base)
+    // First build: full pass; the model links two blocks the extractors cannot.
+    const g1 = await getDocGraph(doc1, CONFIG, {
+      callStructured: scripted([
+        {
+          name: 'link_blocks',
+          input: { from_block_id: 'b10', to_block_id: 'b11', edge_type: 'depends-on' },
+        },
+      ]),
+    })
+    expect(g1.llmApplied).toBe(true)
+    expect(g1.edges.some((e) => e.source === 'llm' && e.from === 'b10')).toBe(true)
+
+    // Edit exactly one block (b5) — still references the Alpha definition (b2).
+    const doc2 = bigDoc('b', 30, {
+      ...base,
+      5: 'The Alpha applies to all backups made before launch.',
+    })
+    const captured: StructuredRequest[] = []
+    const g2 = await getDocGraph(doc2, CONFIG, { callStructured: scripted([], captured) })
+
+    // One extraction call over the changed block + its graph neighbor only.
+    expect(captured).toHaveLength(1)
+    const prompt = captured[0].messages.map((m) => m.content).join('\n')
+    expect(prompt).toContain('[b5]')
+    expect(prompt).toContain('[b2]') // 1-hop neighbor via the Alpha reference edge
+    expect(prompt).not.toContain('[b10]') // unchanged, unconnected — never re-sent
+    expect(prompt).not.toContain('Unique filler paragraph number 20') // far block text absent
+
+    // The prior LLM edge between two unchanged blocks was carried forward.
+    const carried = g2.edges.find((e) => e.source === 'llm' && e.from === 'b10')
+    expect(carried).toMatchObject({ from: 'b10', to: 'b11', type: 'depends-on' })
+    expect(g2.llmApplied).toBe(true)
+    expect(g2.llmPartial).toBe(false)
+  })
+
+  it('overlap matching picks the RIGHT prior graph out of several cached ones', async () => {
+    const docA = bigDoc('a', 10)
+    const docC = bigDoc('c', 10)
+    await getDocGraph(docA, CONFIG, {
+      callStructured: scripted([
+        { name: 'link_blocks', input: { from_block_id: 'a3', to_block_id: 'a4', edge_type: 'depends-on' } },
+      ]),
+    })
+    await getDocGraph(docC, CONFIG, {
+      callStructured: scripted([
+        { name: 'link_blocks', input: { from_block_id: 'c3', to_block_id: 'c4', edge_type: 'duplicates' } },
+      ]),
+    })
+
+    // Edit one block of doc A: its prior graph (9/10 overlap) must be chosen.
+    const docA2 = bigDoc('a', 10, { 7: 'Rewritten seventh paragraph.' })
+    const captured: StructuredRequest[] = []
+    const g = await getDocGraph(docA2, CONFIG, { callStructured: scripted([], captured) })
+
+    expect(captured).toHaveLength(1)
+    const prompt = captured[0].messages.map((m) => m.content).join('\n')
+    expect(prompt).toContain('[a7]')
+    expect(prompt).not.toContain('[a0]') // incremental against A, not a fresh full pass
+    expect(g.edges.some((e) => e.source === 'llm' && e.from === 'a3' && e.to === 'a4')).toBe(true)
+    expect(g.edges.some((e) => e.from === 'c3')).toBe(false)
+  })
+
+  it('below the >50% overlap threshold the build is treated as fresh (full pass, nothing carried)', async () => {
+    const docA = bigDoc('a', 10)
+    await getDocGraph(docA, CONFIG, {
+      callStructured: scripted([
+        { name: 'link_blocks', input: { from_block_id: 'a8', to_block_id: 'a9', edge_type: 'depends-on' } },
+      ]),
+    })
+
+    // 6 of 10 blocks rewritten → only 40% overlap with the cached graph.
+    const docD = bigDoc(
+      'a',
+      10,
+      Object.fromEntries(
+        Array.from({ length: 6 }, (_, i) => [i, `Completely rewritten paragraph ${i}.`]),
+      ),
+    )
+    const captured: StructuredRequest[] = []
+    const g = await getDocGraph(docD, CONFIG, { callStructured: scripted([], captured) })
+
+    const prompt = captured.flatMap((r) => r.messages).map((m) => m.content).join('\n')
+    // Unchanged, unconnected blocks are in the listing — proof of a FULL pass.
+    expect(prompt).toContain('[a6]')
+    expect(prompt).toContain('[a9]')
+    // Nothing carried forward from a graph that isn't the same document.
+    expect(g.edges.some((e) => e.source === 'llm')).toBe(false)
   })
 })
 

--- a/src/lib/graphrag/__tests__/embedEdges.test.ts
+++ b/src/lib/graphrag/__tests__/embedEdges.test.ts
@@ -141,6 +141,84 @@ describe('augmentWithEmbeddingEdges', () => {
       true,
     )
   })
+
+  it('vector cache is keyed by provider + embed model: a settings switch re-embeds everything', async () => {
+    // Vectors from different providers/models live in incompatible spaces —
+    // reusing them would silently compare across embedding models.
+    const calls: string[][] = []
+    const embed = scriptedEmbed(calls)
+
+    const g1 = buildDeterministicGraph(FIXTURE_DOC)
+    await augmentWithEmbeddingEdges(g1, CONFIG, embed)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toHaveLength(4)
+
+    // Same doc, different provider — zero cache hits, full re-embed.
+    const g2 = buildDeterministicGraph(FIXTURE_DOC)
+    await augmentWithEmbeddingEdges(g2, { provider: 'openai', apiKey: 'k', model: 'gpt-4o' }, embed)
+    expect(calls).toHaveLength(2)
+    expect(calls[1]).toHaveLength(4)
+
+    // Same provider, different embed model — also a full re-embed.
+    const g3 = buildDeterministicGraph(FIXTURE_DOC)
+    await augmentWithEmbeddingEdges(g3, { ...CONFIG, embedModel: 'other-embedder' }, embed)
+    expect(calls).toHaveLength(3)
+    expect(calls[2]).toHaveLength(4)
+  })
+
+  it('mismatched vector dimensions produce NO edge — cosine never truncates to Math.min', async () => {
+    const doc = docOf(p('m0', 'first block'), p('m1', 'middle block'), p('m2', 'third block'))
+    const graph = buildDeterministicGraph(doc)
+    // m0 is 3-dim, m2 is 2-dim; the truncated 2-dim prefix WOULD be a perfect
+    // match (cos = 1.0), which is exactly the masking the fix removes.
+    const embed: EmbedFn = async (texts) =>
+      texts.map((t) =>
+        t === 'first block' ? [1, 0, 0] : t === 'third block' ? [1, 0] : [0, 1],
+      )
+    await augmentWithEmbeddingEdges(graph, CONFIG, embed)
+    expect(graph.edges.filter((e) => e.source === 'embedding')).toHaveLength(0)
+    expect(graph.embeddingsApplied).toBe(true)
+  })
+})
+
+describe('augmentWithEmbeddingEdges — block cap (mirror of llmPartial)', () => {
+  const mkDoc = (n: number) =>
+    docOf(...Array.from({ length: n }, (_, i) => p(`e${i}`, `embed filler ${i}`)))
+
+  it('300 blocks (the boundary): fully embedded, no warn, embeddingsPartial false', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const calls: string[][] = []
+      const graph = buildDeterministicGraph(mkDoc(300))
+      await augmentWithEmbeddingEdges(graph, CONFIG, scriptedEmbed(calls))
+      expect(calls[0]).toHaveLength(300)
+      expect(graph.embeddingsPartial).toBe(false)
+      expect(graph.embeddingsApplied).toBe(true)
+      expect(warn).not.toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('301 blocks: capped at 300 in doc order, console.warn (blockIds only, no text), embeddingsPartial set', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const calls: string[][] = []
+      const graph = buildDeterministicGraph(mkDoc(301))
+      await augmentWithEmbeddingEdges(graph, CONFIG, scriptedEmbed(calls))
+      expect(calls[0]).toHaveLength(300)
+      expect(calls[0][0]).toBe('embed filler 0') // doc order, from the top
+      expect(graph.embeddingsPartial).toBe(true)
+      expect(graph.embeddingsApplied).toBe(true)
+      expect(warn).toHaveBeenCalledTimes(1)
+      const msg = String(warn.mock.calls[0][0])
+      expect(msg).toContain('1 of 301')
+      expect(msg).toContain('[e300]')
+      expect(msg).not.toContain('embed filler') // blockIds only — never block text
+    } finally {
+      warn.mockRestore()
+    }
+  })
 })
 
 describe('fetchEmbeddings', () => {
@@ -157,20 +235,46 @@ describe('fetchEmbeddings', () => {
     expect((init.headers as Record<string, string>)['x-provider']).toBe('claude')
   })
 
-  it('200 with vectors → returns them; network failure → null', async () => {
+  it('200 with vectors → returns them', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response(JSON.stringify({ vectors: [[1, 0]] }), { status: 200 })),
     )
     expect(await fetchEmbeddings(['x'], CONFIG)).toEqual([[1, 0]])
+  })
 
+  it('transient failures THROW so the pass stays unapplied and retries: network, 429, 5xx', async () => {
+    // Only a 501 (permanent — provider has no embeddings API) may return
+    // null; null marks embeddingsApplied forever, so a transient blip must
+    // never take that path.
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => {
         throw new Error('offline')
       }),
     )
-    expect(await fetchEmbeddings(['x'], CONFIG)).toBeNull()
+    await expect(fetchEmbeddings(['x'], CONFIG)).rejects.toThrow('offline')
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('rate limited', { status: 429 })))
+    await expect(fetchEmbeddings(['x'], CONFIG)).rejects.toThrow('429')
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('upstream boom', { status: 502 })))
+    await expect(fetchEmbeddings(['x'], CONFIG)).rejects.toThrow('502')
+  })
+
+  it('sends x-embed-model only when config.embedModel is set (UI lands in Wave C)', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ vectors: [[1, 0]] }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchEmbeddings(['x'], { ...CONFIG, embedModel: 'nomic-embed-text' })
+    const withModel = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1]
+    expect((withModel.headers as Record<string, string>)['x-embed-model']).toBe('nomic-embed-text')
+
+    await fetchEmbeddings(['x'], CONFIG)
+    const without = (fetchMock.mock.calls[1] as unknown as [string, RequestInit])[1]
+    expect('x-embed-model' in (without.headers as Record<string, string>)).toBe(false)
   })
 })
 

--- a/src/lib/graphrag/__tests__/embedEdges.test.ts
+++ b/src/lib/graphrag/__tests__/embedEdges.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { CallStructuredFn } from '@/lib/ai/structuredClient'
+import {
+  buildDeterministicGraph,
+  getDocGraph,
+  getNeighborhood,
+  invalidateDocGraphCache,
+} from '../docGraph'
+import {
+  augmentWithEmbeddingEdges,
+  clearEmbeddingVectorCache,
+  fetchEmbeddings,
+  type EmbedFn,
+} from '../embedEdges'
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+function docOf(...blocks: PMNode[]): PMNode {
+  return schema.node('doc', null, blocks)
+}
+
+// Deterministic unit-ish vectors keyed by block text:
+// cos(alpha, gamma) = 0.98 (> 0.82), everything else involving delta ≈ 0.
+const VECS: Record<string, number[]> = {
+  'alpha topic text': [1, 0],
+  'beta topic text': [0.99, 0.14],
+  'gamma topic text': [0.98, 0.199],
+  'delta topic text': [0, 1],
+}
+
+const FIXTURE_DOC = docOf(
+  p('b0', 'alpha topic text'),
+  p('b1', 'beta topic text'),
+  p('b2', 'gamma topic text'),
+  p('b3', 'delta topic text'),
+)
+
+function scriptedEmbed(calls?: string[][]): EmbedFn {
+  return async (texts) => {
+    calls?.push(texts)
+    return texts.map((t) => VECS[t] ?? [0, 0])
+  }
+}
+
+const scriptedStructured: CallStructuredFn = async () => ({ toolCalls: [] })
+
+beforeEach(() => {
+  invalidateDocGraphCache()
+  clearEmbeddingVectorCache()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('augmentWithEmbeddingEdges', () => {
+  it('links similar NON-adjacent blocks; skips doc-adjacent pairs and sub-threshold pairs', async () => {
+    const graph = buildDeterministicGraph(FIXTURE_DOC)
+    await augmentWithEmbeddingEdges(graph, CONFIG, scriptedEmbed())
+
+    const embEdges = graph.edges.filter((e) => e.source === 'embedding')
+    // b0–b2 is the only pair that is non-adjacent AND above 0.82.
+    expect(embEdges).toHaveLength(1)
+    expect(embEdges[0]).toMatchObject({
+      from: 'b0',
+      to: 'b2',
+      type: 'duplicates',
+      source: 'embedding',
+      evidence: 'semantic similarity 0.98',
+    })
+    // b0–b1 is above threshold but doc-adjacent — never linked.
+    expect(embEdges.some((e) => e.to === 'b1' || e.from === 'b1')).toBe(false)
+    // Adjacency index updated so the cascade can traverse the new edge.
+    expect(getNeighborhood(graph, 'b0', 1).has('b2')).toBe(true)
+    expect(graph.embeddingsApplied).toBe(true)
+  })
+
+  it('skips graph-adjacent pairs even above the threshold (already connected)', async () => {
+    const doc = docOf(
+      p('g0', '"Alpha" means the retention window for records.'),
+      p('g1', 'Completely unrelated filler block.'),
+      p('g2', 'The Alpha applies to all backups.'),
+    )
+    const graph = buildDeterministicGraph(doc)
+    // Sanity: the defined-term extractor already linked g2 → g0.
+    expect(graph.adjacency.get('g0')?.some((e) => e.from === 'g2')).toBe(true)
+
+    const embed: EmbedFn = async (texts) =>
+      texts.map((t) => (t.includes('filler') ? [0, 1] : [1, 0])) // g0 ≡ g2
+    await augmentWithEmbeddingEdges(graph, CONFIG, embed)
+    expect(graph.edges.filter((e) => e.source === 'embedding')).toHaveLength(0)
+    expect(graph.embeddingsApplied).toBe(true)
+  })
+
+  it('null embed result (unsupported provider) → no edges, no throw, marked applied', async () => {
+    const graph = buildDeterministicGraph(FIXTURE_DOC)
+    const before = graph.edges.length
+    await augmentWithEmbeddingEdges(graph, CONFIG, async () => null)
+    expect(graph.edges).toHaveLength(before)
+    expect(graph.embeddingsApplied).toBe(true) // silent no-op — no retry loop
+  })
+
+  it('a throwing embed fn is swallowed and left unapplied for a later retry', async () => {
+    const graph = buildDeterministicGraph(FIXTURE_DOC)
+    const before = graph.edges.length
+    await augmentWithEmbeddingEdges(graph, CONFIG, async () => {
+      throw new Error('transport down')
+    })
+    expect(graph.edges).toHaveLength(before)
+    expect(graph.embeddingsApplied).toBe(false)
+  })
+
+  it('vector cache: a rebuild embeds ONLY blocks whose text changed', async () => {
+    const calls: string[][] = []
+    const embed = scriptedEmbed(calls)
+
+    const g1 = buildDeterministicGraph(FIXTURE_DOC)
+    await augmentWithEmbeddingEdges(g1, CONFIG, embed)
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toHaveLength(4)
+
+    const edited = docOf(
+      p('b0', 'alpha topic text'),
+      p('b1', 'beta topic text'),
+      p('b2', 'gamma topic text'),
+      p('b3', 'delta topic text revised'),
+    )
+    const g2 = buildDeterministicGraph(edited)
+    await augmentWithEmbeddingEdges(g2, CONFIG, embed)
+    expect(calls).toHaveLength(2)
+    expect(calls[1]).toEqual(['delta topic text revised']) // cache hit for the rest
+    // Cached vectors still produce the b0–b2 edge without re-embedding them.
+    expect(g2.edges.some((e) => e.source === 'embedding' && e.from === 'b0' && e.to === 'b2')).toBe(
+      true,
+    )
+  })
+})
+
+describe('fetchEmbeddings', () => {
+  it('501 from /api/embed (claude has no embeddings API) → null, silent no-op', async () => {
+    const fetchMock = vi.fn(
+      async () => new Response(JSON.stringify({ reason: 'unsupported' }), { status: 501 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const out = await fetchEmbeddings(['some text'], CONFIG)
+    expect(out).toBeNull()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
+    expect(url).toBe('/api/embed')
+    expect((init.headers as Record<string, string>)['x-provider']).toBe('claude')
+  })
+
+  it('200 with vectors → returns them; network failure → null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ vectors: [[1, 0]] }), { status: 200 })),
+    )
+    expect(await fetchEmbeddings(['x'], CONFIG)).toEqual([[1, 0]])
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('offline')
+      }),
+    )
+    expect(await fetchEmbeddings(['x'], CONFIG)).toBeNull()
+  })
+})
+
+describe('getDocGraph — embedding pass wiring', () => {
+  it('runs the embedding pass after the LLM pass and merges its edges', async () => {
+    const graph = await getDocGraph(FIXTURE_DOC, CONFIG, {
+      callStructured: scriptedStructured,
+      embed: scriptedEmbed(),
+      embeddingsEnabled: true,
+    })
+    expect(graph.llmApplied).toBe(true)
+    expect(graph.embeddingsApplied).toBe(true)
+    expect(graph.edges.some((e) => e.source === 'embedding')).toBe(true)
+  })
+
+  it('embeddingsEnabled=false skips the pass entirely', async () => {
+    const embed = vi.fn(scriptedEmbed())
+    const graph = await getDocGraph(FIXTURE_DOC, CONFIG, {
+      callStructured: scriptedStructured,
+      embed,
+      embeddingsEnabled: false,
+    })
+    expect(embed).not.toHaveBeenCalled()
+    expect(graph.embeddingsApplied).toBe(false)
+    expect(graph.edges.some((e) => e.source === 'embedding')).toBe(false)
+  })
+
+  it('skipEmbeddings (background rebuild path) skips regardless of the setting', async () => {
+    const embed = vi.fn(scriptedEmbed())
+    const graph = await getDocGraph(FIXTURE_DOC, CONFIG, {
+      callStructured: scriptedStructured,
+      skipLlm: true,
+      skipEmbeddings: true,
+      embed,
+      embeddingsEnabled: true,
+    })
+    expect(embed).not.toHaveBeenCalled()
+    expect(graph.embeddingsApplied).toBe(false)
+  })
+
+  it('settings store ships embeddingsEnabled default-on with a setter (UI toggle lands in Wave C)', async () => {
+    const { useSettingsStore } = await import('@/stores/settingsStore')
+    expect(useSettingsStore.getState().embeddingsEnabled).toBe(true)
+    useSettingsStore.getState().setEmbeddingsEnabled(false)
+    expect(useSettingsStore.getState().embeddingsEnabled).toBe(false)
+    useSettingsStore.getState().setEmbeddingsEnabled(true) // restore for other tests
+  })
+})

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -9,7 +9,10 @@ import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClien
  * Document dependency graph — the retrieval index the cascade queries instead
  * of the raw document text. Nodes are textblocks keyed by stable blockId;
  * edges are typed relations from deterministic extractors (cross-references,
- * defined terms, duplicated sentences) plus one cached LLM extraction pass.
+ * defined terms, duplicated sentences) plus a cached, chunked LLM extraction
+ * pass that updates incrementally: per-block hashes diff each build against
+ * the closest prior graph so only changed blocks (and their neighbors) are
+ * re-extracted.
  *
  * Positions stored on nodes are build-time snapshots for ordering only — every
  * consumer re-resolves blocks against the live doc via findBlockById.
@@ -42,6 +45,14 @@ export interface DocGraph {
   builtAt: number
   /** True once the LLM extraction pass ran and its edges were merged. */
   llmApplied: boolean
+  /**
+   * True when the LLM pass could not cover every block (chunk cap hit, or an
+   * incomplete prior pass carried forward) — the graph is still usable, just
+   * with known-reduced recall. Never a silent truncation: setting this warns.
+   */
+  llmPartial: boolean
+  /** Per-textblock FNV-1a over blockId + text — the incremental-diff unit. */
+  blockHashes: Map<string, string>
   nodes: Map<string, DocGraphNode>
   edges: DocGraphEdge[]
   /** Undirected index: blockId → edges touching it. */
@@ -58,8 +69,14 @@ const EDGE_TYPES: ReadonlySet<string> = new Set([
   'duplicates',
 ])
 
-/** Skip the LLM pass beyond this many textblocks (deterministic edges only). */
-const LLM_PASS_MAX_BLOCKS = 200
+// LLM pass chunking: contiguous ≤40-block listings with a 4-block overlap
+// between consecutive chunks (cheap cross-boundary stitching — validation
+// already drops edges citing ids outside the graph), capped at 8 calls per
+// build. Beyond the cap the graph is marked llmPartial and warns — never a
+// silent truncation.
+const LLM_CHUNK_SIZE = 40
+const LLM_CHUNK_OVERLAP = 4
+const LLM_MAX_CHUNKS = 8
 
 const TERM_STOPWORDS = new Set([
   'the', 'this', 'that', 'these', 'those', 'with', 'from', 'have', 'been',
@@ -84,6 +101,21 @@ export function contentHash(doc: PMNode): string {
     update(b.node.textContent)
     update('\u0002')
   }
+  return h.toString(36)
+}
+
+/** FNV-1a over one block's id + text — the per-block incremental-diff unit. */
+export function blockHash(blockId: string, text: string): string {
+  let h = 0x811c9dc5
+  const update = (s: string) => {
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i)
+      h = Math.imul(h, 0x01000193) >>> 0
+    }
+  }
+  update(blockId)
+  update('\u0001')
+  update(text)
   return h.toString(36)
 }
 
@@ -166,10 +198,12 @@ export function buildDeterministicGraph(doc: PMNode): DocGraph {
   const headingStack: Array<{ level: number; text: string }> = []
   const headingByNorm = new Map<string, string>()
   const headingsInOrder: Array<{ blockId: string; text: string }> = []
+  const blockHashes = new Map<string, string>()
 
   for (const b of blocks) {
     if (!b.blockId) continue
     const text = b.node.textContent
+    blockHashes.set(b.blockId, blockHash(b.blockId, text))
     if (b.node.type.name === 'heading') {
       const level = (b.node.attrs.level as number) ?? 1
       while (headingStack.length && headingStack[headingStack.length - 1].level >= level) {
@@ -264,6 +298,8 @@ export function buildDeterministicGraph(doc: PMNode): DocGraph {
     contentHash: contentHash(doc),
     builtAt: Date.now(),
     llmApplied: false,
+    llmPartial: false,
+    blockHashes,
     nodes,
     edges,
     adjacency: buildAdjacency(edges),
@@ -324,46 +360,96 @@ function llmAvailable(config: LLMConfig): boolean {
 }
 
 /**
- * One extraction call per document. Mutates `graph` in place: validated LLM
- * edges are merged and `llmApplied` flips true. Failures leave the
- * deterministic graph intact and `llmApplied` false — never throws.
+ * Contiguous ≤LLM_CHUNK_SIZE chunks over the ordered block list, consecutive
+ * chunks sharing LLM_CHUNK_OVERLAP blocks, hard-capped at LLM_MAX_CHUNKS.
+ * `skipped` counts trailing blocks beyond the cap that no chunk covers.
+ */
+function chunkNodes(ordered: DocGraphNode[]): { chunks: DocGraphNode[][]; skipped: number } {
+  const chunks: DocGraphNode[][] = []
+  const stride = LLM_CHUNK_SIZE - LLM_CHUNK_OVERLAP
+  let covered = 0
+  for (let start = 0; start < ordered.length && chunks.length < LLM_MAX_CHUNKS; start += stride) {
+    chunks.push(ordered.slice(start, start + LLM_CHUNK_SIZE))
+    covered = Math.min(ordered.length, start + LLM_CHUNK_SIZE)
+    if (covered >= ordered.length) break
+  }
+  return { chunks, skipped: ordered.length - covered }
+}
+
+/**
+ * Chunked extraction over the graph — or, when `targetIds` is given, only that
+ * changed-neighborhood subset (the incremental path). Mutates `graph` in
+ * place: validated LLM edges are merged and `llmApplied` flips true; blocks
+ * left uncovered by the chunk cap set `llmPartial` and warn — no silent
+ * truncation. A chunk failure stops the pass with `llmApplied` still false
+ * (edges merged so far are kept; the retry dedupes) — never throws.
  */
 export async function augmentWithLlmEdges(
   graph: DocGraph,
   config: LLMConfig,
   call: CallStructuredFn = fetchStructured,
+  targetIds?: ReadonlySet<string>,
 ): Promise<void> {
   if (graph.llmApplied) return
-  if (graph.nodes.size === 0 || graph.nodes.size > LLM_PASS_MAX_BLOCKS) return
+  if (graph.nodes.size === 0) return
   if (!llmAvailable(config)) return
 
-  const listing = [...graph.nodes.values()]
+  const ordered = [...graph.nodes.values()]
+    .filter((n) => !targetIds || targetIds.has(n.blockId))
     .sort((a, b) => a.pos - b.pos)
-    .map((n) => `[${n.blockId}] ${n.text}`)
-    .join('\n')
-
-  let toolCalls
-  try {
-    const res = await call(
-      {
-        messages: [
-          { role: 'system', content: LINK_SYSTEM },
-          { role: 'user', content: `DOCUMENT BLOCKS:\n${listing}` },
-        ],
-        tools: [LINK_BLOCKS_TOOL],
-        maxTokens: 2000,
-        temperature: 0.1,
-      },
-      // Edge extraction is the cascade's RECALL mechanism — paraphrase
-      // dependencies only surface if this pass finds them, so it runs on the
-      // user's selected model, never a silent cheap-model downgrade.
-      config,
-    )
-    toolCalls = res.toolCalls
-  } catch {
+  if (ordered.length === 0) {
+    // Incremental build where every change was a deletion — nothing to extract.
+    graph.llmApplied = true
     return
   }
 
+  const { chunks, skipped } = chunkNodes(ordered)
+  if (skipped > 0) {
+    graph.llmPartial = true
+    console.warn(
+      `docGraph: LLM extraction chunk cap hit — ${skipped} of ${ordered.length} blocks ` +
+        `(from [${ordered[ordered.length - skipped].blockId}] onward) were not analyzed; ` +
+        'graph marked llmPartial',
+    )
+  }
+
+  const allToolCalls: { name: string; input: unknown }[] = []
+  for (const chunk of chunks) {
+    const listing = chunk.map((n) => `[${n.blockId}] ${n.text}`).join('\n')
+    try {
+      const res = await call(
+        {
+          messages: [
+            { role: 'system', content: LINK_SYSTEM },
+            { role: 'user', content: `DOCUMENT BLOCKS:\n${listing}` },
+          ],
+          tools: [LINK_BLOCKS_TOOL],
+          maxTokens: 2000,
+          temperature: 0.1,
+        },
+        // Edge extraction is the cascade's RECALL mechanism — paraphrase
+        // dependencies only surface if this pass finds them, so it runs on the
+        // user's selected model, never a silent cheap-model downgrade.
+        config,
+      )
+      allToolCalls.push(...res.toolCalls)
+    } catch {
+      // Merge what earlier chunks found, but leave llmApplied false so the
+      // next getDocGraph retries (the edge-key dedupe absorbs the overlap).
+      mergeLlmToolCalls(graph, allToolCalls)
+      return
+    }
+  }
+
+  mergeLlmToolCalls(graph, allToolCalls)
+  graph.llmApplied = true
+}
+
+/** Validate + dedupe link_blocks calls into the graph, rebuilding adjacency. */
+function mergeLlmToolCalls(
+  graph: DocGraph,
+  toolCalls: { name: string; input: unknown }[],
+): void {
   const edgeKeys = new Set(graph.edges.map((e) => `${e.from}${e.to}${e.type}`))
   for (const tc of toolCalls) {
     if (tc.name !== 'link_blocks') continue
@@ -389,7 +475,6 @@ export async function augmentWithLlmEdges(
     })
   }
   graph.adjacency = buildAdjacency(graph.edges)
-  graph.llmApplied = true
 }
 
 // --- Cache + entry points ---------------------------------------------------
@@ -409,9 +494,71 @@ function cacheGraph(hash: string, graph: DocGraph): void {
 }
 
 /**
+ * Best prior graph for an incremental LLM pass: the cached, llm-applied graph
+ * sharing the most per-block hashes with `graph` — and more than half of its
+ * blocks, else the edit is too large to treat as incremental. There is no
+ * documentId to key on, so hash overlap IS the document-identity heuristic.
+ */
+function findBestPriorGraph(graph: DocGraph, excludeHash: string): DocGraph | null {
+  let best: DocGraph | null = null
+  let bestOverlap = graph.blockHashes.size / 2 // strict >50% threshold
+  for (const [hash, candidate] of graphCache) {
+    if (hash === excludeHash || !candidate.llmApplied) continue
+    let overlap = 0
+    for (const [id, h] of graph.blockHashes) {
+      if (candidate.blockHashes.get(id) === h) overlap++
+    }
+    if (overlap > bestOverlap) {
+      bestOverlap = overlap
+      best = candidate
+    }
+  }
+  return best
+}
+
+/**
+ * Diff `graph` against a prior build: carries forward prior LLM edges whose
+ * BOTH endpoints are unchanged (edges touching changed blocks are dropped for
+ * re-extraction), inherits llmPartial, and returns the changed/new block ids.
+ */
+function carryForwardLlmEdges(graph: DocGraph, prior: DocGraph): Set<string> {
+  const changed = new Set<string>()
+  for (const [id, h] of graph.blockHashes) {
+    if (prior.blockHashes.get(id) !== h) changed.add(id)
+  }
+  const edgeKeys = new Set(graph.edges.map((e) => `${e.from}${e.to}${e.type}`))
+  for (const edge of prior.edges) {
+    if (edge.source !== 'llm') continue
+    if (changed.has(edge.from) || changed.has(edge.to)) continue
+    if (!graph.nodes.has(edge.from) || !graph.nodes.has(edge.to)) continue
+    const key = `${edge.from}${edge.to}${edge.type}`
+    if (edgeKeys.has(key)) continue
+    edgeKeys.add(key)
+    graph.edges.push({ ...edge })
+  }
+  graph.adjacency = buildAdjacency(graph.edges)
+  if (prior.llmPartial) graph.llmPartial = true
+  return changed
+}
+
+/** The seed blocks plus their 1-hop graph neighbors (union). */
+function expandOneHop(graph: DocGraph, seed: ReadonlySet<string>): Set<string> {
+  const out = new Set(seed)
+  for (const id of seed) {
+    for (const edge of graph.adjacency.get(id) ?? []) {
+      out.add(edge.from === id ? edge.to : edge.from)
+    }
+  }
+  return out
+}
+
+/**
  * The cascade's graph entry point: content-hash cached, concurrent builds
- * deduped. Deterministic build is sync-fast; the LLM pass is awaited once and
- * silently skipped when no provider is callable (graph stays usable).
+ * deduped. Deterministic build is sync-fast and always global; the LLM pass is
+ * incremental — when a cached prior graph covers most of the same blocks, its
+ * edges between unchanged blocks are carried forward and only changed blocks
+ * plus their 1-hop neighbors are re-extracted. Silently skipped when no
+ * provider is callable (graph stays usable).
  */
 export async function getDocGraph(
   doc: PMNode,
@@ -428,8 +575,14 @@ export async function getDocGraph(
 
   const promise = (async () => {
     const graph = cached ?? buildDeterministicGraph(doc)
-    if (!deps.skipLlm) {
-      await augmentWithLlmEdges(graph, config, deps.callStructured ?? fetchStructured)
+    if (!deps.skipLlm && !graph.llmApplied) {
+      let targetIds: Set<string> | undefined
+      const prior = findBestPriorGraph(graph, hash)
+      if (prior) {
+        const changed = carryForwardLlmEdges(graph, prior)
+        targetIds = expandOneHop(graph, changed)
+      }
+      await augmentWithLlmEdges(graph, config, deps.callStructured ?? fetchStructured, targetIds)
     }
     cacheGraph(hash, graph)
     return graph

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -57,6 +57,11 @@ export interface DocGraph {
    * the provider has no embeddings API (fewer edges, no retry loop).
    */
   embeddingsApplied: boolean
+  /**
+   * True when the embedding pass could not cover every block (block cap hit)
+   * — mirror of llmPartial. Never a silent truncation: setting this warns.
+   */
+  embeddingsPartial: boolean
   /** Per-textblock FNV-1a over blockId + text — the incremental-diff unit. */
   blockHashes: Map<string, string>
   nodes: Map<string, DocGraphNode>
@@ -75,11 +80,16 @@ const EDGE_TYPES: ReadonlySet<string> = new Set([
   'duplicates',
 ])
 
-// LLM pass chunking: contiguous ≤40-block listings with a 4-block overlap
-// between consecutive chunks (cheap cross-boundary stitching — validation
-// already drops edges citing ids outside the graph), capped at 8 calls per
-// build. Beyond the cap the graph is marked llmPartial and warns — never a
-// silent truncation.
+// LLM pass sizing. Docs up to LLM_SINGLE_CALL_MAX blocks (the core 5–20-page
+// use case) go to the model in ONE whole-doc call so every pair of blocks is
+// co-visible — chunking would make pairs more than ~LLM_CHUNK_SIZE blocks
+// apart structurally unlinkable. Only ABOVE 150 blocks does the pass fall
+// back to contiguous ≤40-block chunks with a 4-block overlap between
+// consecutive chunks (cheap cross-boundary stitching — validation already
+// drops edges citing ids outside the graph), capped at 8 calls per build.
+// Beyond the cap the graph is marked llmPartial and warns — never a silent
+// truncation.
+const LLM_SINGLE_CALL_MAX = 150
 const LLM_CHUNK_SIZE = 40
 const LLM_CHUNK_OVERLAP = 4
 const LLM_MAX_CHUNKS = 8
@@ -306,6 +316,7 @@ export function buildDeterministicGraph(doc: PMNode): DocGraph {
     llmApplied: false,
     llmPartial: false,
     embeddingsApplied: false,
+    embeddingsPartial: false,
     blockHashes,
     nodes,
     edges,
@@ -367,11 +378,16 @@ function llmAvailable(config: LLMConfig): boolean {
 }
 
 /**
- * Contiguous ≤LLM_CHUNK_SIZE chunks over the ordered block list, consecutive
- * chunks sharing LLM_CHUNK_OVERLAP blocks, hard-capped at LLM_MAX_CHUNKS.
- * `skipped` counts trailing blocks beyond the cap that no chunk covers.
+ * Listings for the extraction pass. At or under LLM_SINGLE_CALL_MAX blocks:
+ * ONE whole-doc listing (every pair co-visible). Above it: contiguous
+ * ≤LLM_CHUNK_SIZE chunks, consecutive chunks sharing LLM_CHUNK_OVERLAP
+ * blocks, hard-capped at LLM_MAX_CHUNKS. `skipped` counts trailing blocks
+ * beyond the cap that no chunk covers.
  */
 function chunkNodes(ordered: DocGraphNode[]): { chunks: DocGraphNode[][]; skipped: number } {
+  if (ordered.length <= LLM_SINGLE_CALL_MAX) {
+    return { chunks: [ordered], skipped: 0 }
+  }
   const chunks: DocGraphNode[][] = []
   const stride = LLM_CHUNK_SIZE - LLM_CHUNK_OVERLAP
   let covered = 0
@@ -388,8 +404,10 @@ function chunkNodes(ordered: DocGraphNode[]): { chunks: DocGraphNode[][]; skippe
  * changed-neighborhood subset (the incremental path). Mutates `graph` in
  * place: validated LLM edges are merged and `llmApplied` flips true; blocks
  * left uncovered by the chunk cap set `llmPartial` and warn — no silent
- * truncation. A chunk failure stops the pass with `llmApplied` still false
- * (edges merged so far are kept; the retry dedupes) — never throws.
+ * truncation. Chunk calls run in parallel (fetchWithRetry inside the call fn
+ * already handles per-call retry); any chunk failure keeps the successful
+ * chunks' edges but leaves `llmApplied` false so the next build retries (the
+ * edge-key dedupe absorbs the re-reported edges) — never throws.
  */
 export async function augmentWithLlmEdges(
   graph: DocGraph,
@@ -420,11 +438,12 @@ export async function augmentWithLlmEdges(
     )
   }
 
-  const allToolCalls: { name: string; input: unknown }[] = []
-  for (const chunk of chunks) {
-    const listing = chunk.map((n) => `[${n.blockId}] ${n.text}`).join('\n')
-    try {
-      const res = await call(
+  // Chunk calls are independent listings — run them in parallel (the call fn
+  // handles per-call retry internally).
+  const results = await Promise.allSettled(
+    chunks.map((chunk) => {
+      const listing = chunk.map((n) => `[${n.blockId}] ${n.text}`).join('\n')
+      return call(
         {
           messages: [
             { role: 'system', content: LINK_SYSTEM },
@@ -439,17 +458,21 @@ export async function augmentWithLlmEdges(
         // user's selected model, never a silent cheap-model downgrade.
         config,
       )
-      allToolCalls.push(...res.toolCalls)
-    } catch {
-      // Merge what earlier chunks found, but leave llmApplied false so the
-      // next getDocGraph retries (the edge-key dedupe absorbs the overlap).
-      mergeLlmToolCalls(graph, allToolCalls)
-      return
-    }
+    }),
+  )
+
+  const allToolCalls: { name: string; input: unknown }[] = []
+  let anyFailed = false
+  for (const res of results) {
+    if (res.status === 'fulfilled') allToolCalls.push(...res.value.toolCalls)
+    else anyFailed = true
   }
 
+  // Merge what the successful chunks found; a failed chunk leaves llmApplied
+  // false so the next getDocGraph retries (the edge-key dedupe absorbs the
+  // re-reported edges).
   mergeLlmToolCalls(graph, allToolCalls)
-  graph.llmApplied = true
+  if (!anyFailed) graph.llmApplied = true
 }
 
 /** Validate + dedupe link_blocks calls into the graph, rebuilding adjacency. */
@@ -548,13 +571,31 @@ function carryForwardLlmEdges(graph: DocGraph, prior: DocGraph): Set<string> {
   return changed
 }
 
-/** The seed blocks plus their 1-hop graph neighbors (union). */
-function expandOneHop(graph: DocGraph, seed: ReadonlySet<string>): Set<string> {
+/**
+ * The seed blocks plus their 1-hop graph neighbors (union of the CURRENT
+ * graph's adjacency and, when given, the PRIOR graph's adjacency).
+ *
+ * The prior adjacency is load-bearing: carryForwardLlmEdges DROPS every LLM
+ * edge touching a changed block, and rebuilds the current adjacency after the
+ * drop — so a dropped edge's far endpoint is invisible to the current
+ * adjacency. Without seeding from the prior graph the far endpoint never
+ * re-enters the re-extraction listing, the model can never re-propose the
+ * link, and every incremental pass permanently destroys LLM edges touching
+ * edited blocks (monotonic graph decay compounding across a session).
+ */
+function expandOneHop(
+  graph: DocGraph,
+  seed: ReadonlySet<string>,
+  priorAdjacency?: Map<string, DocGraphEdge[]>,
+): Set<string> {
   const out = new Set(seed)
+  const addFar = (id: string, edge: DocGraphEdge) => {
+    const far = edge.from === id ? edge.to : edge.from
+    if (graph.nodes.has(far)) out.add(far)
+  }
   for (const id of seed) {
-    for (const edge of graph.adjacency.get(id) ?? []) {
-      out.add(edge.from === id ? edge.to : edge.from)
-    }
+    for (const edge of graph.adjacency.get(id) ?? []) addFar(id, edge)
+    for (const edge of priorAdjacency?.get(id) ?? []) addFar(id, edge)
   }
   return out
 }
@@ -614,7 +655,9 @@ export async function getDocGraph(
       const prior = findBestPriorGraph(graph, hash)
       if (prior) {
         const changed = carryForwardLlmEdges(graph, prior)
-        targetIds = expandOneHop(graph, changed)
+        // Union with the prior adjacency so far endpoints of DROPPED LLM
+        // edges re-enter the listing and can be re-proposed.
+        targetIds = expandOneHop(graph, changed, prior.adjacency)
       }
       await augmentWithLlmEdges(graph, config, deps.callStructured ?? fetchStructured, targetIds)
     }

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -4,6 +4,7 @@ import type { LLMConfig } from '@/stores/settingsStore'
 import type { CascadeEdgeType } from '@/lib/annotations/types'
 import { collectTextblocks } from '@/lib/prosemirror/blockIds'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { augmentWithEmbeddingEdges, type EmbedFn } from './embedEdges'
 
 /**
  * Document dependency graph — the retrieval index the cascade queries instead
@@ -29,7 +30,7 @@ export interface DocGraphNode {
   definedTerms: string[]
 }
 
-export type DocGraphEdgeSource = 'deterministic' | 'llm' | 'graphiti'
+export type DocGraphEdgeSource = 'deterministic' | 'llm' | 'embedding' | 'graphiti'
 
 export interface DocGraphEdge {
   from: string
@@ -51,6 +52,11 @@ export interface DocGraph {
    * with known-reduced recall. Never a silent truncation: setting this warns.
    */
   llmPartial: boolean
+  /**
+   * True once the embedding pass ran — including the silent no-op case where
+   * the provider has no embeddings API (fewer edges, no retry loop).
+   */
+  embeddingsApplied: boolean
   /** Per-textblock FNV-1a over blockId + text — the incremental-diff unit. */
   blockHashes: Map<string, string>
   nodes: Map<string, DocGraphNode>
@@ -299,6 +305,7 @@ export function buildDeterministicGraph(doc: PMNode): DocGraph {
     builtAt: Date.now(),
     llmApplied: false,
     llmPartial: false,
+    embeddingsApplied: false,
     blockHashes,
     nodes,
     edges,
@@ -552,22 +559,49 @@ function expandOneHop(graph: DocGraph, seed: ReadonlySet<string>): Set<string> {
   return out
 }
 
+/** User toggle for the embedding pass (settings store, default true). */
+async function embeddingsEnabledFromStore(): Promise<boolean> {
+  try {
+    const { useSettingsStore } = await import('@/stores/settingsStore')
+    return useSettingsStore.getState().embeddingsEnabled
+  } catch {
+    return true
+  }
+}
+
 /**
  * The cascade's graph entry point: content-hash cached, concurrent builds
  * deduped. Deterministic build is sync-fast and always global; the LLM pass is
  * incremental — when a cached prior graph covers most of the same blocks, its
  * edges between unchanged blocks are carried forward and only changed blocks
- * plus their 1-hop neighbors are re-extracted. Silently skipped when no
- * provider is callable (graph stays usable).
+ * plus their 1-hop neighbors are re-extracted. The embedding pass runs after
+ * the LLM pass (vector cache makes it incremental for free). Both passes are
+ * silently skipped when no provider is callable (graph stays usable).
  */
 export async function getDocGraph(
   doc: PMNode,
   config: LLMConfig,
-  deps: { callStructured?: CallStructuredFn; skipLlm?: boolean } = {},
+  deps: {
+    callStructured?: CallStructuredFn
+    skipLlm?: boolean
+    /** Skip the embedding pass regardless of the user setting (background rebuilds). */
+    skipEmbeddings?: boolean
+    embed?: EmbedFn
+    /** Test/caller override for the settings-store embeddings toggle. */
+    embeddingsEnabled?: boolean
+  } = {},
 ): Promise<DocGraph> {
   const hash = contentHash(doc)
+  const embeddingsOn =
+    !deps.skipEmbeddings &&
+    llmAvailable(config) &&
+    (deps.embeddingsEnabled ?? (await embeddingsEnabledFromStore()))
   const cached = graphCache.get(hash)
-  if (cached && (cached.llmApplied || deps.skipLlm || !llmAvailable(config))) {
+  if (
+    cached &&
+    (cached.llmApplied || deps.skipLlm || !llmAvailable(config)) &&
+    (cached.embeddingsApplied || !embeddingsOn)
+  ) {
     return cached
   }
   const pending = inflight.get(hash)
@@ -583,6 +617,9 @@ export async function getDocGraph(
         targetIds = expandOneHop(graph, changed)
       }
       await augmentWithLlmEdges(graph, config, deps.callStructured ?? fetchStructured, targetIds)
+    }
+    if (embeddingsOn && !graph.embeddingsApplied) {
+      await augmentWithEmbeddingEdges(graph, config, deps.embed)
     }
     cacheGraph(hash, graph)
     return graph
@@ -623,9 +660,10 @@ let rebuildTimer: ReturnType<typeof setTimeout> | null = null
 /**
  * Debounced background rebuild, wired into the editor's dispatchTransaction so
  * the cascade usually hits a warm deterministic graph. Deliberately
- * DETERMINISTIC-ONLY (`skipLlm`): document text must never leave the machine
- * as a side effect of typing — the LLM extraction pass runs lazily inside the
- * cascade, which the user explicitly initiated. All failures are swallowed.
+ * DETERMINISTIC-ONLY (`skipLlm` + `skipEmbeddings`): document text must never
+ * leave the machine as a side effect of typing — the LLM extraction and
+ * embedding passes run lazily inside the cascade, which the user explicitly
+ * initiated. All failures are swallowed.
  */
 export function scheduleDocGraphRebuild(view: EditorView, delayMs = 2000): void {
   if (rebuildTimer) clearTimeout(rebuildTimer)
@@ -636,6 +674,7 @@ export function scheduleDocGraphRebuild(view: EditorView, delayMs = 2000): void 
       const { useSettingsStore } = await import('@/stores/settingsStore')
       await getDocGraph(view.state.doc, useSettingsStore.getState().llmConfig, {
         skipLlm: true,
+        skipEmbeddings: true,
       })
     })().catch(() => {})
   }, delayMs)

--- a/src/lib/graphrag/embedEdges.ts
+++ b/src/lib/graphrag/embedEdges.ts
@@ -9,18 +9,34 @@ import type { DocGraph, DocGraphEdge } from './docGraph'
  * 'embedding'. Graph-adjacent pairs and doc-adjacent neighbors are skipped:
  * the former are already connected, the latter are trivially related prose.
  *
- * Same failure-swallowing contract as the LLM pass: unsupported providers
- * (Anthropic has no embeddings API) and any failure degrade to fewer edges —
- * never an error thrown into the cascade.
+ * Failure contract: a PERMANENTLY unsupported provider (Anthropic has no
+ * embeddings API — /api/embed answers 501) degrades to fewer edges with no
+ * retry loop; TRANSIENT failures (network, 429, 5xx) throw out of the embed
+ * fn, augmentWithEmbeddingEdges swallows them and leaves the pass unapplied
+ * so the next cascade retries. Never an error thrown into the cascade.
  */
 
-/** null = embeddings unsupported for this provider, or the call failed. */
+/**
+ * null = embeddings PERMANENTLY unsupported for this provider (no retry).
+ * Transient failures must THROW so the pass stays unapplied and is retried.
+ */
 export type EmbedFn = (texts: string[], config: LLMConfig) => Promise<number[][] | null>
 
+// NOTE: uncalibrated across embedding models — 0.82 was picked against
+// text-embedding-3-small-style cosine distributions, and different models
+// (or dimensions) shift the similarity range. If a swapped embed model over-
+// or under-links paraphrases, this constant is where to tune.
 const SIMILARITY_THRESHOLD = 0.82
 
-// Module-level vector cache keyed by per-block content hash — an incremental
-// rebuild only embeds blocks whose text actually changed.
+// Cap on the embedding pass: only the first EMBED_MAX_BLOCKS blocks in doc
+// order are embedded. Beyond it the graph is marked embeddingsPartial and
+// warns (mirror of llmPartial) — never a silent truncation.
+const EMBED_MAX_BLOCKS = 300
+
+// Module-level vector cache keyed by provider + embed model + per-block
+// content hash — an incremental rebuild only embeds blocks whose text
+// actually changed, and switching provider/model never reuses foreign
+// vectors (which would silently compare across incompatible spaces).
 const VECTOR_CACHE_MAX = 500
 const vectorCache = new Map<string, number[]>()
 
@@ -41,32 +57,39 @@ export function clearEmbeddingVectorCache(): void {
 
 /**
  * Default EmbedFn: the provider-agnostic /api/embed route (same header
- * convention as /api/structured). A 501 (provider has no embeddings API) and
- * every other failure return null — the caller treats it as a silent no-op.
+ * convention as /api/structured, plus x-embed-model when configured). Only a
+ * 501 (provider PERMANENTLY has no embeddings API — the claude case) returns
+ * null, which the caller treats as a silent no-op with no retry. Everything
+ * transient — network errors, 429, 5xx — THROWS, so augmentWithEmbeddingEdges
+ * leaves embeddingsApplied false and the next cascade retries.
  */
 export const fetchEmbeddings: EmbedFn = async (texts, config) => {
-  try {
-    const res = await fetch('/api/embed', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': config.apiKey,
-        'x-provider': config.provider,
-        'x-model': config.model,
-        ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
-      },
-      body: JSON.stringify({ texts }),
-    })
-    if (!res.ok) return null
-    const data = await res.json()
-    return Array.isArray(data.vectors) ? (data.vectors as number[][]) : null
-  } catch {
-    return null
-  }
+  const res = await fetch('/api/embed', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': config.apiKey,
+      'x-provider': config.provider,
+      'x-model': config.model,
+      ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
+      ...(config.embedModel ? { 'x-embed-model': config.embedModel } : {}),
+    },
+    body: JSON.stringify({ texts }),
+  })
+  if (res.status === 501) return null // permanent: provider has no embeddings API
+  if (!res.ok) throw new Error(`embed request failed: ${res.status}`) // transient: retried
+  const data = await res.json()
+  return Array.isArray(data.vectors) ? (data.vectors as number[][]) : null
 }
 
+/**
+ * Cosine similarity. A dimension mismatch (vectors from different embedding
+ * models sharing the cache window) returns 0 — never Math.min truncation,
+ * which would silently compare incompatible spaces.
+ */
 function cosine(a: number[], b: number[]): number {
-  const len = Math.min(a.length, b.length)
+  if (a.length !== b.length) return 0
+  const len = a.length
   let dot = 0
   let normA = 0
   let normB = 0
@@ -84,11 +107,13 @@ function isGraphAdjacent(graph: DocGraph, a: string, b: string): boolean {
 }
 
 /**
- * Mutates `graph` in place: embeds all textblocks (cache-aware, one batched
- * call for the misses) and adds `duplicates` edges between non-adjacent pairs
- * above the similarity threshold. A null embed result (unsupported/failed
- * transport) marks the pass applied with zero edges; a thrown scripted embed
- * is swallowed and left unapplied for a later retry. Never throws.
+ * Mutates `graph` in place: embeds the first EMBED_MAX_BLOCKS textblocks in
+ * doc order (cache-aware, one batched call for the misses; beyond the cap the
+ * graph is marked embeddingsPartial and warns) and adds `duplicates` edges
+ * between non-adjacent pairs above the similarity threshold. A null embed
+ * result (provider permanently unsupported) marks the pass applied with zero
+ * edges; a thrown embed (transient failure) is swallowed and left unapplied
+ * for a later retry. Never throws.
  */
 export async function augmentWithEmbeddingEdges(
   graph: DocGraph,
@@ -101,8 +126,20 @@ export async function augmentWithEmbeddingEdges(
     return
   }
 
-  const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
-  const hashOf = (blockId: string) => graph.blockHashes.get(blockId) ?? blockId
+  const orderedAll = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
+  const ordered = orderedAll.slice(0, EMBED_MAX_BLOCKS)
+  if (orderedAll.length > EMBED_MAX_BLOCKS) {
+    const skipped = orderedAll.slice(EMBED_MAX_BLOCKS)
+    graph.embeddingsPartial = true
+    console.warn(
+      `docGraph: embedding pass block cap hit — ${skipped.length} of ${orderedAll.length} blocks ` +
+        `(from [${skipped[0].blockId}] onward) were not embedded; graph marked embeddingsPartial`,
+    )
+  }
+  // Vectors from different providers/models live in incompatible spaces —
+  // key the cache by both so a settings switch re-embeds instead of reusing.
+  const hashOf = (blockId: string) =>
+    `${config.provider}:${config.embedModel ?? 'default'}:${graph.blockHashes.get(blockId) ?? blockId}`
 
   const missing = ordered.filter((n) => !vectorCache.has(hashOf(n.blockId)))
   if (missing.length > 0) {

--- a/src/lib/graphrag/embedEdges.ts
+++ b/src/lib/graphrag/embedEdges.ts
@@ -1,0 +1,158 @@
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { DocGraph, DocGraphEdge } from './docGraph'
+
+/**
+ * Embedding edge source — paraphrase recall the extractors and the link_blocks
+ * pass both miss. Every textblock is embedded (one batched call, vectors
+ * cached by per-block content hash), and NON-adjacent block pairs above a
+ * cosine-similarity threshold gain a `duplicates` edge with source
+ * 'embedding'. Graph-adjacent pairs and doc-adjacent neighbors are skipped:
+ * the former are already connected, the latter are trivially related prose.
+ *
+ * Same failure-swallowing contract as the LLM pass: unsupported providers
+ * (Anthropic has no embeddings API) and any failure degrade to fewer edges —
+ * never an error thrown into the cascade.
+ */
+
+/** null = embeddings unsupported for this provider, or the call failed. */
+export type EmbedFn = (texts: string[], config: LLMConfig) => Promise<number[][] | null>
+
+const SIMILARITY_THRESHOLD = 0.82
+
+// Module-level vector cache keyed by per-block content hash — an incremental
+// rebuild only embeds blocks whose text actually changed.
+const VECTOR_CACHE_MAX = 500
+const vectorCache = new Map<string, number[]>()
+
+function cacheVector(hash: string, vector: number[]): void {
+  vectorCache.delete(hash)
+  vectorCache.set(hash, vector)
+  while (vectorCache.size > VECTOR_CACHE_MAX) {
+    const oldest = vectorCache.keys().next().value
+    if (oldest === undefined) break
+    vectorCache.delete(oldest)
+  }
+}
+
+/** Test hygiene: clear the module-level vector cache. */
+export function clearEmbeddingVectorCache(): void {
+  vectorCache.clear()
+}
+
+/**
+ * Default EmbedFn: the provider-agnostic /api/embed route (same header
+ * convention as /api/structured). A 501 (provider has no embeddings API) and
+ * every other failure return null — the caller treats it as a silent no-op.
+ */
+export const fetchEmbeddings: EmbedFn = async (texts, config) => {
+  try {
+    const res = await fetch('/api/embed', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': config.apiKey,
+        'x-provider': config.provider,
+        'x-model': config.model,
+        ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
+      },
+      body: JSON.stringify({ texts }),
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    return Array.isArray(data.vectors) ? (data.vectors as number[][]) : null
+  } catch {
+    return null
+  }
+}
+
+function cosine(a: number[], b: number[]): number {
+  const len = Math.min(a.length, b.length)
+  let dot = 0
+  let normA = 0
+  let normB = 0
+  for (let i = 0; i < len; i++) {
+    dot += a[i] * b[i]
+    normA += a[i] * a[i]
+    normB += b[i] * b[i]
+  }
+  if (normA === 0 || normB === 0) return 0
+  return dot / Math.sqrt(normA * normB)
+}
+
+function isGraphAdjacent(graph: DocGraph, a: string, b: string): boolean {
+  return (graph.adjacency.get(a) ?? []).some((e) => e.from === b || e.to === b)
+}
+
+/**
+ * Mutates `graph` in place: embeds all textblocks (cache-aware, one batched
+ * call for the misses) and adds `duplicates` edges between non-adjacent pairs
+ * above the similarity threshold. A null embed result (unsupported/failed
+ * transport) marks the pass applied with zero edges; a thrown scripted embed
+ * is swallowed and left unapplied for a later retry. Never throws.
+ */
+export async function augmentWithEmbeddingEdges(
+  graph: DocGraph,
+  config: LLMConfig,
+  embed: EmbedFn = fetchEmbeddings,
+): Promise<void> {
+  if (graph.embeddingsApplied) return
+  if (graph.nodes.size === 0) {
+    graph.embeddingsApplied = true
+    return
+  }
+
+  const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
+  const hashOf = (blockId: string) => graph.blockHashes.get(blockId) ?? blockId
+
+  const missing = ordered.filter((n) => !vectorCache.has(hashOf(n.blockId)))
+  if (missing.length > 0) {
+    let vectors: number[][] | null
+    try {
+      vectors = await embed(missing.map((n) => n.text), config)
+    } catch {
+      return // transport blew up — leave unapplied so a later build retries
+    }
+    if (!vectors || vectors.length !== missing.length) {
+      // Unsupported provider or malformed response — silent no-op, no retry loop.
+      graph.embeddingsApplied = true
+      return
+    }
+    missing.forEach((n, i) => cacheVector(hashOf(n.blockId), vectors[i]))
+  }
+
+  const vecs = ordered.map((n) => vectorCache.get(hashOf(n.blockId)))
+  const added: DocGraphEdge[] = []
+  for (let i = 0; i < ordered.length; i++) {
+    const va = vecs[i]
+    if (!va) continue
+    for (let j = i + 1; j < ordered.length; j++) {
+      if (j === i + 1) continue // doc-adjacent neighbors — trivially related
+      const vb = vecs[j]
+      if (!vb) continue
+      if (isGraphAdjacent(graph, ordered[i].blockId, ordered[j].blockId)) continue
+      const sim = cosine(va, vb)
+      if (sim <= SIMILARITY_THRESHOLD) continue
+      added.push({
+        from: ordered[i].blockId,
+        to: ordered[j].blockId,
+        type: 'duplicates',
+        source: 'embedding',
+        evidence: `semantic similarity ${sim.toFixed(2)}`,
+      })
+    }
+  }
+
+  if (added.length > 0) {
+    graph.edges.push(...added)
+    const push = (id: string, edge: DocGraphEdge) => {
+      const list = graph.adjacency.get(id)
+      if (list) list.push(edge)
+      else graph.adjacency.set(id, [edge])
+    }
+    for (const edge of added) {
+      push(edge.from, edge)
+      push(edge.to, edge)
+    }
+  }
+  graph.embeddingsApplied = true
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -10,6 +10,12 @@ export interface LLMConfig {
   apiKey: string
   model: string
   baseUrl?: string
+  /**
+   * Embedding model for the doc-graph paraphrase pass (sent as x-embed-model
+   * to /api/embed). No UI yet — Wave C exposes it; unset uses the route's
+   * per-provider default.
+   */
+  embedModel?: string
 }
 
 export const PROVIDER_MODELS: Record<LLMProvider, { label: string; value: string }[]> = {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -68,9 +68,16 @@ interface SettingsState {
   llmConfig: LLMConfig
   whisperApiKey: string
   showApiKeyModal: boolean
+  /**
+   * Embedding-based paraphrase edges in the doc graph (default on). Silently
+   * inert for providers without an embeddings API (Anthropic). UI toggle
+   * lands in Wave C — the persisted field ships first.
+   */
+  embeddingsEnabled: boolean
   setLLMConfig: (config: Partial<LLMConfig>) => void
   setWhisperKey: (key: string) => void
   setShowApiKeyModal: (show: boolean) => void
+  setEmbeddingsEnabled: (enabled: boolean) => void
   hasKeys: () => boolean
 }
 
@@ -85,10 +92,12 @@ export const useSettingsStore = create<SettingsState>()(
       },
       whisperApiKey: '',
       showApiKeyModal: false,
+      embeddingsEnabled: true,
       setLLMConfig: (config) =>
         set((s) => ({ llmConfig: { ...s.llmConfig, ...config } })),
       setWhisperKey: (key) => set({ whisperApiKey: key }),
       setShowApiKeyModal: (show) => set({ showApiKeyModal: show }),
+      setEmbeddingsEnabled: (enabled) => set({ embeddingsEnabled: enabled }),
       hasKeys: () => {
         const s = get()
         // Ollama runs locally — no API key needed


### PR DESCRIPTION
## Why

The dependency graph rebuilt from scratch on every content change (whole-doc hash), silently skipped the LLM extraction pass entirely above 200 blocks, and had no way to catch paraphrase dependencies ("a tenth of a second" ↔ "100ms p99") that regexes can't see. Recall on exactly the long-document use case the cascade exists for depended on it.

## What

**Per-block incremental graph updates** (`docGraph.ts`): per-block FNV hashes; on rebuild, the best prior graph (>50% blockHash overlap) donates its LLM edges between unchanged blocks, and re-extraction runs only over changed blocks + their 1-hop neighborhood — **seeded from the prior graph's adjacency**, so editing an endpoint of an LLM-only edge re-lists the far endpoint instead of permanently destroying the link (the sharpest adversarial-review finding: post-drop adjacency seeding caused monotonic, compounding graph decay that 389 green tests couldn't see because the only 1-hop test went through a deterministic edge).

**Honest coverage instead of a silent skip**: single whole-doc extraction call up to **150 blocks** (preserving the old every-pair-co-visible recall on the core 5–20-page case — unconditional chunking would have silently regressed it); above 150, parallel (`Promise.allSettled`) chunked calls (≤40 blocks, 4-block overlap, max 8) with an explicit `llmPartial` flag and a warn naming what was skipped. No silent truncation at any size.

**Embeddings edge source** (`/api/embed` + `embedEdges.ts`): provider-agnostic (OpenAI-compatible + Ollama; bare Claude → 501 treated as a clean permanent no-op — Anthropic has no embeddings API; `baseUrl` override is the proxy escape hatch). Cosine > 0.82 between non-adjacent blocks → `duplicates`/`embedding` edges. Hardened per review: transient failures (network/429/5xx) **throw and retry next cascade** instead of permanently disabling; vector cache keyed by provider+model+blockHash (a provider switch can no longer compare vectors from different embedding spaces — dimension mismatches also produce no edge instead of truncated garbage); 300-block cap with an `embeddingsPartial` flag.

**Privacy posture unchanged**: the background typing rebuild skips both the LLM and embeddings passes — document text still only leaves the machine inside user-initiated cascades, and only to the provider already configured.

**Heading context in cascade payloads**: candidate lines carry their `§ Heading › Subheading` path.

## Testing

398 passed + 10 skipped (was 370 + 10 on main; +28), typecheck/lint/build clean. Adversarial review ran pre-PR (verdict NO-MERGE → all findings fixed in `a7fa655`), with regression tests pinning: the far-endpoint re-listing, the 150/151-block single-call boundary, transient-vs-permanent embed failure semantics, provider-switch re-embedding, and the 300-block cap.

## Notes for reviewers

- `settingsStore` gains `embeddingsEnabled` (default on; UI toggle ships in Wave C) and optional `embedModel`.
- The 0.82 similarity threshold is uncalibrated across embedding models — commented as the tuning point.
- Cross-chunk links beyond the 4-block overlap remain unproposable on >150-block docs; embeddings backfill `duplicates` only. Documented trade, not a silent one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
