### PR TITLE
Cascade v2 Wave C: trust affordances, enforced flow-state buffering, spend controls, review-surface fixes

### DIFF
--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -4,9 +4,14 @@ import { useState, useCallback, useEffect } from 'react'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { TextSelection } from 'prosemirror-state'
-import { setProposedEdits, clearProposedEdits } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import {
+  setProposedEdits,
+  clearProposedEdits,
+  revealProposedEdits,
+  getProposedAnchors,
+} from '@/lib/prosemirror/plugins/proposedChangePlugin'
 import { readLinePluginKey } from '@/lib/prosemirror/plugins/readLinePlugin'
-import { partitionCascadeReveal, cascadeBreakpointPos } from '@/lib/annotations/cascadeReveal'
+import { partitionCascadeReveal, cascadeBreakpointPos, pollCascadeReveal } from '@/lib/annotations/cascadeReveal'
 import { ResolutionActions } from './ResolutionActions'
 import { CascadeList } from './CascadeList'
 import { ConversationThread } from './ConversationThread'
@@ -61,14 +66,17 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
   // "call out" those regions in the editor; clear them once it deactivates or the
   // edits are applied/dismissed (status leaves 'resolved'). Only the active card
   // touches decorations, so inactive cards never dispatch.
-  // Flow-state buffering (PRD): the primary edit and any cascade in the
-  // already-read region reveal immediately; cascades BELOW the read-line are
-  // held until the read-line high-water mark crosses the end of the primary
-  // edit's block (a coarse breakpoint). The read-line only advances via
-  // editor transactions, so a light poll of the plugin state is the simplest
-  // robust observer (no plugin-view registration, no extra store). A
-  // highWaterMark of 0 — no reading tracked yet — reveals everything
-  // immediately (see partitionCascadeReveal).
+  // Flow-state buffering (PRD, reveal-flag design): the plugin ALWAYS receives
+  // the FULL edit set so every edit has a live apply-time anchor from the first
+  // dispatch; cascades BELOW the read-line are stored revealed:false (no
+  // decoration yet) and flipped visible — statuses untouched — once the
+  // read-line high-water mark crosses the end of the primary edit's block (a
+  // coarse breakpoint). The read-line only advances via editor transactions,
+  // so a light poll of the plugin state is the simplest robust observer (no
+  // plugin-view registration, no extra store). Each poll tick reads LIVE
+  // mapped anchors (pollCascadeReveal) so typing during the hold shifts the
+  // partition and the breakpoint correctly. A highWaterMark of 0 — no reading
+  // tracked yet — reveals everything immediately (see partitionCascadeReveal).
   const reviewEdits = annotation.resolution?.edits
   useEffect(() => {
     if (!view || !isActive) return
@@ -76,15 +84,17 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
       const primary = reviewEdits.find((e) => e.relation === 'primary')
       const breakpoint = cascadeBreakpointPos(view.state.doc, primary)
       const highWaterMark = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
-      const { reveal, held } = partitionCascadeReveal(reviewEdits, highWaterMark, breakpoint)
-      setProposedEdits(view, reveal)
+      const { held } = partitionCascadeReveal(reviewEdits, highWaterMark, breakpoint)
+      setProposedEdits(view, reviewEdits, held.map((e) => e.id))
       if (held.length > 0) {
         const timer = setInterval(() => {
-          const mark = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
-          if (mark >= breakpoint) {
-            clearInterval(timer)
-            setProposedEdits(view, reviewEdits)
+          const ids = pollCascadeReveal(view.state)
+          if (ids.length > 0) revealProposedEdits(view, ids)
+          let anyHeld = false
+          for (const a of getProposedAnchors(view.state).values()) {
+            if (!a.revealed) { anyHeld = true; break }
           }
+          if (!anyHeld) clearInterval(timer)
         }, 500)
         return () => {
           clearInterval(timer)

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -5,6 +5,8 @@ import { useAnnotationStore } from '@/stores/annotationStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { TextSelection } from 'prosemirror-state'
 import { setProposedEdits, clearProposedEdits } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import { readLinePluginKey } from '@/lib/prosemirror/plugins/readLinePlugin'
+import { partitionCascadeReveal, cascadeBreakpointPos } from '@/lib/annotations/cascadeReveal'
 import { ResolutionActions } from './ResolutionActions'
 import { CascadeList } from './CascadeList'
 import { ConversationThread } from './ConversationThread'
@@ -59,11 +61,36 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
   // "call out" those regions in the editor; clear them once it deactivates or the
   // edits are applied/dismissed (status leaves 'resolved'). Only the active card
   // touches decorations, so inactive cards never dispatch.
+  // Flow-state buffering (PRD): the primary edit and any cascade in the
+  // already-read region reveal immediately; cascades BELOW the read-line are
+  // held until the read-line high-water mark crosses the end of the primary
+  // edit's block (a coarse breakpoint). The read-line only advances via
+  // editor transactions, so a light poll of the plugin state is the simplest
+  // robust observer (no plugin-view registration, no extra store). A
+  // highWaterMark of 0 — no reading tracked yet — reveals everything
+  // immediately (see partitionCascadeReveal).
   const reviewEdits = annotation.resolution?.edits
   useEffect(() => {
     if (!view || !isActive) return
     if (annotation.status === 'resolved' && reviewEdits && reviewEdits.length > 1) {
-      setProposedEdits(view, reviewEdits)
+      const primary = reviewEdits.find((e) => e.relation === 'primary')
+      const breakpoint = cascadeBreakpointPos(view.state.doc, primary)
+      const highWaterMark = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
+      const { reveal, held } = partitionCascadeReveal(reviewEdits, highWaterMark, breakpoint)
+      setProposedEdits(view, reveal)
+      if (held.length > 0) {
+        const timer = setInterval(() => {
+          const mark = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
+          if (mark >= breakpoint) {
+            clearInterval(timer)
+            setProposedEdits(view, reviewEdits)
+          }
+        }, 500)
+        return () => {
+          clearInterval(timer)
+          clearProposedEdits(view)
+        }
+      }
     } else {
       clearProposedEdits(view)
     }

--- a/src/components/Annotations/CascadeList.tsx
+++ b/src/components/Annotations/CascadeList.tsx
@@ -1,7 +1,9 @@
 'use client'
 
 import { useEditorStore } from '@/stores/editorStore'
+import { useDocGraphStore } from '@/stores/docGraphStore'
 import { getProposedAnchors, setProposedEditStatus } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import { findEdgePath, formatEdgePath } from '@/lib/graphrag/docGraph'
 import type { Annotation, CascadeSeverity, ProposedEdit, ProposedEditStatus } from '@/lib/annotations/types'
 import { SEVERITY_LABELS, SEVERITY_ORDER } from '@/lib/annotations/types'
 
@@ -42,6 +44,7 @@ function truncate(text: string, max = 80): string {
  */
 export function CascadeList({ annotation }: CascadeListProps) {
   const view = useEditorStore((s) => s.view)
+  const graph = useDocGraphStore((s) => s.graph)
 
   // Only show while the resolution is under review. Once applied/dismissed the
   // plugin anchors are cleared, so live status would be unreadable and the
@@ -57,6 +60,24 @@ export function CascadeList({ annotation }: CascadeListProps) {
   if (cascades.length === 0) return null
 
   const count = cascades.length
+  const primaryBlockId = edits.find((e) => e.relation === 'primary')?.blockId ?? null
+
+  /**
+   * "Why this proposal?" — the graph path linking the primary edit's block to
+   * this cascade's block, e.g. `linked via references ("Total Budget")`.
+   * Returns null (renders nothing) whenever the graph, block ids, or a path
+   * are unavailable — never blocks the row.
+   */
+  const whyLine = (edit: ProposedEdit): string | null => {
+    if (!graph || !primaryBlockId || !edit.blockId) return null
+    try {
+      const path = findEdgePath(graph, primaryBlockId, edit.blockId)
+      if (!path || path.length === 0) return null
+      return `linked via ${formatEdgePath(path)}`
+    } catch {
+      return null
+    }
+  }
 
   /** Read the live (transaction-mapped) status for an edit, else its stored status. */
   const liveStatus = (edit: ProposedEdit): ProposedEditStatus => {
@@ -106,6 +127,7 @@ export function CascadeList({ annotation }: CascadeListProps) {
       <div className="flex flex-col gap-1.5">
         {cascades.map((edit) => {
           const status = liveStatus(edit)
+          const why = whyLine(edit)
           return (
             <div
               key={edit.id}
@@ -135,6 +157,13 @@ export function CascadeList({ annotation }: CascadeListProps) {
                   )}
                 </span>
               </button>
+
+              {/* "Why this proposal?" — graph path from the primary edit's block */}
+              {why && (
+                <p className="mt-0.5 pl-1 text-[10px] font-mono text-ink/50 truncate" title={why}>
+                  {why}
+                </p>
+              )}
 
               {/* Accept / Reject status toggles */}
               <div className="mt-1 flex items-center gap-1 pl-1">

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -13,7 +13,7 @@ import { runCascadeCheck } from '@/lib/graphrag/cascadeCheck'
 import { ingestAnnotationEpisode, ingestEditEpisode } from '@/lib/graphrag/episodeIngestion'
 import { recordHumanDecision, handlerToApprovalAction } from '@/lib/audit/approvalGate'
 import { applyUncertaintyFromLogprobs, applyUncertaintyFromFlags } from '@/lib/ai/uncertainty'
-import { getProposedAnchors } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import { getProposedAnchors, setProposedEditStatus } from '@/lib/prosemirror/plugins/proposedChangePlugin'
 import { applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
@@ -452,6 +452,12 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       <SemanticCommitModal
         changes={commitChanges}
         initialRejected={commitInitialRejected}
+        onToggle={(id, status) => {
+          // Modal → plugin write-back: the plugin's status is the single
+          // pre-apply source of truth across all review surfaces. No-ops for
+          // ids the plugin doesn't track (single-edit fallback rows).
+          if (view) setProposedEditStatus(view, id, status)
+        }}
         onConfirm={(ids) => applyConfirmedEdit(ids)}
         onCancel={() => { setShowDiffModal(false); setPendingHandler(null) }}
         provocation={annotation.resolution?.provocation}

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { useChangesStore } from '@/stores/changesStore'
@@ -14,6 +14,11 @@ import { ingestAnnotationEpisode, ingestEditEpisode } from '@/lib/graphrag/episo
 import { recordHumanDecision, handlerToApprovalAction } from '@/lib/audit/approvalGate'
 import { applyUncertaintyFromLogprobs, applyUncertaintyFromFlags } from '@/lib/ai/uncertainty'
 import { getProposedAnchors, setProposedEditStatus } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import {
+  openCommitReview,
+  restoreCommitReview,
+  type CommitStatusSnapshot,
+} from '@/lib/annotations/commitStatusSnapshot'
 import { applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
@@ -33,6 +38,9 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   const [pendingHandler, setPendingHandler] = useState<string | null>(null)
   const [showTweakInput, setShowTweakInput] = useState(false)
   const [tweakText, setTweakText] = useState('')
+  // Plugin statuses at modal-open time — cancel restores these so an
+  // abandoned review session never leaks its toggles into the inline surfaces.
+  const commitSnapshotRef = useRef<CommitStatusSnapshot | null>(null)
 
   if (!annotation.resolution) return null
 
@@ -262,6 +270,17 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     setPendingHandler(null)
   }
 
+  // Open the commit modal: snapshot plugin statuses and seed the modal's
+  // optional-severity pre-rejections into the plugin (symmetric seeding — all
+  // review surfaces agree the moment the modal opens). Cancel restores the
+  // snapshot; confirm keeps the live statuses.
+  const openCommitModal = () => {
+    const edits = annotation.resolution?.edits
+    commitSnapshotRef.current =
+      view && edits && edits.length > 1 ? openCommitReview(view, edits) : null
+    setShowDiffModal(true)
+  }
+
   const handleAction = async (handler: string) => {
     // Log human oversight decision if we have an audit trail (non-blocking)
     const auditId = annotation.resolution?.auditId
@@ -278,7 +297,7 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         const edit = annotation.resolution?.suggestedEdit
         if (edit && view) {
           setPendingHandler(handler)
-          setShowDiffModal(true)
+          openCommitModal()
         }
         break
       }
@@ -289,7 +308,7 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         if (edit && view) {
           // Has a suggestedEdit — show diff modal
           setPendingHandler(handler)
-          setShowDiffModal(true)
+          openCommitModal()
         } else if (annotation.resolution && view) {
           // No suggestedEdit (ask/dig/flag) — insert resolution content as new paragraph after annotation
           const insertPos = Math.min(annotation.anchor.to, view.state.doc.content.size)
@@ -458,8 +477,21 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           // ids the plugin doesn't track (single-edit fallback rows).
           if (view) setProposedEditStatus(view, id, status)
         }}
-        onConfirm={(ids) => applyConfirmedEdit(ids)}
-        onCancel={() => { setShowDiffModal(false); setPendingHandler(null) }}
+        onConfirm={(ids) => {
+          // Confirm: the live statuses stand — drop the snapshot, no restore.
+          commitSnapshotRef.current = null
+          applyConfirmedEdit(ids)
+        }}
+        onCancel={() => {
+          // Cancel: restore the open-time statuses so modal toggles (and the
+          // open-time optional pre-rejections) don't leak into inline surfaces.
+          if (view && commitSnapshotRef.current) {
+            restoreCommitReview(view, commitSnapshotRef.current)
+          }
+          commitSnapshotRef.current = null
+          setShowDiffModal(false)
+          setPendingHandler(null)
+        }}
         provocation={annotation.resolution?.provocation}
         isHighRisk={!!annotation.resolution?.usedMADS}
       />

--- a/src/components/Editor/ProposedEditControl.tsx
+++ b/src/components/Editor/ProposedEditControl.tsx
@@ -8,6 +8,8 @@ import {
   getProposedAnchors,
   setProposedEditStatus,
 } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import { useDocGraphStore } from '@/stores/docGraphStore'
+import { findEdgePath, formatEdgePath } from '@/lib/graphrag/docGraph'
 import { SEVERITY_LABELS } from '@/lib/annotations/types'
 
 interface ControlPosition {
@@ -24,9 +26,28 @@ interface ControlPosition {
 export function ProposedEditControl() {
   const activeId = useProposedEditUiStore((s) => s.activeId)
   const view = useEditorStore((s) => s.view)
+  const graph = useDocGraphStore((s) => s.graph)
   const [position, setPosition] = useState<ControlPosition | null>(null)
 
   const anchor = activeId && view ? getProposedAnchors(view.state).get(activeId) : undefined
+
+  // "Why this proposal?" — graph path from the primary edit's block to this
+  // cascade's block. Null (renders nothing) whenever the graph or block ids
+  // are unavailable — never blocks the card.
+  let whyLine: string | null = null
+  if (graph && view && anchor && anchor.relation === 'cascade' && anchor.blockId) {
+    const primary = [...getProposedAnchors(view.state).values()].find(
+      (a) => a.relation === 'primary',
+    )
+    if (primary?.blockId) {
+      try {
+        const path = findEdgePath(graph, primary.blockId, anchor.blockId)
+        if (path && path.length > 0) whyLine = `linked via ${formatEdgePath(path)}`
+      } catch {
+        whyLine = null
+      }
+    }
+  }
 
   useEffect(() => {
     if (!anchor || !view) {
@@ -106,6 +127,11 @@ export function ProposedEditControl() {
         {anchor.evidence && (
           <p className="proposed-edit-control-evidence">
             &ldquo;{anchor.evidence.quotedText}&rdquo; · {anchor.evidence.edgeType}
+          </p>
+        )}
+        {whyLine && (
+          <p className="proposed-edit-control-evidence" title={whyLine}>
+            {whyLine}
           </p>
         )}
         <div className="proposed-edit-control-actions">

--- a/src/components/Editor/SemanticCommitModal.tsx
+++ b/src/components/Editor/SemanticCommitModal.tsx
@@ -32,6 +32,13 @@ interface SemanticCommitModalProps {
   isHighRisk?: boolean
   /** Change ids already rejected inline — pre-toggled off so the two surfaces agree. */
   initialRejected?: Record<string, boolean>
+  /**
+   * Called when the user flips a change's Accept/Reject toggle, so the caller
+   * can write the status back to the pre-apply source of truth (the
+   * proposedChange plugin) and keep the inline control, CascadeList, and this
+   * modal in agreement.
+   */
+  onToggle?: (id: string, status: 'accepted' | 'rejected') => void
 }
 
 /**
@@ -50,6 +57,7 @@ export function SemanticCommitModal({
   provocation,
   isHighRisk = false,
   initialRejected,
+  onToggle,
 }: SemanticCommitModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const [acknowledged, setAcknowledged] = useState(false)
@@ -75,8 +83,12 @@ export function SemanticCommitModal({
         ? `Apply ${acceptedIds.length} change${acceptedIds.length !== 1 ? 's' : ''}`
         : 'Apply All Changes'
 
-  const toggle = (id: string) =>
-    setRejected((r) => ({ ...r, [id]: !r[id] }))
+  // Flip a change and mirror the new status into the plugin (single pre-apply
+  // source of truth across inline control, CascadeList, and this modal).
+  const setChoice = (id: string, status: 'accepted' | 'rejected') => {
+    setRejected((r) => ({ ...r, [id]: status === 'rejected' }))
+    onToggle?.(id, status)
+  }
 
   return (
     <div
@@ -121,7 +133,9 @@ export function SemanticCommitModal({
                         </span>
                       )}
                       <button
-                        onClick={() => !isRejected || toggle(change.id)}
+                        onClick={() => {
+                          if (isRejected) setChoice(change.id, 'accepted')
+                        }}
                         className={`px-2 py-0.5 text-xs font-medium rounded border transition-colors ${
                           !isRejected
                             ? 'border-green-400 bg-green-50 text-green-700'
@@ -131,7 +145,9 @@ export function SemanticCommitModal({
                         Accept
                       </button>
                       <button
-                        onClick={() => isRejected || toggle(change.id)}
+                        onClick={() => {
+                          if (!isRejected) setChoice(change.id, 'rejected')
+                        }}
                         className={`px-2 py-0.5 text-xs font-medium rounded border transition-colors ${
                           isRejected
                             ? 'border-red-400 bg-red-50 text-red-700'

--- a/src/components/Layout/StatusBar.tsx
+++ b/src/components/Layout/StatusBar.tsx
@@ -3,6 +3,35 @@
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
+import { useDocGraphStore } from '@/stores/docGraphStore'
+
+/** Chip state for the document-map (doc graph) build lifecycle. */
+function graphChip(
+  status: 'idle' | 'building' | 'ready',
+  graph: { llmApplied: boolean; llmPartial: boolean; embeddingsPartial: boolean } | null,
+): { label: string; title: string } | null {
+  if (status === 'building') {
+    return {
+      label: 'graph: building…',
+      title: 'Mapping how sections of your document relate to each other.',
+    }
+  }
+  if (!graph) return null
+  const partial = graph.llmPartial || graph.embeddingsPartial
+  const partialNote = partial
+    ? ' Some sections could not be analyzed, so a few connections may be missing.'
+    : ''
+  if (graph.llmApplied) {
+    return {
+      label: `graph: enriched${partial ? ' +partial' : ''}`,
+      title: `The section map includes AI-detected connections between sections.${partialNote}`,
+    }
+  }
+  return {
+    label: `graph: rules only${partial ? ' +partial' : ''}`,
+    title: `The section map only covers explicit cross-references and repeated terms so far. AI-detected connections are added when an annotation is resolved.${partialNote}`,
+  }
+}
 
 export function StatusBar() {
   const provider = useSettingsStore((s) => s.llmConfig.provider)
@@ -11,6 +40,9 @@ export function StatusBar() {
   const annotationCount = useAnnotationStore((s) => s.annotations.length)
   const changeSetCount = useChangesStore((s) => s.changeSets.length)
   const changeCount = useChangesStore((s) => s.entries.filter((e) => !e.undone).length)
+  const graphStatus = useDocGraphStore((s) => s.status)
+  const graph = useDocGraphStore((s) => s.graph)
+  const chip = graphChip(graphStatus, graph)
 
   return (
     <div className="flex items-center justify-between px-4 py-2 border-t border-border/70 bg-white/70 backdrop-blur-sm text-xs font-mono text-muted">
@@ -18,6 +50,11 @@ export function StatusBar() {
         <span className="status-chip px-2.5 py-1 rounded-full">{annotationCount} annotations</span>
         <span className="status-chip px-2.5 py-1 rounded-full">{changeSetCount} change sets</span>
         <span className="status-chip px-2.5 py-1 rounded-full">{changeCount} changes</span>
+        {chip && (
+          <span className="status-chip px-2.5 py-1 rounded-full" title={chip.title}>
+            {chip.label}
+          </span>
+        )}
       </div>
       <div className="flex items-center gap-4">
         <span className={`status-chip px-2.5 py-1 rounded-full ${hasKeys ? 'text-annotation-correction' : 'text-accent'}`}>

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   useSettingsStore,
   type LLMProvider,
@@ -28,6 +28,13 @@ export function ApiKeyModal() {
   const [customModel, setCustomModel] = useState('')
   const [baseUrl, setBaseUrl] = useState(llmConfig.baseUrl ?? PROVIDER_BASE_URLS[llmConfig.provider] ?? '')
   const [wKey, setWKey] = useState(whisperKey)
+  // Spend estimate is module state, not reactive — poll it while the modal is
+  // open so long-lived sessions see the line move without reopening.
+  const [sessionTokens, setSessionTokens] = useState(() => getSessionEstimate())
+  useEffect(() => {
+    const timer = setInterval(() => setSessionTokens(getSessionEstimate()), 2000)
+    return () => clearInterval(timer)
+  }, [])
 
   const handleProviderChange = (p: LLMProvider) => {
     setProvider(p)
@@ -230,7 +237,7 @@ export function ApiKeyModal() {
             </p>
 
             <p className="text-xs font-mono text-muted">
-              This session: ~{getSessionEstimate().toLocaleString()} tokens (estimate)
+              This session: ~{sessionTokens.toLocaleString()} tokens sent (rough estimate; excludes transcription)
             </p>
           </div>
 

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -9,6 +9,7 @@ import {
   PROVIDER_BASE_URLS,
 } from '@/stores/settingsStore'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
+import { getSessionEstimate } from '@/lib/ai/spendEstimate'
 
 export function ApiKeyModal() {
   const llmConfig = useSettingsStore((s) => s.llmConfig)
@@ -16,6 +17,10 @@ export function ApiKeyModal() {
   const setLLMConfig = useSettingsStore((s) => s.setLLMConfig)
   const setWhisperKey = useSettingsStore((s) => s.setWhisperKey)
   const setShow = useSettingsStore((s) => s.setShowApiKeyModal)
+  const judgeEnabled = useSettingsStore((s) => s.judgeEnabled)
+  const setJudgeEnabled = useSettingsStore((s) => s.setJudgeEnabled)
+  const embeddingsEnabled = useSettingsStore((s) => s.embeddingsEnabled)
+  const setEmbeddingsEnabled = useSettingsStore((s) => s.setEmbeddingsEnabled)
 
   const [provider, setProvider] = useState<LLMProvider>(llmConfig.provider)
   const [apiKey, setApiKey] = useState(llmConfig.apiKey)
@@ -56,7 +61,7 @@ export function ApiKeyModal() {
           <button onClick={() => setShow(false)} className="text-muted hover:text-ink text-xl leading-none">&times;</button>
         </div>
 
-        <div className="p-6 space-y-4">
+        <div className="p-6 space-y-4 max-h-[75vh] overflow-y-auto">
           {/* Provider */}
           <div>
             <label className="block text-xs font-mono uppercase tracking-wider text-muted mb-1.5">Provider</label>
@@ -169,6 +174,65 @@ export function ApiKeyModal() {
               <p className="mt-1 text-xs text-muted">Whisper requires an OpenAI API key regardless of your LLM provider.</p>
             </div>
           )}
+
+          {/* AI data & spend */}
+          <div className="pt-4 border-t border-border space-y-3">
+            <h3 className="text-xs font-mono uppercase tracking-wider text-muted">AI data &amp; spend</h3>
+
+            <label className="flex items-start gap-2.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={judgeEnabled}
+                onChange={(e) => setJudgeEnabled(e.target.checked)}
+                className="mt-0.5 accent-ink"
+              />
+              <span className="text-sm text-ink leading-snug">
+                Verify must-severity citations
+                <span className="block text-xs text-muted">
+                  Extra small model call that double-checks each cited conflict before it is
+                  marked &ldquo;must change&rdquo;.
+                </span>
+              </span>
+            </label>
+
+            <label className="flex items-start gap-2.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={embeddingsEnabled}
+                onChange={(e) => setEmbeddingsEnabled(e.target.checked)}
+                className="mt-0.5 accent-ink"
+              />
+              <span className="text-sm text-ink leading-snug">
+                Semantic similarity edges (embeddings)
+                <span className="block text-xs text-muted">
+                  Finds paraphrased duplicates across sections. Requires a provider with an
+                  embeddings API (OpenAI or Ollama).
+                </span>
+              </span>
+            </label>
+
+            <div>
+              <label className="block text-xs font-mono uppercase tracking-wider text-muted mb-1.5">
+                Embedding model <span className="normal-case font-sans text-muted/70">(optional override)</span>
+              </label>
+              <input
+                value={llmConfig.embedModel ?? ''}
+                onChange={(e) => setLLMConfig({ embedModel: e.target.value || undefined })}
+                placeholder="Default: text-embedding-3-small (OpenAI) / nomic-embed-text (Ollama)"
+                className="w-full px-3 py-2 text-sm font-mono border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent/20"
+              />
+            </div>
+
+            <p className="text-xs text-muted leading-relaxed">
+              Document text leaves this machine only when you act: on annotation resolution,
+              cascade analysis, citation verification, and semantic-similarity indexing — never
+              while typing. All calls go only to your configured provider.
+            </p>
+
+            <p className="text-xs font-mono text-muted">
+              This session: ~{getSessionEstimate().toLocaleString()} tokens (estimate)
+            </p>
+          </div>
 
           <button
             onClick={handleSave}

--- a/src/lib/ai/__tests__/client.test.ts
+++ b/src/lib/ai/__tests__/client.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { callLLM, callLLMWithLogprobs, streamLLM, type LLMConfig, type LLMMessage } from '../client'
+import { getSessionEstimate, resetSessionEstimate } from '../spendEstimate'
+
+const config: LLMConfig = { provider: 'claude', apiKey: 'k', model: 'm' }
+const messages: LLMMessage[] = [{ role: 'user', content: 'hello world, count me' }]
+
+beforeEach(() => {
+  resetSessionEstimate()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () =>
+      new Response(JSON.stringify({ content: 'ok', logprobs: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('client spend accounting (soft indicator coverage)', () => {
+  it('callLLM counts the outbound payload chars', async () => {
+    await callLLM(messages, config)
+    expect(getSessionEstimate()).toBeGreaterThan(0)
+  })
+
+  it('callLLMWithLogprobs counts the outbound payload chars', async () => {
+    await callLLMWithLogprobs(messages, config)
+    expect(getSessionEstimate()).toBeGreaterThan(0)
+  })
+
+  it('streamLLM counts the outbound payload chars', async () => {
+    for await (const _chunk of streamLLM(messages, config)) {
+      // drain
+    }
+    expect(getSessionEstimate()).toBeGreaterThan(0)
+  })
+})

--- a/src/lib/ai/__tests__/orchestrator.test.ts
+++ b/src/lib/ai/__tests__/orchestrator.test.ts
@@ -571,6 +571,24 @@ describe('proposeCascadeEdits — relevance judge gating must', () => {
     expect(edits[0].reason).toBe('stale date')
   })
 
+  it('judgeEnabled: false skips the judge stage entirely — severity stays derived', async () => {
+    const state = stateOf(FIXTURE_DOC)
+    let judgeCalled = false
+    const edits = await proposeCascadeEdits(state, primaryOf(FIXTURE_DOC), CONFIG, {
+      graph: buildDeterministicGraph(FIXTURE_DOC),
+      callStructured: scripted([MUST_PROPOSAL]),
+      judgeEnabled: false,
+      judge: async () => {
+        judgeCalled = true
+        return new Map()
+      },
+    })
+    expect(judgeCalled).toBe(false)
+    expect(edits).toHaveLength(1)
+    expect(edits[0].severity).toBe('must')
+    expect(edits[0].reason).toBe('stale date')
+  })
+
   it('never calls the judge when no must survives derivation', async () => {
     const state = stateOf(FIXTURE_DOC)
     let judgeCalled = false

--- a/src/lib/ai/__tests__/spendEstimate.test.ts
+++ b/src/lib/ai/__tests__/spendEstimate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { addEstimate, getSessionEstimate, resetSessionEstimate } from '../spendEstimate'
+
+beforeEach(() => {
+  resetSessionEstimate()
+})
+
+describe('spendEstimate', () => {
+  it('starts at zero', () => {
+    expect(getSessionEstimate()).toBe(0)
+  })
+
+  it('accumulates and converts chars to tokens at ~4 chars/token', () => {
+    addEstimate(400)
+    expect(getSessionEstimate()).toBe(100)
+    addEstimate(400)
+    expect(getSessionEstimate()).toBe(200)
+  })
+
+  it('rounds the token estimate', () => {
+    addEstimate(6) // 1.5 tokens → 2
+    expect(getSessionEstimate()).toBe(2)
+  })
+
+  it('ignores junk input (negative, zero, NaN, Infinity)', () => {
+    addEstimate(-100)
+    addEstimate(0)
+    addEstimate(NaN)
+    addEstimate(Infinity)
+    expect(getSessionEstimate()).toBe(0)
+  })
+
+  it('resets to zero', () => {
+    addEstimate(4000)
+    expect(getSessionEstimate()).toBe(1000)
+    resetSessionEstimate()
+    expect(getSessionEstimate()).toBe(0)
+  })
+})

--- a/src/lib/ai/client.ts
+++ b/src/lib/ai/client.ts
@@ -1,3 +1,5 @@
+import { addEstimate } from './spendEstimate'
+
 export type LLMProvider = 'claude' | 'openai' | 'ollama'
 
 export interface LLMConfig {
@@ -30,6 +32,9 @@ export async function callLLM(
   config: LLMConfig,
   options: LLMRequestOptions = {},
 ): Promise<string> {
+  const body = JSON.stringify({ messages, ...options })
+  // Soft spend indicator (display only) — resolve/classify traffic counts too.
+  addEstimate(body.length)
   const response = await fetch('/api/resolve', {
     method: 'POST',
     headers: {
@@ -39,7 +44,7 @@ export async function callLLM(
       'x-model': config.model,
       ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
     },
-    body: JSON.stringify({ messages, ...options }),
+    body,
   })
 
   if (!response.ok) {
@@ -73,6 +78,8 @@ export async function callLLMWithLogprobs(
   config: LLMConfig,
   options: Omit<LLMRequestOptions, 'stream'> = {},
 ): Promise<LLMResponse> {
+  const body = JSON.stringify({ messages, ...options, logprobs: true })
+  addEstimate(body.length)
   const response = await fetch('/api/resolve', {
     method: 'POST',
     headers: {
@@ -82,7 +89,7 @@ export async function callLLMWithLogprobs(
       'x-model': config.model,
       ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
     },
-    body: JSON.stringify({ messages, ...options, logprobs: true }),
+    body,
   })
 
   if (!response.ok) {
@@ -102,6 +109,8 @@ export async function* streamLLM(
   config: LLMConfig,
   options: LLMRequestOptions = {},
 ): AsyncGenerator<string> {
+  const body = JSON.stringify({ messages, ...options, stream: true })
+  addEstimate(body.length)
   const response = await fetch('/api/resolve', {
     method: 'POST',
     headers: {
@@ -111,7 +120,7 @@ export async function* streamLLM(
       'x-model': config.model,
       ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
     },
-    body: JSON.stringify({ messages, ...options, stream: true }),
+    body,
   })
 
   if (!response.ok) {

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -209,6 +209,21 @@ export interface CascadeOptions {
   maxBlocks?: number
   /** Relevance judge for 'must' candidates; defaults to judgeMustCandidates over callStructured. */
   judge?: JudgeFn
+  /**
+   * Test/caller override for the settings-store citation-verification toggle.
+   * When false the judge stage is skipped entirely — severities stay derived.
+   */
+  judgeEnabled?: boolean
+}
+
+/** User toggle for the citation-verification judge (settings store, default true). */
+async function judgeEnabledFromStore(): Promise<boolean> {
+  try {
+    const { useSettingsStore } = await import('@/stores/settingsStore')
+    return useSettingsStore.getState().judgeEnabled
+  } catch {
+    return true
+  }
 }
 
 /**
@@ -390,6 +405,11 @@ export async function proposeCascadeEdits(
   }
 
   edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+
+  // User toggle ("Verify must-severity citations"): when off, skip the judge
+  // entirely — severities stay derived from graph structure + conflict checks.
+  const judgeOn = opts.judgeEnabled ?? (await judgeEnabledFromStore())
+  if (!judgeOn) return edits
 
   const demoted = await applyRelevanceJudge(
     edits,

--- a/src/lib/ai/spendEstimate.ts
+++ b/src/lib/ai/spendEstimate.ts
@@ -1,0 +1,28 @@
+/**
+ * Soft, session-scoped spend indicator. Every outbound AI payload reports its
+ * character count here (fetchStructured, fetchEmbeddings); the settings panel
+ * shows the running total as an approximate token count (chars / 4 — the
+ * common rough heuristic for English text). Display only: nothing is
+ * enforced, nothing is persisted, and the number is clearly labeled an
+ * estimate. Resets with the page session.
+ */
+
+const CHARS_PER_TOKEN = 4
+
+let sessionChars = 0
+
+/** Record an outbound payload's size in characters. Ignores junk input. */
+export function addEstimate(chars: number): void {
+  if (!Number.isFinite(chars) || chars <= 0) return
+  sessionChars += chars
+}
+
+/** Approximate tokens sent this session (chars / 4, rounded). */
+export function getSessionEstimate(): number {
+  return Math.round(sessionChars / CHARS_PER_TOKEN)
+}
+
+/** Test hygiene / explicit reset. */
+export function resetSessionEstimate(): void {
+  sessionChars = 0
+}

--- a/src/lib/ai/structuredClient.ts
+++ b/src/lib/ai/structuredClient.ts
@@ -1,4 +1,5 @@
 import type { LLMConfig } from '@/stores/settingsStore'
+import { addEstimate } from '@/lib/ai/spendEstimate'
 
 /**
  * Injectable client for the provider-agnostic `/api/structured` tool-calling
@@ -92,6 +93,10 @@ export async function fetchWithRetry(
 }
 
 export const fetchStructured: CallStructuredFn = async (req, config) => {
+  const body = JSON.stringify(req)
+  // Soft spend indicator (display only) — count the outbound payload once,
+  // not per retry: retries re-send the same content.
+  addEstimate(body.length)
   const res = await fetchWithRetry(`${structuredBaseUrl}/api/structured`, {
     method: 'POST',
     headers: {
@@ -101,7 +106,7 @@ export const fetchStructured: CallStructuredFn = async (req, config) => {
       'x-model': config.model,
       ...(config.baseUrl ? { 'x-base-url': config.baseUrl } : {}),
     },
-    body: JSON.stringify(req),
+    body,
   })
   const data = await res.json()
   return { toolCalls: Array.isArray(data.toolCalls) ? data.toolCalls : [] }

--- a/src/lib/annotations/__tests__/cascadeReveal.test.ts
+++ b/src/lib/annotations/__tests__/cascadeReveal.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { schema } from '@/lib/prosemirror/schema'
+import { partitionCascadeReveal, cascadeBreakpointPos } from '../cascadeReveal'
+import type { ProposedEdit } from '../types'
+
+function edit(overrides: Partial<ProposedEdit>): ProposedEdit {
+  return {
+    id: 'pe_x',
+    from: 0,
+    to: 5,
+    newText: 'new',
+    reason: 'test',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: 'old',
+    severity: 'probably',
+    evidence: null,
+    ...overrides,
+  }
+}
+
+const primary = edit({ id: 'pe_primary', relation: 'primary', from: 10, to: 20, severity: 'must' })
+const cascadeAbove = edit({ id: 'pe_above', from: 30, to: 40 })
+const cascadeBelow = edit({ id: 'pe_below', from: 200, to: 210 })
+const all = [primary, cascadeAbove, cascadeBelow]
+
+describe('partitionCascadeReveal', () => {
+  it('highWaterMark 0 (no reading tracked yet) reveals everything immediately', () => {
+    // Deliberate: fresh sessions and headless flows have no reading signal —
+    // holding cascades behind a mark that may never move would hide review UI.
+    const { reveal, held } = partitionCascadeReveal(all, 0, 25)
+    expect(reveal).toEqual(all)
+    expect(held).toEqual([])
+  })
+
+  it('high-water mark past the breakpoint reveals everything', () => {
+    const { reveal, held } = partitionCascadeReveal(all, 25, 25)
+    expect(reveal).toEqual(all)
+    expect(held).toEqual([])
+  })
+
+  it('holds below-read-line cascades, reveals primary + already-read cascades', () => {
+    // Reader is at 100: primary (always) and the cascade at 30 (already read —
+    // must flag) reveal; the cascade at 200 is held for the breakpoint.
+    const { reveal, held } = partitionCascadeReveal(all, 100, 300)
+    expect(reveal.map((e) => e.id)).toEqual(['pe_primary', 'pe_above'])
+    expect(held.map((e) => e.id)).toEqual(['pe_below'])
+  })
+
+  it('primary is always revealed even when below the read line', () => {
+    const farPrimary = edit({ id: 'pe_p2', relation: 'primary', from: 500, to: 510 })
+    const { reveal, held } = partitionCascadeReveal([farPrimary, cascadeBelow], 100, 600)
+    expect(reveal.map((e) => e.id)).toEqual(['pe_p2'])
+    expect(held.map((e) => e.id)).toEqual(['pe_below'])
+  })
+
+  it('cascade exactly at the high-water mark counts as unread (held)', () => {
+    const at = edit({ id: 'pe_at', from: 100, to: 110 })
+    const { held } = partitionCascadeReveal([primary, at], 100, 300)
+    expect(held.map((e) => e.id)).toEqual(['pe_at'])
+  })
+})
+
+describe('cascadeBreakpointPos', () => {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('first paragraph')]),
+    schema.node('paragraph', { blockId: 'b2' }, [schema.text('second paragraph')]),
+  ])
+  // b1: pos 0, nodeSize 17 → content end 16. b2 starts at 17.
+
+  it('uses the primary blockId to find the block content end', () => {
+    const pos = cascadeBreakpointPos(doc, { to: 3, blockId: 'b1' })
+    expect(pos).toBe(16)
+  })
+
+  it('falls back to resolving the edit position when blockId is missing', () => {
+    const pos = cascadeBreakpointPos(doc, { to: 3 })
+    expect(pos).toBe(16)
+  })
+
+  it('falls back to resolving when the blockId no longer exists', () => {
+    const pos = cascadeBreakpointPos(doc, { to: 20, blockId: 'gone' })
+    // Position 20 is inside b2 (content 18..34).
+    expect(pos).toBe(34)
+  })
+
+  it('returns 0 (reveal immediately) when there is no primary', () => {
+    expect(cascadeBreakpointPos(doc, undefined)).toBe(0)
+  })
+
+  it('clamps out-of-range positions instead of throwing', () => {
+    const pos = cascadeBreakpointPos(doc, { to: 9999 })
+    expect(typeof pos).toBe('number')
+  })
+})

--- a/src/lib/annotations/__tests__/commitStatusSnapshot.test.ts
+++ b/src/lib/annotations/__tests__/commitStatusSnapshot.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import {
+  createProposedChangePlugin,
+  setProposedEdits,
+  setProposedEditStatus,
+  getProposedAnchors,
+} from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import { openCommitReview, restoreCommitReview } from '../commitStatusSnapshot'
+import type { ProposedEdit } from '../types'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+function mount(doc: PMNode): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const state = EditorState.create({ schema, doc, plugins: [createProposedChangePlugin()] })
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      const newState = view.state.apply(transaction)
+      view.updateState(newState)
+    },
+  })
+  return view
+}
+
+function edit(overrides: Partial<ProposedEdit>): ProposedEdit {
+  return {
+    id: 'pe_1',
+    from: 1,
+    to: 2,
+    newText: 'replacement',
+    reason: 'test',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: 'target',
+    severity: 'probably',
+    evidence: null,
+    ...overrides,
+  }
+}
+
+// doc: b1 "alpha beta gamma" — "alpha" 1..6, "beta" 7..11, "gamma" 12..17.
+const doc = schema.node('doc', null, [p('b1', 'alpha beta gamma')])
+
+const edits: ProposedEdit[] = [
+  edit({ id: 'pe_primary', from: 1, to: 6, targetText: 'alpha', relation: 'primary', severity: 'must', blockId: 'b1' }),
+  edit({ id: 'pe_opt', from: 7, to: 11, targetText: 'beta', severity: 'optional', blockId: 'b1' }),
+  edit({ id: 'pe_prob', from: 12, to: 17, targetText: 'gamma', severity: 'probably', blockId: 'b1' }),
+]
+
+const views: EditorView[] = []
+function tracked(view: EditorView): EditorView {
+  views.push(view)
+  return view
+}
+
+afterEach(() => {
+  while (views.length) views.pop()!.destroy()
+})
+
+describe('commit-modal status snapshot (MED fix: cancel must not leak toggles)', () => {
+  it('open snapshots pre-open statuses and seeds optional pre-rejections into the plugin', () => {
+    const view = tracked(mount(doc))
+    setProposedEdits(view, edits)
+    setProposedEditStatus(view, 'pe_prob', 'accepted')
+
+    const snapshot = openCommitReview(view, edits)
+
+    // Snapshot holds the statuses as they were BEFORE the open-time seeding.
+    expect(snapshot).toEqual({
+      pe_primary: 'pending',
+      pe_opt: 'pending',
+      pe_prob: 'accepted',
+    })
+    // The optional cascade's modal pre-rejection is now IN the plugin, so the
+    // inline control and CascadeList agree with the modal immediately.
+    const anchors = getProposedAnchors(view.state)
+    expect(anchors.get('pe_opt')!.status).toBe('rejected')
+    // Non-optional and explicitly-decided statuses are untouched.
+    expect(anchors.get('pe_primary')!.status).toBe('pending')
+    expect(anchors.get('pe_prob')!.status).toBe('accepted')
+  })
+
+  it('open → toggle reject → cancel: plugin statuses restored to the snapshot', () => {
+    const view = tracked(mount(doc))
+    setProposedEdits(view, edits)
+    setProposedEditStatus(view, 'pe_prob', 'accepted')
+
+    const snapshot = openCommitReview(view, edits)
+
+    // User flips toggles in the modal (write-through to the plugin)...
+    setProposedEditStatus(view, 'pe_prob', 'rejected')
+    setProposedEditStatus(view, 'pe_primary', 'rejected')
+
+    // ...then cancels. Everything goes back to the open-time snapshot,
+    // including undoing the open-time optional pre-rejection.
+    restoreCommitReview(view, snapshot)
+    const anchors = getProposedAnchors(view.state)
+    expect(anchors.get('pe_primary')!.status).toBe('pending')
+    expect(anchors.get('pe_opt')!.status).toBe('pending')
+    expect(anchors.get('pe_prob')!.status).toBe('accepted')
+  })
+
+  it('an optional cascade the user explicitly accepted inline is NOT pre-rejected at open', () => {
+    const view = tracked(mount(doc))
+    setProposedEdits(view, edits)
+    setProposedEditStatus(view, 'pe_opt', 'accepted')
+
+    openCommitReview(view, edits)
+    expect(getProposedAnchors(view.state).get('pe_opt')!.status).toBe('accepted')
+  })
+})

--- a/src/lib/annotations/cascadeReveal.ts
+++ b/src/lib/annotations/cascadeReveal.ts
@@ -1,0 +1,75 @@
+import type { Node as PMNode } from 'prosemirror-model'
+import { findBlockById } from '@/lib/prosemirror/blockIds'
+import type { ProposedEdit } from './types'
+
+/**
+ * Flow-state buffering for cascade reveals (core PRD rule): downstream
+ * cascade callouts must not yank the reader's attention mid-paragraph. On
+ * reveal-time the edit set is split:
+ *
+ * - the PRIMARY edit always shows immediately (it is the user's own intent);
+ * - cascades ABOVE the read-line high-water mark show immediately — content
+ *   the user already read has changed, and the PRD requires that to flag;
+ * - cascades BELOW the read-line are HELD until the high-water mark crosses
+ *   the end of the primary edit's block (a coarse, natural breakpoint).
+ *
+ * highWaterMark === 0 means no reading has been tracked yet (fresh session,
+ * short doc that never scrolled, headless/e2e flows) — everything reveals
+ * immediately: with no reading signal there is no flow state to protect,
+ * and holding cascades forever behind a mark that may never move would
+ * silently hide review surfaces.
+ */
+export interface CascadeRevealPartition {
+  /** Edits to show now. */
+  reveal: ProposedEdit[]
+  /** Cascades held back until the read-line crosses `breakpointPos`. */
+  held: ProposedEdit[]
+}
+
+export function partitionCascadeReveal(
+  edits: ProposedEdit[],
+  highWaterMark: number,
+  breakpointPos: number,
+): CascadeRevealPartition {
+  if (highWaterMark === 0 || highWaterMark >= breakpointPos) {
+    return { reveal: edits, held: [] }
+  }
+  const reveal: ProposedEdit[] = []
+  const held: ProposedEdit[] = []
+  for (const edit of edits) {
+    if (edit.relation === 'primary' || edit.from < highWaterMark) {
+      reveal.push(edit)
+    } else {
+      held.push(edit)
+    }
+  }
+  return { reveal, held }
+}
+
+/**
+ * The coarse reveal breakpoint: the END of the primary edit's block, in the
+ * same coordinate the read-line plugin stores (the block's content end, i.e.
+ * what `$pos.end(depth)` yields when that block is marked read). Prefers the
+ * primary edit's blockId; falls back to resolving the edit's position; a
+ * missing primary or unresolvable position returns 0 so everything reveals
+ * immediately — failures must never hide review surfaces.
+ */
+export function cascadeBreakpointPos(
+  doc: PMNode,
+  primary: Pick<ProposedEdit, 'to' | 'blockId'> | undefined,
+): number {
+  if (!primary) return 0
+  if (primary.blockId) {
+    const found = findBlockById(doc, primary.blockId)
+    // Content end of the block node: pos + nodeSize - 1.
+    if (found) return found.pos + found.node.nodeSize - 1
+  }
+  try {
+    const clamped = Math.max(0, Math.min(primary.to, doc.content.size))
+    const $pos = doc.resolve(clamped)
+    if ($pos.depth > 0) return $pos.end($pos.depth)
+  } catch {
+    // fall through
+  }
+  return 0
+}

--- a/src/lib/annotations/cascadeReveal.ts
+++ b/src/lib/annotations/cascadeReveal.ts
@@ -1,6 +1,9 @@
 import type { Node as PMNode } from 'prosemirror-model'
+import type { EditorState } from 'prosemirror-state'
 import { findBlockById } from '@/lib/prosemirror/blockIds'
-import type { ProposedEdit } from './types'
+import { readLinePluginKey } from '@/lib/prosemirror/plugins/readLinePlugin'
+import { getProposedAnchors } from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import type { ProposedEdit, ProposedEditRelation } from './types'
 
 /**
  * Flow-state buffering for cascade reveals (core PRD rule): downstream
@@ -19,23 +22,23 @@ import type { ProposedEdit } from './types'
  * and holding cascades forever behind a mark that may never move would
  * silently hide review surfaces.
  */
-export interface CascadeRevealPartition {
+export interface CascadeRevealPartition<T = ProposedEdit> {
   /** Edits to show now. */
-  reveal: ProposedEdit[]
+  reveal: T[]
   /** Cascades held back until the read-line crosses `breakpointPos`. */
-  held: ProposedEdit[]
+  held: T[]
 }
 
-export function partitionCascadeReveal(
-  edits: ProposedEdit[],
+export function partitionCascadeReveal<T extends Pick<ProposedEdit, 'relation' | 'from'>>(
+  edits: T[],
   highWaterMark: number,
   breakpointPos: number,
-): CascadeRevealPartition {
+): CascadeRevealPartition<T> {
   if (highWaterMark === 0 || highWaterMark >= breakpointPos) {
     return { reveal: edits, held: [] }
   }
-  const reveal: ProposedEdit[] = []
-  const held: ProposedEdit[] = []
+  const reveal: T[] = []
+  const held: T[] = []
   for (const edit of edits) {
     if (edit.relation === 'primary' || edit.from < highWaterMark) {
       reveal.push(edit)
@@ -72,4 +75,29 @@ export function cascadeBreakpointPos(
     // fall through
   }
   return 0
+}
+
+/**
+ * One tick of the flow-state hold poll, computed from LIVE plugin anchors —
+ * positions are re-mapped through every transaction, so both the ABOVE/BELOW
+ * partition and the breakpoint (the primary anchor's live block end) track
+ * the document as the user types during a hold, instead of freezing at the
+ * stale stored from/to captured at proposal time.
+ *
+ * Returns the ids of currently-HELD (unrevealed) anchors that should reveal
+ * now; empty array when nothing is held or nothing is ready.
+ */
+export function pollCascadeReveal(state: EditorState): string[] {
+  const anchors = getProposedAnchors(state)
+  const heldNow: Array<{ id: string; relation: ProposedEditRelation; from: number }> = []
+  let primary: { to: number; blockId?: string } | undefined
+  for (const [id, a] of anchors) {
+    if (a.relation === 'primary') primary = { to: a.to, blockId: a.blockId }
+    if (!a.revealed) heldNow.push({ id, relation: a.relation, from: a.from })
+  }
+  if (heldNow.length === 0) return []
+  const highWaterMark = readLinePluginKey.getState(state)?.highWaterMark ?? 0
+  const breakpoint = cascadeBreakpointPos(state.doc, primary)
+  const { reveal } = partitionCascadeReveal(heldNow, highWaterMark, breakpoint)
+  return reveal.map((e) => e.id)
 }

--- a/src/lib/annotations/commitStatusSnapshot.ts
+++ b/src/lib/annotations/commitStatusSnapshot.ts
@@ -1,0 +1,57 @@
+import type { EditorView } from 'prosemirror-view'
+import {
+  getProposedAnchors,
+  setProposedEditStatus,
+} from '@/lib/prosemirror/plugins/proposedChangePlugin'
+import type { ProposedEdit, ProposedEditStatus } from './types'
+
+/**
+ * Commit-modal status bookkeeping. The proposedChange plugin's statuses are
+ * the single pre-apply source of truth across every review surface (inline
+ * control, CascadeList, SemanticCommitModal), and the modal writes toggles
+ * through live — so opening the modal must snapshot the statuses first, and
+ * CANCEL must put them back, or an abandoned review session leaks its toggles
+ * into the inline surfaces.
+ */
+export type CommitStatusSnapshot = Record<string, ProposedEditStatus>
+
+/**
+ * Called when the modal OPENS. Two jobs, in order:
+ * 1. Snapshot the plugin's current statuses for the involved edit ids (the
+ *    restore target for cancel).
+ * 2. Seed the modal's optional-severity pre-rejections INTO the plugin —
+ *    accept-all defaults to must + probably, so still-pending optional
+ *    cascades flip to rejected in the plugin too, and the inline control /
+ *    CascadeList agree with the modal from the moment it opens (previously
+ *    the modal showed them rejected while the plugin still said pending).
+ */
+export function openCommitReview(view: EditorView, edits: ProposedEdit[]): CommitStatusSnapshot {
+  const anchors = getProposedAnchors(view.state)
+  const snapshot: CommitStatusSnapshot = {}
+  for (const e of edits) {
+    const a = anchors.get(e.id)
+    if (a) snapshot[e.id] = a.status
+  }
+  for (const e of edits) {
+    if (e.relation !== 'cascade' || e.severity !== 'optional') continue
+    if (anchors.get(e.id)?.status === 'pending') {
+      setProposedEditStatus(view, e.id, 'rejected')
+    }
+  }
+  return snapshot
+}
+
+/**
+ * Called on modal CANCEL: restore every snapshotted status (toggles made while
+ * the modal was open — including the open-time optional pre-rejections — must
+ * not leak). On CONFIRM this is NOT called; the live statuses stand.
+ */
+export function restoreCommitReview(view: EditorView, snapshot: CommitStatusSnapshot): void {
+  for (const [id, status] of Object.entries(snapshot)) {
+    // Read fresh per id — each restore dispatch advances the state.
+    const current = getProposedAnchors(view.state).get(id)
+    if (current && current.status !== status) {
+      setProposedEditStatus(view, id, status)
+    }
+  }
+}

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -8,8 +8,11 @@ import {
   augmentWithLlmEdges,
   getDocGraph,
   getNeighborhood,
+  findEdgePath,
+  formatEdgePath,
   contentHash,
   invalidateDocGraphCache,
+  type DocGraphEdge,
 } from '../docGraph'
 
 const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
@@ -586,5 +589,78 @@ describe('getDocGraph cache', () => {
     expect(called).toBe(false)
     expect(g.llmApplied).toBe(false)
     expect(g.nodes.has('b1')).toBe(true)
+  })
+})
+
+describe('findEdgePath', () => {
+  it('returns the direct edge between adjacent blocks', () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('def', '"Total Budget" means the fifty thousand dollar pool.'),
+        p('use', 'Marketing may spend part of the Total Budget each quarter.'),
+      ),
+    )
+    const path = findEdgePath(graph, 'use', 'def')
+    expect(path).not.toBeNull()
+    expect(path!.length).toBe(1)
+    expect(path![0].type).toBe('references')
+    expect(path![0].evidence).toBe('Total Budget')
+  })
+
+  it('is direction-agnostic (undirected adjacency)', () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('def', '"Total Budget" means the fifty thousand dollar pool.'),
+        p('use', 'Marketing may spend part of the Total Budget each quarter.'),
+      ),
+    )
+    const path = findEdgePath(graph, 'def', 'use')
+    expect(path).not.toBeNull()
+    expect(path!.length).toBe(1)
+  })
+
+  it('finds the shortest multi-hop path in walk order', () => {
+    const graph = buildDeterministicGraph(docOf(p('a', 'x'), p('b', 'y'), p('c', 'z')))
+    const ab: DocGraphEdge = { from: 'a', to: 'b', type: 'references', source: 'llm', evidence: 'alpha' }
+    const bc: DocGraphEdge = { from: 'c', to: 'b', type: 'contradicts', source: 'llm' }
+    graph.edges.push(ab, bc)
+    graph.adjacency.set('a', [ab])
+    graph.adjacency.set('b', [ab, bc])
+    graph.adjacency.set('c', [bc])
+    const path = findEdgePath(graph, 'a', 'c')
+    expect(path).toEqual([ab, bc])
+  })
+
+  it('returns null for unknown blocks and disconnected pairs, [] for the same block', () => {
+    const graph = buildDeterministicGraph(docOf(p('a', 'one'), p('b', 'unrelated')))
+    expect(findEdgePath(graph, 'a', 'missing')).toBeNull()
+    expect(findEdgePath(graph, 'missing', 'a')).toBeNull()
+    expect(findEdgePath(graph, 'a', 'b')).toBeNull()
+    expect(findEdgePath(graph, 'a', 'a')).toEqual([])
+  })
+})
+
+describe('formatEdgePath', () => {
+  it('renders type plus quoted evidence, joined by arrows', () => {
+    const path: DocGraphEdge[] = [
+      { from: 'a', to: 'b', type: 'references', source: 'deterministic', evidence: 'Total Budget' },
+      { from: 'b', to: 'c', type: 'contradicts', source: 'llm' },
+    ]
+    expect(formatEdgePath(path)).toBe('references ("Total Budget") → contradicts')
+  })
+
+  it('truncates long evidence terms to keep the line compact', () => {
+    const path: DocGraphEdge[] = [
+      {
+        from: 'a',
+        to: 'b',
+        type: 'duplicates',
+        source: 'deterministic',
+        evidence: 'This is a very long duplicated sentence that keeps going.',
+      },
+    ]
+    const out = formatEdgePath(path)
+    expect(out).toContain('…')
+    expect(out.length).toBeLessThan(45)
   })
 })

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -601,18 +601,25 @@ function expandOneHop(
 }
 
 /**
+ * Monotonic publish sequence — every getDocGraph invocation allocates one seq
+ * and stamps BOTH of its publishes ('building' and the final 'ready') with it.
+ * The store compare-and-sets on the seq, so a slow older build finishing after
+ * a newer publish can neither churn the chip back to 'building' nor overwrite
+ * a fresher graph with a stale one.
+ */
+let publishSeq = 0
+
+/**
  * Publish build lifecycle to the UI store (StatusBar chip, edge-path
  * affordances). Browser-only via lazy import — node tests and server code
  * never touch the store (same precedent as scheduleDocGraphRebuild's lazy
  * settings-store import). Failures are swallowed: publishing is cosmetic.
  */
-function publishDocGraph(status: 'building' | 'ready', graph?: DocGraph): void {
+function publishDocGraph(seq: number, status: 'building' | 'ready', graph?: DocGraph): void {
   if (typeof window === 'undefined') return
   void import('@/stores/docGraphStore')
     .then(({ useDocGraphStore }) => {
-      const store = useDocGraphStore.getState()
-      if (graph) store.setGraph(graph)
-      store.setStatus(status)
+      useDocGraphStore.getState().publish(seq, status, graph)
     })
     .catch(() => {})
 }
@@ -661,14 +668,16 @@ export async function getDocGraph(
     (cached.embeddingsApplied || !embeddingsOn)
   ) {
     // Cache hits publish too — a fresh page with a warm cache still needs the
-    // UI store filled before the chip / edge paths can render.
-    publishDocGraph('ready', cached)
+    // UI store filled before the chip / edge paths can render. Synchronous
+    // resolution: publish 'ready' directly, never a 'building' flicker.
+    publishDocGraph(++publishSeq, 'ready', cached)
     return cached
   }
   const pending = inflight.get(hash)
   if (pending) return pending
 
-  publishDocGraph('building')
+  const seq = ++publishSeq
+  publishDocGraph(seq, 'building')
   const promise = (async () => {
     const graph = cached ?? buildDeterministicGraph(doc)
     if (!deps.skipLlm && !graph.llmApplied) {
@@ -686,7 +695,7 @@ export async function getDocGraph(
       await augmentWithEmbeddingEdges(graph, config, deps.embed)
     }
     cacheGraph(hash, graph)
-    publishDocGraph('ready', graph)
+    publishDocGraph(seq, 'ready', graph)
     return graph
   })().finally(() => inflight.delete(hash))
 

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -600,6 +600,23 @@ function expandOneHop(
   return out
 }
 
+/**
+ * Publish build lifecycle to the UI store (StatusBar chip, edge-path
+ * affordances). Browser-only via lazy import — node tests and server code
+ * never touch the store (same precedent as scheduleDocGraphRebuild's lazy
+ * settings-store import). Failures are swallowed: publishing is cosmetic.
+ */
+function publishDocGraph(status: 'building' | 'ready', graph?: DocGraph): void {
+  if (typeof window === 'undefined') return
+  void import('@/stores/docGraphStore')
+    .then(({ useDocGraphStore }) => {
+      const store = useDocGraphStore.getState()
+      if (graph) store.setGraph(graph)
+      store.setStatus(status)
+    })
+    .catch(() => {})
+}
+
 /** User toggle for the embedding pass (settings store, default true). */
 async function embeddingsEnabledFromStore(): Promise<boolean> {
   try {
@@ -643,11 +660,15 @@ export async function getDocGraph(
     (cached.llmApplied || deps.skipLlm || !llmAvailable(config)) &&
     (cached.embeddingsApplied || !embeddingsOn)
   ) {
+    // Cache hits publish too — a fresh page with a warm cache still needs the
+    // UI store filled before the chip / edge paths can render.
+    publishDocGraph('ready', cached)
     return cached
   }
   const pending = inflight.get(hash)
   if (pending) return pending
 
+  publishDocGraph('building')
   const promise = (async () => {
     const graph = cached ?? buildDeterministicGraph(doc)
     if (!deps.skipLlm && !graph.llmApplied) {
@@ -665,6 +686,7 @@ export async function getDocGraph(
       await augmentWithEmbeddingEdges(graph, config, deps.embed)
     }
     cacheGraph(hash, graph)
+    publishDocGraph('ready', graph)
     return graph
   })().finally(() => inflight.delete(hash))
 
@@ -696,6 +718,70 @@ export function getNeighborhood(
     frontier = next
   }
   return dist
+}
+
+/**
+ * BFS shortest path over the undirected adjacency, as the ordered edge list
+ * walked from `fromBlockId` to `toBlockId`. Returns [] when the endpoints are
+ * the same block, null when either endpoint is unknown or no path exists.
+ * Pure — powers the "why this proposal?" affordance.
+ */
+export function findEdgePath(
+  graph: DocGraph,
+  fromBlockId: string,
+  toBlockId: string,
+): DocGraphEdge[] | null {
+  if (!graph.nodes.has(fromBlockId) || !graph.nodes.has(toBlockId)) return null
+  if (fromBlockId === toBlockId) return []
+
+  const cameFrom = new Map<string, { via: DocGraphEdge; prev: string }>()
+  const visited = new Set([fromBlockId])
+  let frontier = [fromBlockId]
+  while (frontier.length) {
+    const next: string[] = []
+    for (const id of frontier) {
+      for (const edge of graph.adjacency.get(id) ?? []) {
+        const far = edge.from === id ? edge.to : edge.from
+        if (visited.has(far)) continue
+        visited.add(far)
+        cameFrom.set(far, { via: edge, prev: id })
+        if (far === toBlockId) {
+          const path: DocGraphEdge[] = []
+          let cursor = toBlockId
+          while (cursor !== fromBlockId) {
+            const step = cameFrom.get(cursor)!
+            path.unshift(step.via)
+            cursor = step.prev
+          }
+          return path
+        }
+        next.push(far)
+      }
+    }
+    frontier = next
+  }
+  return null
+}
+
+const EDGE_EVIDENCE_MAX_CHARS = 24
+
+/**
+ * Human-readable rendering of an edge path for the "why this proposal?" line,
+ * e.g. `references ("Total Budget") → contradicts`. Plain text only — callers
+ * must never inject it as HTML. Evidence terms are truncated to keep the line
+ * compact.
+ */
+export function formatEdgePath(path: DocGraphEdge[]): string {
+  return path
+    .map((edge) => {
+      if (!edge.evidence) return edge.type
+      const term =
+        edge.evidence.length > EDGE_EVIDENCE_MAX_CHARS
+          ? edge.evidence.slice(0, EDGE_EVIDENCE_MAX_CHARS).trimEnd() + '…'
+          : edge.evidence
+      return `${edge.type} ("${term}")`
+    })
+    .join(' → ')
 }
 
 let rebuildTimer: ReturnType<typeof setTimeout> | null = null

--- a/src/lib/graphrag/embedEdges.ts
+++ b/src/lib/graphrag/embedEdges.ts
@@ -1,4 +1,5 @@
 import type { LLMConfig } from '@/stores/settingsStore'
+import { addEstimate } from '@/lib/ai/spendEstimate'
 import type { DocGraph, DocGraphEdge } from './docGraph'
 
 /**
@@ -64,6 +65,8 @@ export function clearEmbeddingVectorCache(): void {
  * leaves embeddingsApplied false and the next cascade retries.
  */
 export const fetchEmbeddings: EmbedFn = async (texts, config) => {
+  // Soft spend indicator (display only).
+  addEstimate(texts.reduce((n, t) => n + t.length, 0))
   const res = await fetch('/api/embed', {
     method: 'POST',
     headers: {

--- a/src/lib/prosemirror/__tests__/proposedChangeReanchor.test.ts
+++ b/src/lib/prosemirror/__tests__/proposedChangeReanchor.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '../schema'
+import {
+  createProposedChangePlugin,
+  setProposedEdits,
+  getProposedAnchors,
+} from '../plugins/proposedChangePlugin'
+import type { ProposedEdit } from '@/lib/annotations/types'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+function docOf(...blocks: PMNode[]): PMNode {
+  return schema.node('doc', null, blocks)
+}
+
+function mount(doc: PMNode): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const state = EditorState.create({ schema, doc, plugins: [createProposedChangePlugin()] })
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      const newState = view.state.apply(transaction)
+      view.updateState(newState)
+    },
+  })
+  return view
+}
+
+function edit(overrides: Partial<ProposedEdit>): ProposedEdit {
+  return {
+    id: 'pe_1',
+    from: 1,
+    to: 2,
+    newText: 'replacement',
+    reason: 'test',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: 'target',
+    severity: 'probably',
+    evidence: null,
+    ...overrides,
+  }
+}
+
+const views: EditorView[] = []
+function tracked(view: EditorView): EditorView {
+  views.push(view)
+  return view
+}
+
+afterEach(() => {
+  while (views.length) views.pop()!.destroy()
+  vi.restoreAllMocks()
+})
+
+describe('setProposedEdits re-anchoring (drift fix)', () => {
+  // doc: p1 "alpha beta gamma" (pos 0, content 1..16), p2 "delta beta omega"
+  const doc = docOf(p('b1', 'alpha beta gamma'), p('b2', 'delta beta omega'))
+
+  it('re-anchors stale from/to against the current doc via blockId', () => {
+    const view = tracked(mount(doc))
+    // "beta" in b2 actually sits at 24..28; the stored anchor is stale garbage.
+    setProposedEdits(view, [edit({ id: 'pe_stale', from: 1, to: 5, targetText: 'beta', blockId: 'b2' })])
+    const anchor = getProposedAnchors(view.state).get('pe_stale')
+    expect(anchor).toBeDefined()
+    expect(view.state.doc.textBetween(anchor!.from, anchor!.to)).toBe('beta')
+    // blockId scoping picked the b2 occurrence, not the earlier b1 one.
+    expect(anchor!.from).toBeGreaterThan(17)
+  })
+
+  it('falls back to a whole-doc fingerprint search when blockId is absent', () => {
+    const view = tracked(mount(doc))
+    setProposedEdits(view, [edit({ id: 'pe_nofid', from: 9, to: 12, targetText: 'gamma' })])
+    const anchor = getProposedAnchors(view.state).get('pe_nofid')
+    expect(anchor).toBeDefined()
+    expect(view.state.doc.textBetween(anchor!.from, anchor!.to)).toBe('gamma')
+  })
+
+  it('drops edits whose target text no longer resolves, and warns with the count', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const view = tracked(mount(doc))
+    setProposedEdits(view, [
+      edit({ id: 'pe_ok', targetText: 'alpha', blockId: 'b1' }),
+      edit({ id: 'pe_gone', targetText: 'vanished text' }),
+    ])
+    const anchors = getProposedAnchors(view.state)
+    expect(anchors.has('pe_ok')).toBe(true)
+    expect(anchors.has('pe_gone')).toBe(false)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('dropped 1 proposed edit'))
+  })
+
+  it('keeps already-correct anchors as-is', () => {
+    const view = tracked(mount(doc))
+    // "alpha" in b1 is at 1..6.
+    setProposedEdits(view, [edit({ id: 'pe_exact', from: 1, to: 6, targetText: 'alpha', blockId: 'b1' })])
+    const anchor = getProposedAnchors(view.state).get('pe_exact')
+    expect(anchor).toMatchObject({ from: 1, to: 6 })
+  })
+
+  it('passes insertions (empty targetText) through with stored positions', () => {
+    const view = tracked(mount(doc))
+    setProposedEdits(view, [edit({ id: 'pe_insert', from: 6, to: 6, targetText: '', newText: ' inserted' })])
+    const anchor = getProposedAnchors(view.state).get('pe_insert')
+    expect(anchor).toMatchObject({ from: 6, to: 6 })
+  })
+})

--- a/src/lib/prosemirror/__tests__/proposedChangeReanchor.test.ts
+++ b/src/lib/prosemirror/__tests__/proposedChangeReanchor.test.ts
@@ -9,6 +9,7 @@ import {
   setProposedEdits,
   getProposedAnchors,
 } from '../plugins/proposedChangePlugin'
+import { blockTextRange } from '../blockIds'
 import type { ProposedEdit } from '@/lib/annotations/types'
 
 function p(blockId: string, text: string): PMNode {
@@ -102,6 +103,22 @@ describe('setProposedEdits re-anchoring (drift fix)', () => {
     setProposedEdits(view, [edit({ id: 'pe_exact', from: 1, to: 6, targetText: 'alpha', blockId: 'b1' })])
     const anchor = getProposedAnchors(view.state).get('pe_exact')
     expect(anchor).toMatchObject({ from: 1, to: 6 })
+  })
+
+  it('validate-stored-first: a correct blockId-less anchor at the SECOND occurrence stays put', () => {
+    // "beta" occurs in b1 AND b2. The stored positions point (correctly) at the
+    // b2 occurrence and there is NO blockId — the fingerprint fallback would
+    // relocate it to the first occurrence in b1. Validate-stored-first must
+    // keep the stored anchor untouched.
+    const view = tracked(mount(doc))
+    const b2Range = blockTextRange(view.state.doc, 'b2', 'beta')!
+    expect(b2Range).toBeTruthy()
+    setProposedEdits(view, [
+      edit({ id: 'pe_second', from: b2Range.from, to: b2Range.to, targetText: 'beta' }),
+    ])
+    const anchor = getProposedAnchors(view.state).get('pe_second')
+    expect(anchor).toMatchObject({ from: b2Range.from, to: b2Range.to })
+    expect(view.state.doc.textBetween(anchor!.from, anchor!.to)).toBe('beta')
   })
 
   it('passes insertions (empty targetText) through with stored positions', () => {

--- a/src/lib/prosemirror/__tests__/proposedChangeReveal.test.ts
+++ b/src/lib/prosemirror/__tests__/proposedChangeReveal.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '../schema'
+import {
+  createProposedChangePlugin,
+  setProposedEdits,
+  setProposedEditStatus,
+  revealProposedEdits,
+  getProposedAnchors,
+} from '../plugins/proposedChangePlugin'
+import { createReadLinePlugin, readLinePluginKey, type ReadLineMeta } from '../plugins/readLinePlugin'
+import { applyProposedEdits } from '../applyProposedEdits'
+import { pollCascadeReveal } from '@/lib/annotations/cascadeReveal'
+import type { ProposedEdit } from '@/lib/annotations/types'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+// b1 content 1..17 (block content end 17), b2 19..35, b3 37..53.
+function makeDoc(): PMNode {
+  return schema.node('doc', null, [
+    p('b1', 'alpha beta gamma'),
+    p('b2', 'delta beta omega'),
+    p('b3', 'omega tail block'),
+  ])
+}
+
+function mount(doc: PMNode): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const state = EditorState.create({
+    schema,
+    doc,
+    plugins: [createProposedChangePlugin(), createReadLinePlugin()],
+  })
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      const newState = view.state.apply(transaction)
+      view.updateState(newState)
+    },
+  })
+  return view
+}
+
+function edit(overrides: Partial<ProposedEdit>): ProposedEdit {
+  return {
+    id: 'pe_1',
+    from: 1,
+    to: 2,
+    newText: 'replacement',
+    reason: 'test',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: 'target',
+    severity: 'probably',
+    evidence: null,
+    ...overrides,
+  }
+}
+
+// "alpha" in b1 at 1..6; "tail" in b3 at 43..47.
+const primaryEdit = () =>
+  edit({ id: 'pe_p', from: 1, to: 6, targetText: 'alpha', newText: 'ALPHA', relation: 'primary', blockId: 'b1', severity: 'must' })
+const cascadeEdit = () =>
+  edit({ id: 'pe_c', from: 43, to: 47, targetText: 'tail', newText: 'TAIL', blockId: 'b3' })
+
+function markRead(view: EditorView, pos: number) {
+  view.dispatch(
+    view.state.tr.setMeta(readLinePluginKey, { markRead: pos } as ReadLineMeta),
+  )
+}
+
+const views: EditorView[] = []
+function tracked(view: EditorView): EditorView {
+  views.push(view)
+  return view
+}
+
+afterEach(() => {
+  while (views.length) views.pop()!.destroy()
+})
+
+describe('flow-state holds as reveal flags (HIGH-1 redesign)', () => {
+  it('held anchors render no decoration and no margin flag, but ARE in getProposedAnchors', () => {
+    const view = tracked(mount(makeDoc()))
+    markRead(view, 5) // reading tracked, hold engaged for below-read-line cascades
+    setProposedEdits(view, [primaryEdit(), cascadeEdit()], ['pe_c'])
+
+    const anchors = getProposedAnchors(view.state)
+    expect(anchors.get('pe_c')).toBeDefined()
+    expect(anchors.get('pe_c')!.revealed).toBe(false)
+    expect(anchors.get('pe_p')!.revealed).toBe(true)
+
+    // Primary is decorated; the held cascade renders nothing at all.
+    expect(view.dom.querySelectorAll('[data-proposed-edit-id="pe_p"]').length).toBeGreaterThan(0)
+    expect(view.dom.querySelectorAll('[data-proposed-edit-id="pe_c"]').length).toBe(0)
+  })
+
+  it('apply succeeds while a cascade is held (modal-accept path, HIGH-1 regression)', () => {
+    const view = tracked(mount(makeDoc()))
+    markRead(view, 5)
+    setProposedEdits(view, [primaryEdit(), cascadeEdit()], ['pe_c'])
+
+    // The modal shows every edit regardless of reveal state; the user accepts
+    // both. The held anchor must still be a valid apply target.
+    const result = applyProposedEdits(view, ['pe_p', 'pe_c'])
+    expect(result.ok).toBe(true)
+    const text = view.state.doc.textContent
+    expect(text).toContain('ALPHA')
+    expect(text).toContain('TAIL')
+    expect(text).not.toContain('alpha')
+    expect(text).not.toContain('tail')
+  })
+
+  it('reveal preserves prior accepted/rejected statuses (MED-3 regression)', () => {
+    const view = tracked(mount(makeDoc()))
+    markRead(view, 5)
+    const cascadeB2 = edit({ id: 'pe_c2', from: 25, to: 29, targetText: 'beta', blockId: 'b2' })
+    setProposedEdits(view, [primaryEdit(), cascadeEdit(), cascadeB2], ['pe_c', 'pe_c2'])
+
+    // In-progress review decisions on revealed AND held anchors...
+    setProposedEditStatus(view, 'pe_p', 'accepted')
+    setProposedEditStatus(view, 'pe_c', 'rejected')
+
+    // ...survive the reveal untouched.
+    revealProposedEdits(view, ['pe_c', 'pe_c2'])
+    const anchors = getProposedAnchors(view.state)
+    expect(anchors.get('pe_p')!.status).toBe('accepted')
+    expect(anchors.get('pe_c')!.status).toBe('rejected')
+    expect(anchors.get('pe_c')!.revealed).toBe(true)
+    expect(anchors.get('pe_c2')!.status).toBe('pending')
+    expect(anchors.get('pe_c2')!.revealed).toBe(true)
+  })
+
+  it('pollCascadeReveal partitions on LIVE positions: typing during the hold shifts the breakpoint', () => {
+    const view = tracked(mount(makeDoc()))
+    markRead(view, 5)
+    setProposedEdits(view, [primaryEdit(), cascadeEdit()], ['pe_c'])
+
+    // User types 10 chars at the START of the primary block during the hold —
+    // the block's content end (the breakpoint) moves 17 → 27.
+    view.dispatch(view.state.tr.insertText('0123456789', 1))
+
+    // Read-line reaches the OLD breakpoint (17). Stale stored positions would
+    // reveal here; the live breakpoint is 27, so the cascade must stay held.
+    markRead(view, 17)
+    expect(pollCascadeReveal(view.state)).toEqual([])
+
+    // Crossing the LIVE breakpoint reveals it.
+    markRead(view, 27)
+    expect(pollCascadeReveal(view.state)).toEqual(['pe_c'])
+    revealProposedEdits(view, ['pe_c'])
+    expect(getProposedAnchors(view.state).get('pe_c')!.revealed).toBe(true)
+    expect(pollCascadeReveal(view.state)).toEqual([])
+  })
+
+  it('reading past the primary block end (the breakpoint) reveals held cascades', () => {
+    const view = tracked(mount(makeDoc()))
+    markRead(view, 5)
+    setProposedEdits(view, [primaryEdit(), cascadeEdit()], ['pe_c'])
+
+    // b1's content end is 17; the read line crossing it releases the hold.
+    markRead(view, 20)
+    expect(pollCascadeReveal(view.state)).toEqual(['pe_c'])
+  })
+})

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -1,7 +1,10 @@
 import type { EditorView } from 'prosemirror-view'
-import type { Node as PMNode } from 'prosemirror-model'
 import { getProposedAnchors } from './plugins/proposedChangePlugin'
-import { blockTextRange } from './blockIds'
+import { blockTextRange, findTextInDoc } from './blockIds'
+
+// Compat re-export: findTextInDoc moved to blockIds.ts (the proposedChange
+// plugin needs it for re-anchoring, and importing it from here would cycle).
+export { findTextInDoc } from './blockIds'
 
 /**
  * Applies a set of accepted proposed edits in ONE transaction, safely.
@@ -27,24 +30,6 @@ export interface AppliedEdit {
 export type ApplyProposedResult =
   | { ok: true; applied: AppliedEdit[] }
   | { ok: false; reason: string }
-
-/** First single-text-node occurrence of `query`, as ProseMirror positions. */
-export function findTextInDoc(doc: PMNode, query: string): { from: number; to: number } | null {
-  if (!query) return null
-  let result: { from: number; to: number } | null = null
-  doc.descendants((node, pos) => {
-    if (result) return false
-    if (node.isText && node.text) {
-      const idx = node.text.indexOf(query)
-      if (idx !== -1) {
-        result = { from: pos + idx, to: pos + idx + query.length }
-        return false
-      }
-    }
-    return true
-  })
-  return result
-}
 
 export function applyProposedEdits(view: EditorView, acceptedIds: string[]): ApplyProposedResult {
   const anchors = getProposedAnchors(view.state)

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -37,6 +37,10 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
   const resolved: AppliedEdit[] = []
 
   for (const id of acceptedIds) {
+    // NOTE: the plugin always holds the FULL edit set (flow-state holds are a
+    // revealed:false flag, never a missing anchor), so an accepted id whose
+    // anchor is still unrevealed is perfectly valid to apply — the commit
+    // modal shows every edit, so accepting one there is a conscious decision.
     const a = anchors.get(id)
     if (!a) return { ok: false, reason: `Proposed edit ${id} no longer exists.` }
 
@@ -44,6 +48,9 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
     const safeTo = Math.min(a.to, doc.content.size)
     const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
 
+    // Insertions (targetText:'' ⇒ from === to) trivially pass this check —
+    // they bypass fingerprint validation entirely (and render no decoration).
+    // Known limitation; do not rely on validation for insertion placement.
     if (current === a.targetText) {
       resolved.push({ from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
       continue

--- a/src/lib/prosemirror/blockIds.ts
+++ b/src/lib/prosemirror/blockIds.ts
@@ -114,6 +114,28 @@ export function computeBlockIdFixes(
 }
 
 /**
+ * First single-text-node occurrence of `query`, as ProseMirror positions.
+ * (Lives here — not in applyProposedEdits — so the proposedChange plugin can
+ * re-anchor without an import cycle; applyProposedEdits re-exports it.)
+ */
+export function findTextInDoc(doc: PMNode, query: string): { from: number; to: number } | null {
+  if (!query) return null
+  let result: { from: number; to: number } | null = null
+  doc.descendants((node, pos) => {
+    if (result) return false
+    if (node.isText && node.text) {
+      const idx = node.text.indexOf(query)
+      if (idx !== -1) {
+        result = { from: pos + idx, to: pos + idx + query.length }
+        return false
+      }
+    }
+    return true
+  })
+  return result
+}
+
+/**
  * Locate `query` inside the block with `blockId`, spanning marks (bold/italic split
  * text nodes but positions stay contiguous). Unlike `findTextInDoc`, this
  * disambiguates repeated phrases by block and can match across mark boundaries.

--- a/src/lib/prosemirror/plugins/proposedChangePlugin.ts
+++ b/src/lib/prosemirror/plugins/proposedChangePlugin.ts
@@ -34,6 +34,14 @@ export interface ProposedAnchor {
   severity: CascadeSeverity
   evidence: CascadeEvidence | null
   blockId?: string
+  /**
+   * Flow-state hold flag (reveal-flag design): `false` means the anchor is
+   * tracked, mapped, status-carrying, and APPLYABLE like any other — it just
+   * renders no decoration yet. Held cascades stay in the apply-time source of
+   * truth; only their visibility is deferred, so a modal-accepted held edit
+   * can never abort the apply transaction with a missing anchor.
+   */
+  revealed: boolean
 }
 
 interface ProposedChangeState {
@@ -41,8 +49,12 @@ interface ProposedChangeState {
 }
 
 export interface ProposedChangeMeta {
-  action: 'setEdits' | 'setStatus' | 'clearAll'
+  action: 'setEdits' | 'setStatus' | 'revealEdits' | 'clearAll'
   edits?: ProposedEdit[]
+  /** setEdits: ids to store with revealed:false (flow-state hold). */
+  heldIds?: string[]
+  /** revealEdits: ids to flip revealed:true (statuses untouched). */
+  ids?: string[]
   id?: string
   status?: ProposedEditStatus
 }
@@ -59,8 +71,15 @@ function isAboveReadLine(state: EditorState, pos: number): boolean {
 function buildDecorations(state: EditorState, anchors: Map<string, ProposedAnchor>): DecorationSet {
   const decos: Decoration[] = []
   for (const [id, a] of anchors) {
+    // Flow-state hold: unrevealed anchors render nothing (no highlight, no
+    // margin flag) but remain live in every other way — mapped, status-carrying,
+    // and applyable.
+    if (!a.revealed) continue
     // Rejected edits are not rendered; pending + accepted are.
     if (a.status === 'rejected') continue
+    // Insertions (targetText:'' ⇒ from === to) render no decoration — known
+    // limitation shared with the fingerprint-validation bypass (see
+    // setProposedEdits / applyProposedEdits).
     if (a.from === a.to) continue
     const above = isAboveReadLine(state, a.from)
     const accepted = a.status === 'accepted'
@@ -126,6 +145,7 @@ export function createProposedChangePlugin(): Plugin {
         const meta = tr.getMeta(proposedChangePluginKey) as ProposedChangeMeta | undefined
         if (meta) {
           if (meta.action === 'setEdits') {
+            const held = new Set(meta.heldIds ?? [])
             anchors = new Map()
             for (const e of meta.edits ?? []) {
               anchors.set(e.id, {
@@ -139,7 +159,19 @@ export function createProposedChangePlugin(): Plugin {
                 severity: e.severity ?? (e.relation === 'primary' ? 'must' : 'probably'),
                 evidence: e.evidence ?? null,
                 blockId: e.blockId,
+                revealed: !held.has(e.id),
               })
+            }
+          } else if (meta.action === 'revealEdits' && meta.ids) {
+            // Flip visibility ONLY — statuses persist, so accept/reject
+            // decisions made while an anchor was held (or on its siblings)
+            // survive the reveal.
+            anchors = new Map(anchors)
+            for (const id of meta.ids) {
+              const existing = anchors.get(id)
+              if (existing && !existing.revealed) {
+                anchors.set(id, { ...existing, revealed: true })
+              }
             }
           } else if (meta.action === 'setStatus' && meta.id && meta.status) {
             const existing = anchors.get(meta.id)
@@ -202,25 +234,39 @@ export function createProposedChangePlugin(): Plugin {
 // --- Helpers --------------------------------------------------------------
 
 /**
- * Show a resolution's proposed edits as decorations.
+ * Show a resolution's proposed edits as decorations. ALWAYS receives the FULL
+ * edit set — flow-state holds are expressed via `heldIds` (those anchors are
+ * stored with revealed:false), never by withholding edits, so the apply-time
+ * source of truth is complete from the first dispatch.
  *
- * Drift fix: stored edit positions were captured at proposal time and the
- * document may have changed since (typing, an earlier apply, a re-reveal).
- * Each edit is re-anchored against the CURRENT doc before its anchor is
- * stored: prefer the block-scoped match when the edit knows its blockId
- * (disambiguating repeated phrases), fall back to a whole-doc fingerprint
- * search, and DROP edits whose target text no longer resolves anywhere
- * (a stale anchor decorating the wrong text is worse than no decoration).
- * Insertions (empty targetText) can't be fingerprinted and pass through
- * with their stored positions.
+ * Drift fix, validate-stored-first (mirrors applyProposedEdits' order):
+ * 1. If the stored range still holds exactly `targetText`, the stored anchor
+ *    IS the truth — keep it untouched. This is what lets a blockId-less
+ *    anchor whose target text also occurs earlier in the document stay at its
+ *    correct occurrence instead of silently relocating to the first match.
+ * 2. Only on mismatch, recover: block-scoped match when the edit knows its
+ *    blockId (disambiguating repeated phrases), else whole-doc fingerprint.
+ * 3. DROP edits whose target text no longer resolves anywhere (a stale anchor
+ *    decorating the wrong text is worse than no decoration).
+ * Insertions (empty targetText) can't be fingerprinted and pass through with
+ * their stored positions unvalidated — known limitation (they also render no
+ * decoration, since from === to).
  */
-export function setProposedEdits(view: EditorView, edits: ProposedEdit[]) {
+export function setProposedEdits(view: EditorView, edits: ProposedEdit[], heldIds?: string[]) {
   const doc = view.state.doc
   const reanchored: ProposedEdit[] = []
   let dropped = 0
   for (const e of edits) {
     if (!e.targetText) {
       reanchored.push(e)
+      continue
+    }
+    const safeFrom = Math.max(0, Math.min(e.from, doc.content.size))
+    const safeTo = Math.max(0, Math.min(e.to, doc.content.size))
+    if (safeFrom <= safeTo && doc.textBetween(safeFrom, safeTo) === e.targetText) {
+      reanchored.push(
+        safeFrom === e.from && safeTo === e.to ? e : { ...e, from: safeFrom, to: safeTo },
+      )
       continue
     }
     const range =
@@ -230,9 +276,7 @@ export function setProposedEdits(view: EditorView, edits: ProposedEdit[]) {
       dropped++
       continue
     }
-    reanchored.push(
-      range.from === e.from && range.to === e.to ? e : { ...e, from: range.from, to: range.to },
-    )
+    reanchored.push({ ...e, from: range.from, to: range.to })
   }
   if (dropped > 0) {
     console.warn(
@@ -243,6 +287,22 @@ export function setProposedEdits(view: EditorView, edits: ProposedEdit[]) {
     view.state.tr.setMeta(proposedChangePluginKey, {
       action: 'setEdits',
       edits: reanchored,
+      heldIds,
+    } as ProposedChangeMeta),
+  )
+}
+
+/**
+ * Flip held anchors to revealed WITHOUT touching their review statuses —
+ * reveal is a pure visibility change, so accept/reject decisions in progress
+ * are preserved by construction.
+ */
+export function revealProposedEdits(view: EditorView, ids: string[]) {
+  if (ids.length === 0) return
+  view.dispatch(
+    view.state.tr.setMeta(proposedChangePluginKey, {
+      action: 'revealEdits',
+      ids,
     } as ProposedChangeMeta),
   )
 }

--- a/src/lib/prosemirror/plugins/proposedChangePlugin.ts
+++ b/src/lib/prosemirror/plugins/proposedChangePlugin.ts
@@ -1,6 +1,7 @@
 import { Plugin, PluginKey, Transaction, EditorState } from 'prosemirror-state'
 import { Decoration, DecorationSet, EditorView } from 'prosemirror-view'
 import { readLinePluginKey } from './readLinePlugin'
+import { blockTextRange, findTextInDoc } from '../blockIds'
 import { useProposedEditUiStore } from '@/stores/proposedEditUiStore'
 import type {
   CascadeEvidence,
@@ -200,12 +201,48 @@ export function createProposedChangePlugin(): Plugin {
 
 // --- Helpers --------------------------------------------------------------
 
-/** Show a resolution's proposed edits as decorations. */
+/**
+ * Show a resolution's proposed edits as decorations.
+ *
+ * Drift fix: stored edit positions were captured at proposal time and the
+ * document may have changed since (typing, an earlier apply, a re-reveal).
+ * Each edit is re-anchored against the CURRENT doc before its anchor is
+ * stored: prefer the block-scoped match when the edit knows its blockId
+ * (disambiguating repeated phrases), fall back to a whole-doc fingerprint
+ * search, and DROP edits whose target text no longer resolves anywhere
+ * (a stale anchor decorating the wrong text is worse than no decoration).
+ * Insertions (empty targetText) can't be fingerprinted and pass through
+ * with their stored positions.
+ */
 export function setProposedEdits(view: EditorView, edits: ProposedEdit[]) {
+  const doc = view.state.doc
+  const reanchored: ProposedEdit[] = []
+  let dropped = 0
+  for (const e of edits) {
+    if (!e.targetText) {
+      reanchored.push(e)
+      continue
+    }
+    const range =
+      (e.blockId ? blockTextRange(doc, e.blockId, e.targetText) : null) ??
+      findTextInDoc(doc, e.targetText)
+    if (!range) {
+      dropped++
+      continue
+    }
+    reanchored.push(
+      range.from === e.from && range.to === e.to ? e : { ...e, from: range.from, to: range.to },
+    )
+  }
+  if (dropped > 0) {
+    console.warn(
+      `proposedChangePlugin: dropped ${dropped} proposed edit(s) whose target text no longer resolves in the document`,
+    )
+  }
   view.dispatch(
     view.state.tr.setMeta(proposedChangePluginKey, {
       action: 'setEdits',
-      edits,
+      edits: reanchored,
     } as ProposedChangeMeta),
   )
 }

--- a/src/stores/__tests__/docGraphStore.test.ts
+++ b/src/stores/__tests__/docGraphStore.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest'
+import { schema } from '@/lib/prosemirror/schema'
+import { getDocGraph, invalidateDocGraphCache } from '@/lib/graphrag/docGraph'
+import { useDocGraphStore } from '@/stores/docGraphStore'
+import type { LLMConfig } from '@/stores/settingsStore'
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
+
+function doc() {
+  return schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('hello world')]),
+  ])
+}
+
+/** publishDocGraph is fire-and-forget via dynamic import — poll until it lands. */
+async function waitForStatus(status: string, timeoutMs = 1000): Promise<void> {
+  const start = Date.now()
+  while (useDocGraphStore.getState().status !== status) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(
+        `timed out waiting for status "${status}" (got "${useDocGraphStore.getState().status}")`,
+      )
+    }
+    await new Promise((r) => setTimeout(r, 5))
+  }
+}
+
+beforeEach(() => {
+  invalidateDocGraphCache()
+  useDocGraphStore.setState({ graph: null, status: 'idle' })
+})
+
+describe('docGraphStore publication (browser only)', () => {
+  it('getDocGraph publishes the built graph and ready status', async () => {
+    const graph = await getDocGraph(doc(), CONFIG, { skipLlm: true, skipEmbeddings: true })
+    await waitForStatus('ready')
+    expect(useDocGraphStore.getState().graph).toBe(graph)
+  })
+
+  it('cache hits publish too (fresh page, warm cache)', async () => {
+    const graph = await getDocGraph(doc(), CONFIG, { skipLlm: true, skipEmbeddings: true })
+    await waitForStatus('ready')
+    // Simulate a fresh UI store with a warm graph cache.
+    useDocGraphStore.setState({ graph: null, status: 'idle' })
+    const again = await getDocGraph(doc(), CONFIG, { skipLlm: true, skipEmbeddings: true })
+    expect(again).toBe(graph)
+    await waitForStatus('ready')
+    expect(useDocGraphStore.getState().graph).toBe(graph)
+  })
+})

--- a/src/stores/__tests__/docGraphStore.test.ts
+++ b/src/stores/__tests__/docGraphStore.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest'
 import { schema } from '@/lib/prosemirror/schema'
-import { getDocGraph, invalidateDocGraphCache } from '@/lib/graphrag/docGraph'
+import { buildDeterministicGraph, getDocGraph, invalidateDocGraphCache } from '@/lib/graphrag/docGraph'
 import { useDocGraphStore } from '@/stores/docGraphStore'
 import type { LLMConfig } from '@/stores/settingsStore'
 
@@ -28,7 +28,7 @@ async function waitForStatus(status: string, timeoutMs = 1000): Promise<void> {
 
 beforeEach(() => {
   invalidateDocGraphCache()
-  useDocGraphStore.setState({ graph: null, status: 'idle' })
+  useDocGraphStore.setState({ graph: null, status: 'idle', lastSeq: 0 })
 })
 
 describe('docGraphStore publication (browser only)', () => {
@@ -47,5 +47,29 @@ describe('docGraphStore publication (browser only)', () => {
     expect(again).toBe(graph)
     await waitForStatus('ready')
     expect(useDocGraphStore.getState().graph).toBe(graph)
+  })
+
+  it('ignores stale-seq publishes (compare-and-set — chip churn/race fix)', () => {
+    const fresh = buildDeterministicGraph(doc())
+    const store = useDocGraphStore.getState()
+
+    store.publish(2, 'ready', fresh)
+    // A slower, OLDER build finishing late must not churn the chip back to
+    // 'building' or overwrite the fresher graph.
+    store.publish(1, 'building')
+    store.publish(1, 'ready', buildDeterministicGraph(doc()))
+
+    expect(useDocGraphStore.getState().status).toBe('ready')
+    expect(useDocGraphStore.getState().graph).toBe(fresh)
+    expect(useDocGraphStore.getState().lastSeq).toBe(2)
+  })
+
+  it('equal-seq publishes apply (a build finishes with the seq of its own "building")', () => {
+    const store = useDocGraphStore.getState()
+    store.publish(3, 'building')
+    const g = buildDeterministicGraph(doc())
+    store.publish(3, 'ready', g)
+    expect(useDocGraphStore.getState().status).toBe('ready')
+    expect(useDocGraphStore.getState().graph).toBe(g)
   })
 })

--- a/src/stores/docGraphStore.ts
+++ b/src/stores/docGraphStore.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { create } from 'zustand'
+import type { DocGraph } from '@/lib/graphrag/docGraph'
+
+/**
+ * UI mirror of the doc-graph build lifecycle. NOT persisted — the graph holds
+ * live Maps keyed by runtime block ids and is rebuilt from the document on
+ * demand. Published by getDocGraph (browser only, via lazy import) so trust
+ * surfaces (StatusBar chip, "why this proposal?" edge paths) can read the
+ * latest graph without triggering a build themselves.
+ */
+
+export type DocGraphStatus = 'idle' | 'building' | 'ready'
+
+interface DocGraphState {
+  graph: DocGraph | null
+  status: DocGraphStatus
+  setGraph: (graph: DocGraph | null) => void
+  setStatus: (status: DocGraphStatus) => void
+}
+
+export const useDocGraphStore = create<DocGraphState>()((set) => ({
+  graph: null,
+  status: 'idle',
+  setGraph: (graph) => set({ graph }),
+  setStatus: (status) => set({ status }),
+}))

--- a/src/stores/docGraphStore.ts
+++ b/src/stores/docGraphStore.ts
@@ -16,6 +16,14 @@ export type DocGraphStatus = 'idle' | 'building' | 'ready'
 interface DocGraphState {
   graph: DocGraph | null
   status: DocGraphStatus
+  /** Highest publish seq applied so far — stale (lower-seq) publishes are ignored. */
+  lastSeq: number
+  /**
+   * Compare-and-set publish: ignores any publish whose seq is below the
+   * highest already applied, so an older build's late 'building'/'ready'
+   * can neither churn the chip nor overwrite a fresher graph.
+   */
+  publish: (seq: number, status: DocGraphStatus, graph?: DocGraph) => void
   setGraph: (graph: DocGraph | null) => void
   setStatus: (status: DocGraphStatus) => void
 }
@@ -23,6 +31,12 @@ interface DocGraphState {
 export const useDocGraphStore = create<DocGraphState>()((set) => ({
   graph: null,
   status: 'idle',
+  lastSeq: 0,
+  publish: (seq, status, graph) =>
+    set((s) => {
+      if (seq < s.lastSeq) return s
+      return { lastSeq: seq, status, ...(graph !== undefined ? { graph } : {}) }
+    }),
   setGraph: (graph) => set({ graph }),
   setStatus: (status) => set({ status }),
 }))

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -76,14 +76,20 @@ interface SettingsState {
   showApiKeyModal: boolean
   /**
    * Embedding-based paraphrase edges in the doc graph (default on). Silently
-   * inert for providers without an embeddings API (Anthropic). UI toggle
-   * lands in Wave C — the persisted field ships first.
+   * inert for providers without an embeddings API (Anthropic).
    */
   embeddingsEnabled: boolean
+  /**
+   * Second-pass citation verification for 'must'-severity cascade candidates
+   * (default on). One extra small-model call per cascade run; when off, the
+   * derived severities stand unverified.
+   */
+  judgeEnabled: boolean
   setLLMConfig: (config: Partial<LLMConfig>) => void
   setWhisperKey: (key: string) => void
   setShowApiKeyModal: (show: boolean) => void
   setEmbeddingsEnabled: (enabled: boolean) => void
+  setJudgeEnabled: (enabled: boolean) => void
   hasKeys: () => boolean
 }
 
@@ -99,11 +105,13 @@ export const useSettingsStore = create<SettingsState>()(
       whisperApiKey: '',
       showApiKeyModal: false,
       embeddingsEnabled: true,
+      judgeEnabled: true,
       setLLMConfig: (config) =>
         set((s) => ({ llmConfig: { ...s.llmConfig, ...config } })),
       setWhisperKey: (key) => set({ whisperApiKey: key }),
       setShowApiKeyModal: (show) => set({ showApiKeyModal: show }),
       setEmbeddingsEnabled: (enabled) => set({ embeddingsEnabled: enabled }),
+      setJudgeEnabled: (enabled) => set({ judgeEnabled: enabled }),
       hasKeys: () => {
         const s = get()
         // Ollama runs locally — no API key needed
@@ -120,6 +128,13 @@ export const useSettingsStore = create<SettingsState>()(
           if (normalized !== state.llmConfig.model) {
             state.setLLMConfig({ model: normalized })
           }
+        }
+        // Backfill toggles missing from older persisted snapshots (default on).
+        if (state && typeof (state as { embeddingsEnabled?: unknown }).embeddingsEnabled !== 'boolean') {
+          state.setEmbeddingsEnabled(true)
+        }
+        if (state && typeof (state as { judgeEnabled?: unknown }).judgeEnabled !== 'boolean') {
+          state.setJudgeEnabled(true)
         }
       },
     }


### PR DESCRIPTION
## Why

The cascade pipeline was precise but opaque: users couldn't see *why* a proposal existed, couldn't tell "graph found nothing" from "graph wasn't ready," had no way to toggle the AI passes that spend their tokens, and the core PRD flow-state rule (cascade flags buffer until coarse reading breakpoints) was never enforced. Two review-surface debts from v8.4 were also still open.

## What

**"Why this proposal?"** — a non-persisted graph store published from `getDocGraph` (seq-guarded against stale publishes), BFS `findEdgePath`, and a compact plain-text path line on `CascadeList` rows and the inline control: `linked via references ("Total Budget") → contradicts`.

**Graph status chip** in the StatusBar: `building… / rules only / enriched (+partial)` — distinguishing missing recall from missing readiness, with accessible explanations.

**Flow-state buffering, enforced correctly** — below-read-line cascade reveals wait until the reader crosses the primary block's end. The adversarial review caught the first design withholding held edits from the plugin entirely, which **hard-broke apply whenever the hold engaged** (missing anchors → whole-transaction abort) and wiped review statuses on reveal. The shipped design keeps every edit in the plugin (apply and modal always see the full set) and holds *decorations only* via a `revealed` flag; the poll partitions on live mapped positions. Regression tests pin apply-during-hold, status preservation across reveal, and breakpoint drift under typing.

**Validate-stored-first re-anchoring** — the drift fix now mirrors `applyProposedEdits`' own safety order: a stored anchor whose text still matches is truth; fingerprint search is recovery only. Review caught the inverted order silently relocating valid blockId-less anchors to the first occurrence of a repeated phrase — where apply-time validation would bless the wrong region. Pinned by the exact adversarial case.

**Modal ↔ plugin symmetry, without leaks** — modal toggles write through to plugin status (one pre-apply source of truth across all three surfaces); opening the modal seeds optional-severity pre-rejections into the plugin so surfaces agree immediately; **Cancel restores a snapshot** so an abandoned dialog changes nothing.

**"AI data & spend" settings** — toggles for citation verification (judge) and semantic-similarity edges, embed-model override, a precise data-egress statement (verified against actual behavior: nothing leaves on typing; 300-block embed cap; cheap-model judge), and a live session token estimate now fed by all structured/LLM/embedding calls.

## Testing

533 passed + 10 skipped (main baseline 490; +43), typecheck/lint/build clean, cascade E2E green (the two ingestion spec failures are pre-existing FalkorDB-dependency issues, verified identical at the baseline commit). Adversarial review pre-PR: NO-MERGE verdict with two HIGH interaction bugs → both redesigned (not patched) in `2a01bdc` with regression tests.

## Notes for reviewers

- Insertions (`targetText: ''`) still bypass fingerprint validation and render no decoration — pre-existing, now documented in-code as a known limitation.
- The spend estimate excludes transcription and is labeled a rough estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
