### PR TITLE
Cascade v2 finale: Graphiti bridge with source-aware selection, one cascade surface, calibration telemetry

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -698,3 +698,18 @@
   flex-direction: column;
   gap: 8px;
 }
+
+/* Cascade list attention flash — "Show affected" scrolls to the CascadeList
+   (the one cascade surface) and pulses its outline once. */
+.cascade-list-flash {
+  animation: cascade-list-flash 1.5s ease-out;
+}
+
+@keyframes cascade-list-flash {
+  0% {
+    box-shadow: 0 0 0 3px rgba(217, 119, 6, 0.55);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(217, 119, 6, 0);
+  }
+}

--- a/src/components/Annotations/CascadeList.tsx
+++ b/src/components/Annotations/CascadeList.tsx
@@ -113,9 +113,12 @@ export function CascadeList({ annotation }: CascadeListProps) {
     if (!view) return
     if (status === 'accepted' || status === 'rejected') {
       // Calibration telemetry (metadata only): guard against the CURRENT live
-      // status so a no-op click never double-counts.
-      const current = getProposedAnchors(view.state).get(edit.id) ?? edit
-      recordCascadeStatusChange(current, status, 'list')
+      // status so a no-op click never double-counts. Record ONLY when the live
+      // plugin anchor exists (matching ProposedEditControl and the modal) —
+      // without an anchor setProposedEditStatus below is a no-op, and counting
+      // a decision that changed nothing would skew calibration.
+      const current = getProposedAnchors(view.state).get(edit.id)
+      if (current) recordCascadeStatusChange(current, status, 'list')
     }
     setProposedEditStatus(view, edit.id, status)
   }

--- a/src/components/Annotations/CascadeList.tsx
+++ b/src/components/Annotations/CascadeList.tsx
@@ -4,6 +4,7 @@ import { useEditorStore } from '@/stores/editorStore'
 import { useDocGraphStore } from '@/stores/docGraphStore'
 import { getProposedAnchors, setProposedEditStatus } from '@/lib/prosemirror/plugins/proposedChangePlugin'
 import { findEdgePath, formatEdgePath } from '@/lib/graphrag/docGraph'
+import { recordCascadeStatusChange } from '@/lib/telemetry/cascadeCalibration'
 import type { Annotation, CascadeSeverity, ProposedEdit, ProposedEditStatus } from '@/lib/annotations/types'
 import { SEVERITY_LABELS, SEVERITY_ORDER } from '@/lib/annotations/types'
 
@@ -110,6 +111,12 @@ export function CascadeList({ annotation }: CascadeListProps) {
 
   const setStatus = (edit: ProposedEdit, status: ProposedEditStatus) => {
     if (!view) return
+    if (status === 'accepted' || status === 'rejected') {
+      // Calibration telemetry (metadata only): guard against the CURRENT live
+      // status so a no-op click never double-counts.
+      const current = getProposedAnchors(view.state).get(edit.id) ?? edit
+      recordCascadeStatusChange(current, status, 'list')
+    }
     setProposedEditStatus(view, edit.id, status)
   }
 

--- a/src/components/Annotations/CascadeList.tsx
+++ b/src/components/Annotations/CascadeList.tsx
@@ -114,7 +114,12 @@ export function CascadeList({ annotation }: CascadeListProps) {
   }
 
   return (
-    <div className="mt-3 mx-1 p-3 border border-amber-300 bg-amber-50 rounded-xl shadow-sm">
+    <div
+      data-cascade-list={annotation.id}
+      tabIndex={-1}
+      aria-label={`Affected sections for this change (${count})`}
+      className="mt-3 mx-1 p-3 border border-amber-300 bg-amber-50 rounded-xl shadow-sm focus:outline-none"
+    >
       {/* Header */}
       <div className="flex items-start gap-2 mb-2">
         <span className="text-amber-600 text-xs font-bold shrink-0">⤳</span>

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -20,6 +20,10 @@ import {
   type CommitStatusSnapshot,
 } from '@/lib/annotations/commitStatusSnapshot'
 import { applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
+import {
+  recordCascadeDecision,
+  recordCascadeStatusChange,
+} from '@/lib/telemetry/cascadeCalibration'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
 import { SemanticCommitModal } from '@/components/Editor/SemanticCommitModal'
@@ -151,6 +155,20 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         setShowDiffModal(false)
         setPendingHandler(null)
         return
+      }
+      // Calibration telemetry: each APPLIED cascade edit (metadata only;
+      // primary edits carry no calibration signal). 'applied' is a distinct
+      // action from the accepted/rejected status changes, so no status guard.
+      const appliedIds = new Set(ids)
+      for (const e of proposed) {
+        if (e.relation !== 'cascade' || !appliedIds.has(e.id)) continue
+        recordCascadeDecision({
+          severity: e.severity,
+          edgeType: e.evidence?.edgeType ?? null,
+          relation: 'cascade',
+          action: 'applied',
+          source: 'modal',
+        })
       }
       for (const ap of result.applied) {
         useChangesStore.getState().addEntry({
@@ -463,7 +481,13 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           // Modal → plugin write-back: the plugin's status is the single
           // pre-apply source of truth across all review surfaces. No-ops for
           // ids the plugin doesn't track (single-edit fallback rows).
-          if (view) setProposedEditStatus(view, id, status)
+          if (view) {
+            // Calibration telemetry (metadata only): guarded against the
+            // CURRENT plugin status so echoed toggles never double-count.
+            const current = getProposedAnchors(view.state).get(id)
+            if (current) recordCascadeStatusChange(current, status, 'modal')
+            setProposedEditStatus(view, id, status)
+          }
         }}
         onConfirm={(ids) => {
           // Confirm: the live statuses stand — drop the snapshot, no restore.

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -20,10 +20,13 @@ import {
   type CommitStatusSnapshot,
 } from '@/lib/annotations/commitStatusSnapshot'
 import { applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
+import { recordCascadeDecision } from '@/lib/telemetry/cascadeCalibration'
 import {
-  recordCascadeDecision,
-  recordCascadeStatusChange,
-} from '@/lib/telemetry/cascadeCalibration'
+  createModalDecisionBuffer,
+  type BufferedEditMeta,
+  type ModalDecisionBuffer,
+} from '@/lib/telemetry/modalDecisionBuffer'
+import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
 import { SemanticCommitModal } from '@/components/Editor/SemanticCommitModal'
@@ -44,6 +47,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   // Plugin statuses at modal-open time — cancel restores these so an
   // abandoned review session never leaks its toggles into the inline surfaces.
   const commitSnapshotRef = useRef<CommitStatusSnapshot | null>(null)
+  // Modal-source telemetry buffer: toggles inside the modal are provisional
+  // (last decision per edit wins), flushed on CONFIRM only, discarded on
+  // cancel — so flip noise and abandoned sessions never inflate calibration.
+  const modalDecisionsRef = useRef<ModalDecisionBuffer | null>(null)
 
   if (!annotation.resolution) return null
 
@@ -295,6 +302,23 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     const edits = annotation.resolution?.edits
     commitSnapshotRef.current =
       view && edits && edits.length > 1 ? openCommitReview(view, edits) : null
+    // Telemetry buffer baseline: the OPEN-time statuses (the snapshot taken
+    // before the optional pre-rejection seeding), so a toggle that ends where
+    // it started flushes nothing on confirm.
+    if (edits && edits.length > 1) {
+      const editsById = new Map<string, BufferedEditMeta>(
+        edits.map((e) => [
+          e.id,
+          { relation: e.relation, severity: e.severity, evidence: e.evidence },
+        ]),
+      )
+      const openStatuses = new Map(
+        edits.map((e) => [e.id, commitSnapshotRef.current?.[e.id] ?? e.status] as const),
+      )
+      modalDecisionsRef.current = createModalDecisionBuffer(editsById, openStatuses)
+    } else {
+      modalDecisionsRef.current = null
+    }
     setShowDiffModal(true)
   }
 
@@ -396,13 +420,11 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           ingestAnnotationEpisode(annotation)
 
           // The cascade proposals ARE the affected-sections view (one cascade
-          // surface). When this resolution carries cascade edits, bring the
-          // CascadeList into view and pulse it — no second read-only
-          // decoration lane.
-          const hasCascadeEdits = (annotation.resolution?.edits ?? []).some(
-            (e) => e.relation === 'cascade',
-          )
-          if (hasCascadeEdits) {
+          // surface). Scroll/pulse the CascadeList ONLY while it is actually
+          // rendered (status 'resolved' + cascade edits) — post-apply the list
+          // unmounts, so anything else falls back to a follow-up message that
+          // produces visible output instead of a dead button.
+          if (showAffectedMode(annotation) === 'scroll') {
             const list = document.querySelector<HTMLElement>(
               `[data-cascade-list="${annotation.id}"]`,
             )
@@ -482,21 +504,27 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           // pre-apply source of truth across all review surfaces. No-ops for
           // ids the plugin doesn't track (single-edit fallback rows).
           if (view) {
-            // Calibration telemetry (metadata only): guarded against the
-            // CURRENT plugin status so echoed toggles never double-count.
-            const current = getProposedAnchors(view.state).get(id)
-            if (current) recordCascadeStatusChange(current, status, 'modal')
+            // Calibration telemetry: BUFFERED (last decision per edit id),
+            // flushed on confirm only — provisional modal flips and cancelled
+            // sessions never inflate the counts.
+            modalDecisionsRef.current?.toggle(id, status)
             setProposedEditStatus(view, id, status)
           }
         }}
         onConfirm={(ids) => {
           // Confirm: the live statuses stand — drop the snapshot, no restore.
+          // Flush the buffered modal decisions (one event per decided edit).
+          modalDecisionsRef.current?.confirm()
+          modalDecisionsRef.current = null
           commitSnapshotRef.current = null
           applyConfirmedEdit(ids)
         }}
         onCancel={() => {
           // Cancel: restore the open-time statuses so modal toggles (and the
           // open-time optional pre-rejections) don't leak into inline surfaces.
+          // Discard the buffered decisions — an abandoned review records nothing.
+          modalDecisionsRef.current?.cancel()
+          modalDecisionsRef.current = null
           if (view && commitSnapshotRef.current) {
             restoreCommitReview(view, commitSnapshotRef.current)
           }

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -32,7 +32,6 @@ interface ResolutionActionsProps {
 
 export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   const updateAnnotation = useAnnotationStore((s) => s.update)
-  const addMessage = useAnnotationStore((s) => s.addMessage)
   const view = useEditorStore((s) => s.view)
   const [showDiffModal, setShowDiffModal] = useState(false)
   const [pendingHandler, setPendingHandler] = useState<string | null>(null)
@@ -374,44 +373,33 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       }
       case 'show-cascade': {
         if (view) {
+          // Feed the knowledge graph (best-effort) — future doc-graph builds
+          // pick these entities up via the graphiti edge pass.
           ingestAnnotationEpisode(annotation)
 
-          const result = await runCascadeCheck(
-            view,
-            annotation.anchor.text,
-            annotation.resolution?.suggestedEdit?.newText ?? annotation.anchor.text,
-            annotation.anchor.from,
+          // The cascade proposals ARE the affected-sections view (one cascade
+          // surface). When this resolution carries cascade edits, bring the
+          // CascadeList into view and pulse it — no second read-only
+          // decoration lane.
+          const hasCascadeEdits = (annotation.resolution?.edits ?? []).some(
+            (e) => e.relation === 'cascade',
           )
-          if (result.count > 0) {
-            const source = result.usedGraphRAG ? 'knowledge graph' : 'keyword analysis'
-            const entities = result.affectedEntities.slice(0, 5).join(', ')
-            const summaryText = `**${result.count} affected section${result.count > 1 ? 's' : ''}** found via ${source}.\n\n${entities ? `Affected: ${entities}` : ''}`
-            // Inject as conversation message
-            const cascadeMsg: ConversationMessage = {
-              id: generateId(),
-              role: 'agent',
-              content: summaryText,
-              suggestedEdit: null,
-              timestamp: Date.now(),
-            }
-            // Seed conversation if needed
-            const freshAnn = useAnnotationStore.getState().getById(annotation.id)
-            if (freshAnn && (!freshAnn.conversation || freshAnn.conversation.length === 0) && freshAnn.resolution) {
-              addMessage(annotation.id, {
-                id: generateId(),
-                role: 'agent',
-                content: freshAnn.resolution.content,
-                suggestedEdit: freshAnn.resolution.suggestedEdit ?? null,
-                timestamp: Date.now(),
-              })
-            }
-            addMessage(annotation.id, cascadeMsg)
-
-            useToastStore.getState().addToast(
-              `${result.count} affected section${result.count > 1 ? 's' : ''} highlighted`,
-              'info'
+          if (hasCascadeEdits) {
+            const list = document.querySelector<HTMLElement>(
+              `[data-cascade-list="${annotation.id}"]`,
             )
+            if (list) {
+              list.scrollIntoView({ behavior: 'smooth', block: 'center' })
+              list.focus({ preventScroll: true })
+              list.classList.remove('cascade-list-flash')
+              // Force a reflow so re-triggering restarts the animation.
+              void list.offsetWidth
+              list.classList.add('cascade-list-flash')
+              window.setTimeout(() => list.classList.remove('cascade-list-flash'), 1600)
+            }
           } else {
+            // No cascade edits to review — fall back to asking the agent for
+            // dependent locations as a conversation message.
             await sendFollowUp(annotation, 'Show all other locations in the document that reference or depend on this content. List each location with its text.')
           }
         }

--- a/src/components/Editor/ProposedEditControl.tsx
+++ b/src/components/Editor/ProposedEditControl.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/prosemirror/plugins/proposedChangePlugin'
 import { useDocGraphStore } from '@/stores/docGraphStore'
 import { findEdgePath, formatEdgePath } from '@/lib/graphrag/docGraph'
+import { recordCascadeStatusChange } from '@/lib/telemetry/cascadeCalibration'
 import { SEVERITY_LABELS } from '@/lib/annotations/types'
 
 interface ControlPosition {
@@ -91,6 +92,10 @@ export function ProposedEditControl() {
 
   const handleAccept = useCallback(() => {
     if (!view || !activeId) return
+    // Calibration telemetry (metadata only, status-change guarded) — read the
+    // CURRENT anchor status before dispatching the change.
+    const current = getProposedAnchors(view.state).get(activeId)
+    if (current) recordCascadeStatusChange(current, 'accepted', 'inline')
     // Status-only: never mutates the document. Batched apply does that.
     setProposedEditStatus(view, activeId, 'accepted')
     useProposedEditUiStore.getState().clear()
@@ -98,6 +103,8 @@ export function ProposedEditControl() {
 
   const handleReject = useCallback(() => {
     if (!view || !activeId) return
+    const current = getProposedAnchors(view.state).get(activeId)
+    if (current) recordCascadeStatusChange(current, 'rejected', 'inline')
     setProposedEditStatus(view, activeId, 'rejected')
     useProposedEditUiStore.getState().clear()
   }, [view, activeId])

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -37,7 +37,9 @@ export function ApiKeyModal() {
   const mustRatio = calibrationRatio('must')
   const likelyRatio = calibrationRatio('probably')
   const optionalRatio = calibrationRatio('optional')
-  const mustMiscalibrated = mustRatio.total > 0 && mustRatio.accepted / mustRatio.total < 0.7
+  // Hint only once there is a real sample — a single early rejection out of
+  // one or two decisions is noise, not miscalibration.
+  const mustMiscalibrated = mustRatio.total >= 5 && mustRatio.accepted / mustRatio.total < 0.7
 
   const [provider, setProvider] = useState<LLMProvider>(llmConfig.provider)
   const [apiKey, setApiKey] = useState(llmConfig.apiKey)
@@ -258,7 +260,8 @@ export function ApiKeyModal() {
                 Share anonymous review stats (no document content)
                 <span className="block text-xs text-muted">
                   Sends only severity and accept/reject counts for cascade proposals —
-                  never document text or identifiers. Off by default.
+                  never document text or identifiers. Off by default. If you connect an
+                  analytics client, its standard metadata applies.
                 </span>
               </span>
             </label>

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/stores/settingsStore'
 import { modelRejectsSampling } from '@/lib/ai/modelCapabilities'
 import { getSessionEstimate } from '@/lib/ai/spendEstimate'
+import { useCascadeCalibrationStore } from '@/stores/cascadeCalibrationStore'
 
 export function ApiKeyModal() {
   const llmConfig = useSettingsStore((s) => s.llmConfig)
@@ -21,6 +22,22 @@ export function ApiKeyModal() {
   const setJudgeEnabled = useSettingsStore((s) => s.setJudgeEnabled)
   const embeddingsEnabled = useSettingsStore((s) => s.embeddingsEnabled)
   const setEmbeddingsEnabled = useSettingsStore((s) => s.setEmbeddingsEnabled)
+  const telemetryEnabled = useSettingsStore((s) => s.telemetryEnabled)
+  const setTelemetryEnabled = useSettingsStore((s) => s.setTelemetryEnabled)
+  const calibrationCounts = useCascadeCalibrationStore((s) => s.counts)
+  const resetCalibration = useCascadeCalibrationStore((s) => s.reset)
+
+  // Local calibration readout: explicit review decisions only (accepted vs
+  // accepted + rejected) — 'applied' is a downstream consequence, not a
+  // per-proposal verdict.
+  const calibrationRatio = (severity: 'must' | 'probably' | 'optional') => {
+    const row = calibrationCounts[severity]
+    return { accepted: row.accepted, total: row.accepted + row.rejected }
+  }
+  const mustRatio = calibrationRatio('must')
+  const likelyRatio = calibrationRatio('probably')
+  const optionalRatio = calibrationRatio('optional')
+  const mustMiscalibrated = mustRatio.total > 0 && mustRatio.accepted / mustRatio.total < 0.7
 
   const [provider, setProvider] = useState<LLMProvider>(llmConfig.provider)
   const [apiKey, setApiKey] = useState(llmConfig.apiKey)
@@ -228,6 +245,46 @@ export function ApiKeyModal() {
                 placeholder="Default: text-embedding-3-small (OpenAI) / nomic-embed-text (Ollama)"
                 className="w-full px-3 py-2 text-sm font-mono border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-accent/20"
               />
+            </div>
+
+            <label className="flex items-start gap-2.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={telemetryEnabled}
+                onChange={(e) => setTelemetryEnabled(e.target.checked)}
+                className="mt-0.5 accent-ink"
+              />
+              <span className="text-sm text-ink leading-snug">
+                Share anonymous review stats (no document content)
+                <span className="block text-xs text-muted">
+                  Sends only severity and accept/reject counts for cascade proposals —
+                  never document text or identifiers. Off by default.
+                </span>
+              </span>
+            </label>
+
+            {/* Local severity-calibration readout — always local, never sent. */}
+            <div className="rounded-lg border border-border bg-warm/40 px-3 py-2 space-y-1">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-mono text-muted">
+                  Must accepted: {mustRatio.accepted}/{mustRatio.total}
+                  {' '}&middot; Likely: {likelyRatio.accepted}/{likelyRatio.total}
+                  {' '}&middot; Optional: {optionalRatio.accepted}/{optionalRatio.total}
+                </p>
+                <button
+                  onClick={resetCalibration}
+                  className="text-xs text-muted hover:text-ink underline underline-offset-2 shrink-0"
+                  title="Reset the local cascade review statistics"
+                >
+                  Reset
+                </button>
+              </div>
+              {mustMiscalibrated && (
+                <p className="text-xs text-annotation-correction">
+                  Verification may be miscalibrated &mdash; you reject most
+                  &ldquo;must change&rdquo; proposals.
+                </p>
+              )}
             </div>
 
             <p className="text-xs text-muted leading-relaxed">

--- a/src/lib/ai/__tests__/orchestrator.test.ts
+++ b/src/lib/ai/__tests__/orchestrator.test.ts
@@ -1,9 +1,14 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { EditorState } from 'prosemirror-state'
 import type { Node as PMNode } from 'prosemirror-model'
 import { schema } from '@/lib/prosemirror/schema'
 import { blockTextRange, findBlockById } from '@/lib/prosemirror/blockIds'
-import { buildDeterministicGraph, invalidateDocGraphCache } from '@/lib/graphrag/docGraph'
+import {
+  buildDeterministicGraph,
+  invalidateDocGraphCache,
+  type DocGraph,
+  type DocGraphEdge,
+} from '@/lib/graphrag/docGraph'
 import type { CallStructuredFn, StructuredRequest } from '@/lib/ai/structuredClient'
 import type { LLMConfig } from '@/stores/settingsStore'
 import type { SuggestedEdit } from '@/lib/annotations/types'
@@ -151,6 +156,57 @@ describe('proposeCascadeEdits — scoping', () => {
     expect(prompt).toContain('[b3]')
     expect(edits).toHaveLength(1)
     expect(edits[0].blockId).toBe('b3')
+  })
+
+  it('source-aware ordering: a deterministic-connected block outranks graphiti co-mentions at the same hop and survives the maxBlocks slice (truncation warns)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // Primary b1 defines "Launch Date"; detB (LAST in the doc, so worst doc
+      // position) references it deterministically; g1..g24 are connected to b1
+      // only through graphiti co-mention edges but all sit at earlier positions.
+      const doc = docOf(
+        p('b1', '"Launch Date" means March 1, 2026.'),
+        ...Array.from({ length: 24 }, (_, i) => p(`g${i + 1}`, `Graphiti filler block ${i + 1}.`)),
+        p('detB', 'Everything is due by the Launch Date.'),
+      )
+      const graph: DocGraph = buildDeterministicGraph(doc)
+      const pushEdge = (e: DocGraphEdge) => {
+        graph.edges.push(e)
+        for (const id of [e.from, e.to]) {
+          const list = graph.adjacency.get(id) ?? []
+          list.push(e)
+          graph.adjacency.set(id, list)
+        }
+      }
+      for (let i = 1; i <= 24; i++) {
+        pushEdge({ from: 'b1', to: `g${i}`, type: 'references', source: 'graphiti', evidence: 'x' })
+      }
+      // Sanity: the deterministic defined-term edge detB→b1 exists.
+      expect(
+        graph.edges.some((e) => e.from === 'detB' && e.to === 'b1' && e.source === 'deterministic'),
+      ).toBe(true)
+
+      const state = stateOf(doc)
+      const primary = primaryEditFor(doc, 'b1', 'March 1, 2026', 'June 1, 2026')
+      const captured: StructuredRequest[] = []
+      await proposeCascadeEdits(state, primary, CONFIG, {
+        graph,
+        maxBlocks: 24, // 26 candidates → 2 must be shed
+        callStructured: scripted([], captured),
+      })
+      const prompt = captured[0].messages.map((m) => m.content).join('\n')
+      // (hop, pos) ordering would shed detB (worst position); (hop, sourceRank,
+      // pos) keeps it and sheds the two worst-positioned graphiti co-mentions.
+      expect(prompt).toContain('[detB]')
+      expect(prompt).toContain('[g22]')
+      expect(prompt).not.toContain('[g23]')
+      expect(prompt).not.toContain('[g24]')
+      // The slice is never silent: counts-only truncation warning.
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(String(warn.mock.calls[0][0])).toContain('24 of 26')
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('candidate lines carry (§ heading path) context; blocks outside any heading stay bare', async () => {

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -307,13 +307,28 @@ export async function proposeCascadeEdits(
 
   // Re-resolve every candidate against the LIVE doc; graph positions are
   // build-time snapshots and are never trusted for content.
-  const candidates: Array<{ blockId: string; hop: number; pos: number; text: string }> = []
-  for (const [blockId, hop] of neighborhood) {
+  const candidates: Array<{
+    blockId: string
+    hop: number
+    sourceRank: number
+    pos: number
+    text: string
+  }> = []
+  for (const [blockId, { hop, sourceRank }] of neighborhood) {
     const live = findBlockById(doc, blockId)
     if (!live) continue // block vanished since graph build
-    candidates.push({ blockId, hop, pos: live.pos, text: live.node.textContent })
+    candidates.push({ blockId, hop, sourceRank, pos: live.pos, text: live.node.textContent })
   }
-  candidates.sort((a, b) => a.hop - b.hop || a.pos - b.pos)
+  // Source-aware ordering: at the same hop, blocks connected via
+  // higher-precision edges (deterministic/llm/embedding) outrank graphiti
+  // co-mentions, so the maxBlocks slice sheds low-precision candidates first.
+  candidates.sort((a, b) => a.hop - b.hop || a.sourceRank - b.sourceRank || a.pos - b.pos)
+  if (candidates.length > maxBlocks) {
+    // Never a silent truncation — counts only, no document text.
+    console.warn(
+      `cascade: neighborhood truncated — sending ${maxBlocks} of ${candidates.length} candidate blocks`,
+    )
+  }
   const sent = candidates.slice(0, maxBlocks)
   const sentIds = new Set(sent.map((c) => c.blockId))
 

--- a/src/lib/annotations/__tests__/showAffected.test.ts
+++ b/src/lib/annotations/__tests__/showAffected.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { showAffectedMode } from '../showAffected'
+import type {
+  Annotation,
+  AnnotationStatus,
+  ProposedEdit,
+  ProposedEditRelation,
+} from '../types'
+
+function edit(relation: ProposedEditRelation): ProposedEdit {
+  return {
+    id: `pe_${relation}_${Math.random().toString(36).slice(2)}`,
+    from: 1,
+    to: 5,
+    newText: 'new',
+    reason: 'r',
+    relation,
+    status: 'pending',
+    targetText: 'old',
+    severity: relation === 'primary' ? 'must' : 'probably',
+    evidence: null,
+  }
+}
+
+function ann(status: AnnotationStatus, edits?: ProposedEdit[]): Annotation {
+  return {
+    id: 'a1',
+    documentId: 'd1',
+    locationGroupKey: 'k',
+    type: 'edit',
+    status,
+    transcript: 't',
+    anchor: { from: 1, to: 5, scope: 'phrase', text: 'old' },
+    resolution:
+      edits === undefined
+        ? null
+        : {
+            type: 'edit',
+            content: 'c',
+            suggestedEdit: null,
+            edits,
+            actions: [],
+          },
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+describe('showAffectedMode', () => {
+  it('scroll: resolved annotation with cascade edits (CascadeList is mounted)', () => {
+    expect(showAffectedMode(ann('resolved', [edit('primary'), edit('cascade')]))).toBe('scroll')
+  })
+
+  it('followup: APPLIED annotation with cascade edits — the list is unmounted, scrolling would be a dead button', () => {
+    expect(showAffectedMode(ann('applied', [edit('primary'), edit('cascade')]))).toBe('followup')
+  })
+
+  it('followup: dismissed annotation with cascade edits', () => {
+    expect(showAffectedMode(ann('dismissed', [edit('primary'), edit('cascade')]))).toBe('followup')
+  })
+
+  it('followup: resolved but only a primary edit (no cascades to show)', () => {
+    expect(showAffectedMode(ann('resolved', [edit('primary')]))).toBe('followup')
+  })
+
+  it('followup: resolved with empty edits or no resolution at all', () => {
+    expect(showAffectedMode(ann('resolved', []))).toBe('followup')
+    expect(showAffectedMode(ann('resolved'))).toBe('followup')
+  })
+})

--- a/src/lib/annotations/showAffected.ts
+++ b/src/lib/annotations/showAffected.ts
@@ -1,0 +1,19 @@
+import type { Annotation } from './types'
+
+/**
+ * Branch decision for the "Show affected" action.
+ *
+ * 'scroll'   — scroll to + pulse the CascadeList. Only valid while the list is
+ *              actually rendered: CascadeList mounts ONLY for status
+ *              'resolved' annotations with cascade edits, so anything else
+ *              (applied, dismissed, no cascades) would scroll to nothing —
+ *              a dead button.
+ * 'followup' — ask the agent for dependent locations as a conversation
+ *              message (always produces visible output).
+ */
+export function showAffectedMode(annotation: Annotation): 'scroll' | 'followup' {
+  const hasCascadeEdits = (annotation.resolution?.edits ?? []).some(
+    (e) => e.relation === 'cascade',
+  )
+  return annotation.status === 'resolved' && hasCascadeEdits ? 'scroll' : 'followup'
+}

--- a/src/lib/graphrag/__tests__/docGraph.test.ts
+++ b/src/lib/graphrag/__tests__/docGraph.test.ts
@@ -12,6 +12,7 @@ import {
   formatEdgePath,
   contentHash,
   invalidateDocGraphCache,
+  SOURCE_PRIORITY,
   type DocGraphEdge,
 } from '../docGraph'
 
@@ -157,12 +158,12 @@ describe('getNeighborhood', () => {
       ),
     )
     const twoHops = getNeighborhood(graph, 'a', 2)
-    expect(twoHops.get('a')).toBe(0)
-    expect(twoHops.get('b')).toBe(1)
-    expect(twoHops.get('c')).toBe(2)
+    expect(twoHops.get('a')).toEqual({ hop: 0, sourceRank: 0 })
+    expect(twoHops.get('b')?.hop).toBe(1)
+    expect(twoHops.get('c')?.hop).toBe(2)
     expect(twoHops.has('d')).toBe(false)
     const threeHops = getNeighborhood(graph, 'a', 3)
-    expect(threeHops.get('d')).toBe(3)
+    expect(threeHops.get('d')?.hop).toBe(3)
   })
 
   it('returns empty map for unknown block', () => {
@@ -176,8 +177,30 @@ describe('getNeighborhood', () => {
     )
     // Sanity: a and b really are connected.
     expect(getNeighborhood(graph, 'b', 1).has('a')).toBe(true)
-    expect([...getNeighborhood(graph, 'b', 0).entries()]).toEqual([['b', 0]])
-    expect([...getNeighborhood(graph, 'b', -1).entries()]).toEqual([['b', 0]])
+    expect([...getNeighborhood(graph, 'b', 0).entries()]).toEqual([
+      ['b', { hop: 0, sourceRank: 0 }],
+    ])
+    expect([...getNeighborhood(graph, 'b', -1).entries()]).toEqual([
+      ['b', { hop: 0, sourceRank: 0 }],
+    ])
+  })
+
+  it('sourceRank is the best (lowest) SOURCE_PRIORITY among edges reaching a block at its discovery hop', () => {
+    const graph = buildDeterministicGraph(docOf(p('a', 'x'), p('b', 'y'), p('c', 'z')))
+    // a—b via graphiti only; a—c via BOTH graphiti and deterministic.
+    const abGraphiti: DocGraphEdge = { from: 'a', to: 'b', type: 'references', source: 'graphiti' }
+    const acGraphiti: DocGraphEdge = { from: 'a', to: 'c', type: 'references', source: 'graphiti' }
+    const acDet: DocGraphEdge = { from: 'c', to: 'a', type: 'references', source: 'deterministic' }
+    graph.edges.push(abGraphiti, acGraphiti, acDet)
+    graph.adjacency.set('a', [abGraphiti, acGraphiti, acDet])
+    graph.adjacency.set('b', [abGraphiti])
+    graph.adjacency.set('c', [acGraphiti, acDet])
+
+    const hood = getNeighborhood(graph, 'a', 1)
+    expect(hood.get('b')).toEqual({ hop: 1, sourceRank: SOURCE_PRIORITY.graphiti })
+    // c was ALSO reached via graphiti first, but the deterministic edge at the
+    // same discovery hop wins the rank.
+    expect(hood.get('c')).toEqual({ hop: 1, sourceRank: SOURCE_PRIORITY.deterministic })
   })
 })
 
@@ -637,6 +660,24 @@ describe('findEdgePath', () => {
     expect(findEdgePath(graph, 'missing', 'a')).toBeNull()
     expect(findEdgePath(graph, 'a', 'b')).toBeNull()
     expect(findEdgePath(graph, 'a', 'a')).toEqual([])
+  })
+
+  it('prefers non-graphiti evidence on an equal-length path (SOURCE_PRIORITY walk order)', () => {
+    const graph = buildDeterministicGraph(docOf(p('a', 'x'), p('b', 'y')))
+    // Parallel a↔b edges: graphiti listed FIRST in adjacency, deterministic second.
+    const graphitiEdge: DocGraphEdge = {
+      from: 'a', to: 'b', type: 'references', source: 'graphiti', evidence: 'Co-Mention',
+    }
+    const detEdge: DocGraphEdge = {
+      from: 'b', to: 'a', type: 'references', source: 'deterministic', evidence: 'Total Budget',
+    }
+    graph.edges.push(graphitiEdge, detEdge)
+    graph.adjacency.set('a', [graphitiEdge, detEdge])
+    graph.adjacency.set('b', [graphitiEdge, detEdge])
+
+    // Both directions surface the higher-precision deterministic edge.
+    expect(findEdgePath(graph, 'a', 'b')).toEqual([detEdge])
+    expect(findEdgePath(graph, 'b', 'a')).toEqual([detEdge])
   })
 })
 

--- a/src/lib/graphrag/__tests__/graphitiEdges.test.ts
+++ b/src/lib/graphrag/__tests__/graphitiEdges.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import type { LLMConfig } from '@/stores/settingsStore'
+import {
+  buildDeterministicGraph,
+  augmentWithGraphitiEdges,
+  getDocGraph,
+  invalidateDocGraphCache,
+  type GraphitiEdgeDeps,
+} from '../docGraph'
+import type { GraphNode, SubgraphResult } from '@/lib/mcp/graphitiClient'
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'test-key', model: 'test-model' }
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+function docOf(...blocks: PMNode[]): PMNode {
+  return schema.node('doc', null, blocks)
+}
+
+function entity(name: string, uuid = `uuid-${name}`): GraphNode {
+  return { uuid, name, summary: '' }
+}
+
+/** Scripted MCP client: fixed searchNodes hits + per-uuid subgraphs. */
+function scriptedClient(
+  hits: GraphNode[],
+  subgraphs: Record<string, SubgraphResult> = {},
+): Required<Pick<GraphitiEdgeDeps, 'searchNodes' | 'getSubgraph'>> {
+  return {
+    searchNodes: vi.fn(async () => hits),
+    getSubgraph: vi.fn(async (uuid: string) => subgraphs[uuid] ?? { nodes: [], edges: [] }),
+  }
+}
+
+beforeEach(() => {
+  invalidateDocGraphCache()
+})
+
+describe('augmentWithGraphitiEdges', () => {
+  it('links every pair of blocks mentioning a graph entity (references/graphiti, entity as evidence)', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('b1', 'The Pilot Program starts in June.'),
+        p('b2', 'Funding for the Pilot Program comes from reserves.'),
+        p('b3', 'Unrelated logistics notes.'),
+      ),
+    )
+    await augmentWithGraphitiEdges(graph, scriptedClient([entity('Pilot Program')]))
+
+    const graphitiEdges = graph.edges.filter((e) => e.source === 'graphiti')
+    expect(graphitiEdges).toEqual([
+      { from: 'b1', to: 'b2', type: 'references', source: 'graphiti', evidence: 'Pilot Program' },
+    ])
+    // Adjacency rebuilt so the cascade neighborhood sees the new edge.
+    expect(graph.adjacency.get('b1')).toContainEqual(graphitiEdges[0])
+    expect(graph.graphitiApplied).toBe(true)
+  })
+
+  it('includes entities discovered via subgraph expansion', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('b1', 'The Retention Window applies to backups.'),
+        p('b2', 'Purge jobs respect the Retention Window.'),
+      ),
+    )
+    const client = scriptedClient([entity('Primary Hit')], {
+      'uuid-Primary Hit': { nodes: [entity('Retention Window')], edges: [] },
+    })
+    await augmentWithGraphitiEdges(graph, client)
+
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([
+      { from: 'b1', to: 'b2', type: 'references', source: 'graphiti', evidence: 'Retention Window' },
+    ])
+  })
+
+  it('requires the entity name at word boundaries in ≥2 distinct blocks', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('b1', 'Budget planning is ongoing.'),      // word-boundary mention
+        p('b2', 'Budgetary constraints apply here.'), // substring only — no match
+        p('b3', 'Nothing relevant.'),
+      ),
+    )
+    await augmentWithGraphitiEdges(graph, scriptedClient([entity('Budget')]))
+    // Only one true block mention ⇒ no pairs ⇒ no edges.
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([])
+  })
+
+  it('skips stopword and short entity names', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('b1', 'This section covers the API and this document.'),
+        p('b2', 'That section also mentions the API and this document.'),
+      ),
+    )
+    await augmentWithGraphitiEdges(
+      graph,
+      scriptedClient([entity('this'), entity('API'), entity('section'), entity('document')]),
+    )
+    // 'this'/'section'/'document' are stopwords; 'API' is under 4 chars.
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([])
+  })
+
+  it('caps an entity to its first 10 blocks in document order (no pairwise firehose)', async () => {
+    const blocks = Array.from({ length: 12 }, (_, i) =>
+      p(`b${i + 1}`, `Clause ${i + 1} references the Total Budget figure.`),
+    )
+    const graph = buildDeterministicGraph(docOf(...blocks))
+    await augmentWithGraphitiEdges(graph, scriptedClient([entity('Total Budget')]))
+
+    const graphitiEdges = graph.edges.filter((e) => e.source === 'graphiti')
+    expect(graphitiEdges).toHaveLength(45) // C(10, 2) — blocks 11/12 excluded
+    const touched = new Set(graphitiEdges.flatMap((e) => [e.from, e.to]))
+    expect(touched.has('b11')).toBe(false)
+    expect(touched.has('b12')).toBe(false)
+  })
+
+  it('returns silently (no edges, no throw) when the MCP client fails', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+    )
+    const before = graph.edges.length
+    await expect(
+      augmentWithGraphitiEdges(graph, {
+        searchNodes: async () => {
+          throw new Error('ECONNREFUSED')
+        },
+        getSubgraph: async () => ({ nodes: [], edges: [] }),
+      }),
+    ).resolves.toBeUndefined()
+    expect(graph.edges).toHaveLength(before)
+    expect(graph.graphitiApplied).toBe(false) // retryable on a later build
+  })
+
+  it('returns silently when the MCP call exceeds the deadline', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+    )
+    await augmentWithGraphitiEdges(graph, {
+      searchNodes: () => new Promise(() => {}), // hangs forever
+      getSubgraph: async () => ({ nodes: [], edges: [] }),
+      timeoutMs: 20,
+    })
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([])
+    expect(graph.graphitiApplied).toBe(false)
+  })
+
+  it('is a no-op when already applied', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+    )
+    const client = scriptedClient([entity('Alpha Term')])
+    await augmentWithGraphitiEdges(graph, client)
+    await augmentWithGraphitiEdges(graph, client)
+    expect(client.searchNodes).toHaveBeenCalledTimes(1)
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toHaveLength(1)
+  })
+})
+
+describe('getDocGraph graphiti wiring', () => {
+  it('runs the graphiti pass on user-initiated builds', async () => {
+    const client = scriptedClient([entity('Alpha Term')])
+    const graph = await getDocGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+      CONFIG,
+      { skipLlm: true, embeddingsEnabled: false, graphiti: client },
+    )
+    expect(client.searchNodes).toHaveBeenCalledTimes(1)
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toHaveLength(1)
+    expect(graph.graphitiApplied).toBe(true)
+  })
+
+  it('background rebuilds skip the graphiti pass entirely (skipGraphiti)', async () => {
+    const client = scriptedClient([entity('Alpha Term')])
+    const graph = await getDocGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+      CONFIG,
+      { skipLlm: true, skipEmbeddings: true, skipGraphiti: true, graphiti: client },
+    )
+    expect(client.searchNodes).not.toHaveBeenCalled()
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([])
+    expect(graph.graphitiApplied).toBe(false)
+  })
+})

--- a/src/lib/graphrag/__tests__/graphitiEdges.test.ts
+++ b/src/lib/graphrag/__tests__/graphitiEdges.test.ts
@@ -119,6 +119,146 @@ describe('augmentWithGraphitiEdges', () => {
     expect(touched.has('b12')).toBe(false)
   })
 
+  it('caps distinct processed entities at 12 per build (13th skipped, count-only warn)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // 13 valid entities TermA01..TermA13, each mentioned in exactly 2 blocks.
+      const blocks = Array.from({ length: 13 }, (_, i) => {
+        const n = String(i + 1).padStart(2, '0')
+        return [
+          p(`x${n}`, `Clause about TermA${n} begins here.`),
+          p(`y${n}`, `Later clause repeats TermA${n} verbatim.`),
+        ]
+      }).flat()
+      const graph = buildDeterministicGraph(docOf(...blocks))
+      // Hub hit is under the 4-char minimum, so it is skipped (not processed)
+      // and the 13 subgraph-discovered entities arrive in insertion order.
+      const client = scriptedClient([entity('API')], {
+        'uuid-API': {
+          nodes: Array.from({ length: 13 }, (_, i) =>
+            entity(`TermA${String(i + 1).padStart(2, '0')}`),
+          ),
+          edges: [],
+        },
+      })
+      await augmentWithGraphitiEdges(graph, client)
+
+      const graphitiEdges = graph.edges.filter((e) => e.source === 'graphiti')
+      expect(graphitiEdges).toHaveLength(12) // one edge per processed entity
+      const evidences = new Set(graphitiEdges.map((e) => e.evidence))
+      expect(evidences.has('TermA12')).toBe(true)
+      expect(evidences.has('TermA13')).toBe(false) // the 13th was never processed
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(String(warn.mock.calls[0][0])).toContain('entity cap')
+      expect(String(warn.mock.calls[0][0])).toContain('12')
+      expect(graph.graphitiApplied).toBe(true)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('caps total graphiti edges at 120 per build (count-only warn, no silent firehose)', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // 3 entities × 10 disjoint mentioning blocks = 3 × C(10,2) = 135 potential edges.
+      const mk = (term: string, prefix: string) =>
+        Array.from({ length: 10 }, (_, i) =>
+          p(`${prefix}${i}`, `Clause ${i} of this section cites the ${term} figure.`),
+        )
+      const graph = buildDeterministicGraph(
+        docOf(...mk('AlphaTotal', 'a'), ...mk('BetaTotal', 'b'), ...mk('GammaTotal', 'c')),
+      )
+      await augmentWithGraphitiEdges(
+        graph,
+        scriptedClient([entity('AlphaTotal'), entity('BetaTotal'), entity('GammaTotal')]),
+      )
+
+      const graphitiEdges = graph.edges.filter((e) => e.source === 'graphiti')
+      expect(graphitiEdges).toHaveLength(120)
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(String(warn.mock.calls[0][0])).toContain('edge cap')
+      expect(String(warn.mock.calls[0][0])).toContain('120')
+      expect(graph.graphitiApplied).toBe(true)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('reversed duplicates of deterministic term edges are deduped (direction-normalized key)', async () => {
+    // Deterministic pass 2b creates use→def ('references', evidence term). The
+    // graphiti pair walks blocks in DOC order, producing def→use — the reverse
+    // orientation of the same relationship, which must not become a parallel edge.
+    const graph = buildDeterministicGraph(
+      docOf(
+        p('def', '"Pilot Program" means the trial rollout.'),
+        p('use', 'Funding for the Pilot Program comes from reserves.'),
+      ),
+    )
+    expect(graph.edges).toEqual([
+      {
+        from: 'use',
+        to: 'def',
+        type: 'references',
+        source: 'deterministic',
+        evidence: 'Pilot Program',
+      },
+    ])
+    await augmentWithGraphitiEdges(graph, scriptedClient([entity('Pilot Program')]))
+    expect(graph.edges.filter((e) => e.source === 'graphiti')).toEqual([])
+    expect(graph.edges).toHaveLength(1) // still just the deterministic edge
+    expect(graph.graphitiApplied).toBe(true)
+  })
+
+  it('threads an AbortSignal to the client and aborts in-flight calls at the deadline', async () => {
+    const graph = buildDeterministicGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+    )
+    const subgraphCalls: string[] = []
+    let searchSignal: AbortSignal | undefined
+    await augmentWithGraphitiEdges(graph, {
+      searchNodes: async (_q, _l, signal) => {
+        searchSignal = signal
+        return [entity('E-one'), entity('E-two'), entity('E-three')]
+      },
+      // Honors the signal: pends until aborted, then rejects.
+      getSubgraph: (uuid, _radius, signal) => {
+        subgraphCalls.push(uuid)
+        return new Promise((_, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')))
+        })
+      },
+      timeoutMs: 20,
+    })
+    expect(searchSignal).toBeInstanceOf(AbortSignal)
+    expect(searchSignal!.aborted).toBe(true)
+    expect(graph.graphitiApplied).toBe(false)
+    // Give any would-be zombie continuation time to fire further calls.
+    await new Promise((r) => setTimeout(r, 40))
+    expect(subgraphCalls).toEqual(['uuid-E-one']) // sequential calls stopped at the abort
+  })
+
+  it('stops zombie sequential getSubgraph calls even when the client ignores the signal', async () => {
+    // The client resolves AFTER the deadline without honoring the abort — the
+    // pass must still stop between calls via the signal.aborted check instead
+    // of walking all three subgraphs in the background.
+    const graph = buildDeterministicGraph(
+      docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),
+    )
+    const subgraphCalls: string[] = []
+    await augmentWithGraphitiEdges(graph, {
+      searchNodes: async () => [entity('E-one'), entity('E-two'), entity('E-three')],
+      getSubgraph: async (uuid) => {
+        subgraphCalls.push(uuid)
+        await new Promise((r) => setTimeout(r, 40)) // outlives the deadline
+        return { nodes: [], edges: [] }
+      },
+      timeoutMs: 15,
+    })
+    expect(graph.graphitiApplied).toBe(false)
+    await new Promise((r) => setTimeout(r, 120))
+    expect(subgraphCalls).toEqual(['uuid-E-one'])
+  })
+
   it('returns silently (no edges, no throw) when the MCP client fails', async () => {
     const graph = buildDeterministicGraph(
       docOf(p('b1', 'Alpha Term here.'), p('b2', 'Alpha Term there.')),

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -38,6 +38,18 @@ export interface DocGraphNode {
 
 export type DocGraphEdgeSource = 'deterministic' | 'llm' | 'embedding' | 'graphiti'
 
+/**
+ * Precision ranking of edge sources — lower is higher-precision. Used to
+ * stable-sort adjacency walks (findEdgePath evidence selection) and to rank
+ * cascade candidates discovered at the same hop (orchestrator ordering).
+ */
+export const SOURCE_PRIORITY: Record<DocGraphEdgeSource, number> = {
+  deterministic: 0,
+  llm: 1,
+  embedding: 2,
+  graphiti: 3,
+}
+
 export interface DocGraphEdge {
   from: string
   to: string
@@ -71,8 +83,11 @@ export interface DocGraph {
   /**
    * True once the Graphiti entity pass ran to completion. Stays false on any
    * MCP failure/timeout (FalkorDB is usually down in dev) — the pass is
-   * best-effort and a later build may retry, but a cached fully-built graph is
-   * never invalidated just because Graphiti was unreachable.
+   * best-effort, but a cached fully-built graph is never invalidated just
+   * because Graphiti was unreachable. Note the retry boundary: a warm-cache
+   * rebuild of the SAME content hash short-circuits before the Graphiti pass,
+   * so a failed pass is only retried when the content hash changes (a new
+   * build) — never on warm-cache hits.
    */
   graphitiApplied: boolean
   /** Per-textblock FNV-1a over blockId + text — the incremental-diff unit. */
@@ -534,21 +549,38 @@ const GRAPHITI_SEARCH_LIMIT = 5
 const GRAPHITI_SUBGRAPH_CAP = 3
 const GRAPHITI_MAX_BLOCKS_PER_ENTITY = 10
 const GRAPHITI_MIN_ENTITY_LENGTH = 4
+// Right-axis bounds: caps per-ENTITY above bound the left axis (blocks per
+// entity), these bound how many entities and how many total edges one build
+// may ever produce — a chatty knowledge graph cannot firehose the doc graph.
+const GRAPHITI_MAX_ENTITIES_PER_BUILD = 12
+const GRAPHITI_MAX_EDGES_PER_BUILD = 120
 
 export interface GraphitiEdgeDeps {
-  searchNodes?: (query: string, limit?: number) => Promise<GraphitiNode[]>
-  getSubgraph?: (nodeId: string, radius?: number) => Promise<GraphitiSubgraph>
+  searchNodes?: (query: string, limit?: number, signal?: AbortSignal) => Promise<GraphitiNode[]>
+  getSubgraph?: (nodeId: string, radius?: number, signal?: AbortSignal) => Promise<GraphitiSubgraph>
   timeoutMs?: number
 }
 
-/** Race a promise against a deadline; the timer never outlives the race. */
-async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+/**
+ * Run abortable work against a deadline. The deadline both rejects the race
+ * AND aborts the signal handed to `work`, so in-flight fetches are cancelled
+ * and any sequential follow-up calls stop — no zombie MCP conversation
+ * outliving the race. The timer never outlives the race.
+ */
+async function withDeadline<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+): Promise<T> {
+  const controller = new AbortController()
   let timer: ReturnType<typeof setTimeout> | undefined
   const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error('graphiti timeout')), ms)
+    timer = setTimeout(() => {
+      controller.abort(new Error('graphiti timeout'))
+      reject(new Error('graphiti timeout'))
+    }, ms)
   })
   try {
-    return await Promise.race([work, deadline])
+    return await Promise.race([work(controller.signal), deadline])
   } finally {
     clearTimeout(timer)
   }
@@ -564,13 +596,21 @@ async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
  * Guardrails (the old read-only lane's false-positive lessons):
  * - entities shorter than GRAPHITI_MIN_ENTITY_LENGTH chars or matching the
  *   term stopwords are skipped entirely;
+ * - at most GRAPHITI_MAX_ENTITIES_PER_BUILD valid entities are processed per
+ *   build (first-appearance order); hitting the cap logs a count-only warn;
  * - an entity mentioned in more than GRAPHITI_MAX_BLOCKS_PER_ENTITY blocks is
  *   capped to its first N blocks in document order (no pairwise firehose);
- * - entities found in fewer than 2 distinct blocks produce nothing.
+ * - at most GRAPHITI_MAX_EDGES_PER_BUILD graphiti edges are added per build;
+ *   hitting the cap logs a count-only warn;
+ * - entities found in fewer than 2 distinct blocks produce nothing;
+ * - dedupe is direction-agnostic: a graphiti pair whose reverse orientation
+ *   already exists as a deterministic/llm 'references' edge adds nothing.
  *
  * Strictly best-effort and non-blocking: the whole MCP conversation races a
- * GRAPHITI_TIMEOUT_MS deadline, and ANY failure (FalkorDB down — the usual
- * dev state) returns silently having changed nothing.
+ * GRAPHITI_TIMEOUT_MS deadline that also ABORTS the in-flight MCP calls (the
+ * AbortSignal is threaded through searchNodes/getSubgraph, and the sequential
+ * subgraph loop stops between calls once aborted), and ANY failure (FalkorDB
+ * down — the usual dev state) returns silently having changed nothing.
  */
 export async function augmentWithGraphitiEdges(
   graph: DocGraph,
@@ -587,46 +627,76 @@ export async function augmentWithGraphitiEdges(
 
   try {
     const entityNames = await withDeadline(
-      (async () => {
+      async (signal) => {
         const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
         const query = ordered
           .map((n) => n.text)
           .join(' ')
           .slice(0, GRAPHITI_QUERY_MAX_CHARS)
-        const matching = await search(query, GRAPHITI_SEARCH_LIMIT)
+        const matching = await search(query, GRAPHITI_SEARCH_LIMIT, signal)
         const names = new Set<string>()
         for (const node of matching.slice(0, GRAPHITI_SUBGRAPH_CAP)) {
+          // The deadline may already have fired — never start a zombie call.
+          if (signal.aborted) throw new Error('graphiti timeout')
           names.add(node.name)
-          const sub = await subgraph(node.uuid, 2)
+          const sub = await subgraph(node.uuid, 2, signal)
           for (const gn of sub.nodes) names.add(gn.name)
         }
         return names
-      })(),
+      },
       timeoutMs,
     )
 
     const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
-    const edgeKeys = new Set(graph.edges.map((e) => `${e.from}${e.to}${e.type}`))
+    const edgeKeys = new Set(graph.edges.map((e) => `${e.from} ${e.to} ${e.type}`))
     let added = false
+    let processedEntities = 0
+    let addedEdges = 0
+    let entityCapHit = false
+    let edgeCapHit = false
     for (const rawName of entityNames) {
       const name = rawName?.trim()
       if (!name || name.length < GRAPHITI_MIN_ENTITY_LENGTH) continue
       if (TERM_STOPWORDS.has(name.toLowerCase())) continue
+      if (processedEntities >= GRAPHITI_MAX_ENTITIES_PER_BUILD) {
+        entityCapHit = true
+        break
+      }
+      processedEntities++
       const containing = ordered
         .filter((n) => containsTerm(n.text, name))
         .slice(0, GRAPHITI_MAX_BLOCKS_PER_ENTITY)
       if (containing.length < 2) continue
-      for (let i = 0; i < containing.length; i++) {
+      outer: for (let i = 0; i < containing.length; i++) {
         for (let j = i + 1; j < containing.length; j++) {
           const from = containing[i].blockId
           const to = containing[j].blockId
-          const key = `${from}${to}references`
-          if (edgeKeys.has(key)) continue
+          // Direction-normalized dedupe: check BOTH orientations so a graphiti
+          // pair can never shadow-duplicate a reversed deterministic term edge.
+          const key = `${from} ${to} references`
+          const reverseKey = `${to} ${from} references`
+          if (edgeKeys.has(key) || edgeKeys.has(reverseKey)) continue
+          if (addedEdges >= GRAPHITI_MAX_EDGES_PER_BUILD) {
+            edgeCapHit = true
+            break outer
+          }
           edgeKeys.add(key)
           graph.edges.push({ from, to, type: 'references', source: 'graphiti', evidence: name })
           added = true
+          addedEdges++
         }
       }
+      if (edgeCapHit) break
+    }
+    if (entityCapHit) {
+      console.warn(
+        `docGraph: graphiti entity cap hit — processed ${GRAPHITI_MAX_ENTITIES_PER_BUILD} entities, remainder skipped`,
+      )
+    }
+    if (edgeCapHit) {
+      console.warn(
+        `docGraph: graphiti edge cap hit — added ${GRAPHITI_MAX_EDGES_PER_BUILD} edges, remainder skipped`,
+      )
     }
     if (added) graph.adjacency = buildAdjacency(graph.edges)
     graph.graphitiApplied = true
@@ -844,24 +914,42 @@ export async function getDocGraph(
   return promise
 }
 
-/** BFS over the undirected adjacency: blockId → hop distance (0 = the block itself). */
+export interface NeighborhoodEntry {
+  /** BFS hop distance (0 = the block itself). */
+  hop: number
+  /**
+   * Best (lowest) SOURCE_PRIORITY among the edges that connected the block at
+   * its discovery hop — a block reachable through a deterministic edge ranks
+   * ahead of one reachable only through a graphiti co-mention at the same hop.
+   * 0 for the seed block itself.
+   */
+  sourceRank: number
+}
+
+/** BFS over the undirected adjacency: blockId → { hop, sourceRank }. */
 export function getNeighborhood(
   graph: DocGraph,
   blockId: string,
   hops: number,
-): Map<string, number> {
-  const dist = new Map<string, number>()
+): Map<string, NeighborhoodEntry> {
+  const dist = new Map<string, NeighborhoodEntry>()
   if (!graph.nodes.has(blockId)) return dist
-  dist.set(blockId, 0)
+  dist.set(blockId, { hop: 0, sourceRank: 0 })
   let frontier = [blockId]
   for (let hop = 1; hop <= hops && frontier.length; hop++) {
     const next: string[] = []
     for (const id of frontier) {
       for (const edge of graph.adjacency.get(id) ?? []) {
         const neighbor = edge.from === id ? edge.to : edge.from
-        if (!dist.has(neighbor)) {
-          dist.set(neighbor, hop)
+        const rank = SOURCE_PRIORITY[edge.source]
+        const existing = dist.get(neighbor)
+        if (!existing) {
+          dist.set(neighbor, { hop, sourceRank: rank })
           next.push(neighbor)
+        } else if (existing.hop === hop && rank < existing.sourceRank) {
+          // Another edge reaches the same block at its discovery hop with a
+          // higher-precision source — keep the best rank.
+          existing.sourceRank = rank
         }
       }
     }
@@ -874,6 +962,9 @@ export function getNeighborhood(
  * BFS shortest path over the undirected adjacency, as the ordered edge list
  * walked from `fromBlockId` to `toBlockId`. Returns [] when the endpoints are
  * the same block, null when either endpoint is unknown or no path exists.
+ * Each node's edges are walked in SOURCE_PRIORITY order (stable sort), so on
+ * equal-length paths the "why this proposal?" line surfaces the
+ * higher-precision evidence (deterministic/llm/embedding before graphiti).
  * Pure — powers the "why this proposal?" affordance.
  */
 export function findEdgePath(
@@ -884,13 +975,16 @@ export function findEdgePath(
   if (!graph.nodes.has(fromBlockId) || !graph.nodes.has(toBlockId)) return null
   if (fromBlockId === toBlockId) return []
 
+  const bySourcePriority = (edges: DocGraphEdge[]): DocGraphEdge[] =>
+    [...edges].sort((a, b) => SOURCE_PRIORITY[a.source] - SOURCE_PRIORITY[b.source])
+
   const cameFrom = new Map<string, { via: DocGraphEdge; prev: string }>()
   const visited = new Set([fromBlockId])
   let frontier = [fromBlockId]
   while (frontier.length) {
     const next: string[] = []
     for (const id of frontier) {
-      for (const edge of graph.adjacency.get(id) ?? []) {
+      for (const edge of bySourcePriority(graph.adjacency.get(id) ?? [])) {
         const far = edge.from === id ? edge.to : edge.from
         if (visited.has(far)) continue
         visited.add(far)

--- a/src/lib/graphrag/docGraph.ts
+++ b/src/lib/graphrag/docGraph.ts
@@ -5,6 +5,12 @@ import type { CascadeEdgeType } from '@/lib/annotations/types'
 import { collectTextblocks } from '@/lib/prosemirror/blockIds'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
 import { augmentWithEmbeddingEdges, type EmbedFn } from './embedEdges'
+import {
+  searchNodes as graphitiSearchNodes,
+  getSubgraph as graphitiGetSubgraph,
+  type GraphNode as GraphitiNode,
+  type SubgraphResult as GraphitiSubgraph,
+} from '@/lib/mcp/graphitiClient'
 
 /**
  * Document dependency graph — the retrieval index the cascade queries instead
@@ -62,6 +68,13 @@ export interface DocGraph {
    * — mirror of llmPartial. Never a silent truncation: setting this warns.
    */
   embeddingsPartial: boolean
+  /**
+   * True once the Graphiti entity pass ran to completion. Stays false on any
+   * MCP failure/timeout (FalkorDB is usually down in dev) — the pass is
+   * best-effort and a later build may retry, but a cached fully-built graph is
+   * never invalidated just because Graphiti was unreachable.
+   */
+  graphitiApplied: boolean
   /** Per-textblock FNV-1a over blockId + text — the incremental-diff unit. */
   blockHashes: Map<string, string>
   nodes: Map<string, DocGraphNode>
@@ -317,6 +330,7 @@ export function buildDeterministicGraph(doc: PMNode): DocGraph {
     llmPartial: false,
     embeddingsApplied: false,
     embeddingsPartial: false,
+    graphitiApplied: false,
     blockHashes,
     nodes,
     edges,
@@ -507,6 +521,121 @@ function mergeLlmToolCalls(
   graph.adjacency = buildAdjacency(graph.edges)
 }
 
+// --- Graphiti entity pass -----------------------------------------------------
+
+// Same call shape as the old read-only cascade lane (searchNodes → top-3
+// subgraphs), but the results become GRAPH EDGES the one cascade surface
+// consumes — not a parallel decoration surface. Tight caps on purpose: the
+// old lane's known failure mode was a false-positive firehose from generic
+// entity names matched all over the document.
+const GRAPHITI_TIMEOUT_MS = 1500
+const GRAPHITI_QUERY_MAX_CHARS = 200
+const GRAPHITI_SEARCH_LIMIT = 5
+const GRAPHITI_SUBGRAPH_CAP = 3
+const GRAPHITI_MAX_BLOCKS_PER_ENTITY = 10
+const GRAPHITI_MIN_ENTITY_LENGTH = 4
+
+export interface GraphitiEdgeDeps {
+  searchNodes?: (query: string, limit?: number) => Promise<GraphitiNode[]>
+  getSubgraph?: (nodeId: string, radius?: number) => Promise<GraphitiSubgraph>
+  timeoutMs?: number
+}
+
+/** Race a promise against a deadline; the timer never outlives the race. */
+async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('graphiti timeout')), ms)
+  })
+  try {
+    return await Promise.race([work, deadline])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Third edge source: knowledge-graph entities from the Graphiti MCP server.
+ * Searches the graph for entities related to this document, then links every
+ * pair of blocks that BOTH mention an entity name (word-boundary match via
+ * containsTerm) with a `references`/`graphiti` edge carrying the entity name
+ * as evidence.
+ *
+ * Guardrails (the old read-only lane's false-positive lessons):
+ * - entities shorter than GRAPHITI_MIN_ENTITY_LENGTH chars or matching the
+ *   term stopwords are skipped entirely;
+ * - an entity mentioned in more than GRAPHITI_MAX_BLOCKS_PER_ENTITY blocks is
+ *   capped to its first N blocks in document order (no pairwise firehose);
+ * - entities found in fewer than 2 distinct blocks produce nothing.
+ *
+ * Strictly best-effort and non-blocking: the whole MCP conversation races a
+ * GRAPHITI_TIMEOUT_MS deadline, and ANY failure (FalkorDB down — the usual
+ * dev state) returns silently having changed nothing.
+ */
+export async function augmentWithGraphitiEdges(
+  graph: DocGraph,
+  deps: GraphitiEdgeDeps = {},
+): Promise<void> {
+  if (graph.graphitiApplied) return
+  if (graph.nodes.size < 2) {
+    graph.graphitiApplied = true
+    return
+  }
+  const search = deps.searchNodes ?? graphitiSearchNodes
+  const subgraph = deps.getSubgraph ?? graphitiGetSubgraph
+  const timeoutMs = deps.timeoutMs ?? GRAPHITI_TIMEOUT_MS
+
+  try {
+    const entityNames = await withDeadline(
+      (async () => {
+        const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
+        const query = ordered
+          .map((n) => n.text)
+          .join(' ')
+          .slice(0, GRAPHITI_QUERY_MAX_CHARS)
+        const matching = await search(query, GRAPHITI_SEARCH_LIMIT)
+        const names = new Set<string>()
+        for (const node of matching.slice(0, GRAPHITI_SUBGRAPH_CAP)) {
+          names.add(node.name)
+          const sub = await subgraph(node.uuid, 2)
+          for (const gn of sub.nodes) names.add(gn.name)
+        }
+        return names
+      })(),
+      timeoutMs,
+    )
+
+    const ordered = [...graph.nodes.values()].sort((a, b) => a.pos - b.pos)
+    const edgeKeys = new Set(graph.edges.map((e) => `${e.from}${e.to}${e.type}`))
+    let added = false
+    for (const rawName of entityNames) {
+      const name = rawName?.trim()
+      if (!name || name.length < GRAPHITI_MIN_ENTITY_LENGTH) continue
+      if (TERM_STOPWORDS.has(name.toLowerCase())) continue
+      const containing = ordered
+        .filter((n) => containsTerm(n.text, name))
+        .slice(0, GRAPHITI_MAX_BLOCKS_PER_ENTITY)
+      if (containing.length < 2) continue
+      for (let i = 0; i < containing.length; i++) {
+        for (let j = i + 1; j < containing.length; j++) {
+          const from = containing[i].blockId
+          const to = containing[j].blockId
+          const key = `${from}${to}references`
+          if (edgeKeys.has(key)) continue
+          edgeKeys.add(key)
+          graph.edges.push({ from, to, type: 'references', source: 'graphiti', evidence: name })
+          added = true
+        }
+      }
+    }
+    if (added) graph.adjacency = buildAdjacency(graph.edges)
+    graph.graphitiApplied = true
+  } catch {
+    // MCP unreachable, malformed reply, or deadline hit — the graph is fully
+    // usable without this pass; return silently, never throw, never block.
+  }
+}
+
 // --- Cache + entry points ---------------------------------------------------
 
 const CACHE_MAX = 8
@@ -654,6 +783,10 @@ export async function getDocGraph(
     embed?: EmbedFn
     /** Test/caller override for the settings-store embeddings toggle. */
     embeddingsEnabled?: boolean
+    /** Skip the Graphiti entity pass (background rebuilds — user-initiated only). */
+    skipGraphiti?: boolean
+    /** Injectable Graphiti MCP client (tests: scripted searchNodes/getSubgraph). */
+    graphiti?: GraphitiEdgeDeps
   } = {},
 ): Promise<DocGraph> {
   const hash = contentHash(doc)
@@ -693,6 +826,14 @@ export async function getDocGraph(
     }
     if (embeddingsOn && !graph.embeddingsApplied) {
       await augmentWithEmbeddingEdges(graph, config, deps.embed)
+    }
+    // Graphiti entity edges: user-initiated builds only (same privacy stance
+    // as the LLM/embedding passes — background typing must never trigger MCP
+    // traffic). Deliberately NOT part of the cache-hit condition above: when
+    // FalkorDB is down (the usual dev state) a warm cache must not re-pay the
+    // connection attempt on every cascade.
+    if (!deps.skipGraphiti && !graph.graphitiApplied) {
+      await augmentWithGraphitiEdges(graph, deps.graphiti)
     }
     cacheGraph(hash, graph)
     publishDocGraph(seq, 'ready', graph)
@@ -798,10 +939,10 @@ let rebuildTimer: ReturnType<typeof setTimeout> | null = null
 /**
  * Debounced background rebuild, wired into the editor's dispatchTransaction so
  * the cascade usually hits a warm deterministic graph. Deliberately
- * DETERMINISTIC-ONLY (`skipLlm` + `skipEmbeddings`): document text must never
- * leave the machine as a side effect of typing — the LLM extraction and
- * embedding passes run lazily inside the cascade, which the user explicitly
- * initiated. All failures are swallowed.
+ * DETERMINISTIC-ONLY (`skipLlm` + `skipEmbeddings` + `skipGraphiti`): document
+ * text must never leave the machine (or process) as a side effect of typing —
+ * the LLM extraction, embedding, and Graphiti passes run lazily inside the
+ * cascade, which the user explicitly initiated. All failures are swallowed.
  */
 export function scheduleDocGraphRebuild(view: EditorView, delayMs = 2000): void {
   if (rebuildTimer) clearTimeout(rebuildTimer)
@@ -813,6 +954,7 @@ export function scheduleDocGraphRebuild(view: EditorView, delayMs = 2000): void 
       await getDocGraph(view.state.doc, useSettingsStore.getState().llmConfig, {
         skipLlm: true,
         skipEmbeddings: true,
+        skipGraphiti: true,
       })
     })().catch(() => {})
   }, delayMs)

--- a/src/lib/mcp/graphitiClient.ts
+++ b/src/lib/mcp/graphitiClient.ts
@@ -43,7 +43,11 @@ export interface SubgraphResult {
   edges: Array<{ source: string; target: string; name?: string; fact: string; validAt?: string | null; invalidAt?: string | null }>
 }
 
-async function mcpCall<T>(toolName: string, args: Record<string, unknown>): Promise<T> {
+async function mcpCall<T>(
+  toolName: string,
+  args: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
   const response = await fetch(GRAPHITI_MCP_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -51,6 +55,7 @@ async function mcpCall<T>(toolName: string, args: Record<string, unknown>): Prom
       method: "tools/call",
       params: { name: toolName, arguments: args },
     }),
+    ...(signal ? { signal } : {}),
   })
   if (!response.ok) {
     throw new Error(`Graphiti ${toolName} failed: ${response.status}`)
@@ -69,15 +74,24 @@ export async function addEpisode(episode: Episode): Promise<{ success: boolean }
   return { success: true }
 }
 
-export async function searchNodes(query: string, limit = 10): Promise<GraphNode[]> {
-  return mcpCall<GraphNode[]>("search_nodes", { query, limit })
+export async function searchNodes(
+  query: string,
+  limit = 10,
+  signal?: AbortSignal,
+): Promise<GraphNode[]> {
+  return mcpCall<GraphNode[]>("search_nodes", { query, limit }, signal)
 }
 
-export async function getSubgraph(nodeId: string, radius = 2): Promise<SubgraphResult> {
-  return mcpCall<SubgraphResult>("get_entity_subgraph", {
-    entity_uuid: nodeId,
-    radius,
-  })
+export async function getSubgraph(
+  nodeId: string,
+  radius = 2,
+  signal?: AbortSignal,
+): Promise<SubgraphResult> {
+  return mcpCall<SubgraphResult>(
+    "get_entity_subgraph",
+    { entity_uuid: nodeId, radius },
+    signal,
+  )
 }
 
 export async function searchFacts(query: string, limit = 10): Promise<GraphEdge[]> {

--- a/src/lib/telemetry/__tests__/cascadeCalibration.test.ts
+++ b/src/lib/telemetry/__tests__/cascadeCalibration.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import {
+  recordCascadeDecision,
+  recordCascadeStatusChange,
+  CASCADE_CALIBRATION_EVENT,
+  type CascadeDecisionEvent,
+  type ReviewedEditLike,
+} from '../cascadeCalibration'
+import {
+  useCascadeCalibrationStore,
+  emptyCalibrationCounts,
+} from '@/stores/cascadeCalibrationStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+
+const CASCADE_EVENT: CascadeDecisionEvent = {
+  severity: 'must',
+  edgeType: 'references',
+  relation: 'cascade',
+  action: 'accepted',
+  source: 'inline',
+}
+
+function pendingEdit(overrides: Partial<ReviewedEditLike> = {}): ReviewedEditLike {
+  return {
+    relation: 'cascade',
+    severity: 'probably',
+    evidence: { sourceBlockId: 'b1', quotedText: '$50,000', edgeType: 'references' },
+    status: 'pending',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useCascadeCalibrationStore.getState().reset()
+  useSettingsStore.setState({ telemetryEnabled: false })
+})
+
+describe('recordCascadeDecision — local aggregate sink', () => {
+  it('always records cascade decisions into the local aggregate', () => {
+    recordCascadeDecision(CASCADE_EVENT)
+    recordCascadeDecision({ ...CASCADE_EVENT, action: 'applied', source: 'modal' })
+    const counts = useCascadeCalibrationStore.getState().counts
+    expect(counts.must.accepted).toBe(1)
+    expect(counts.must.applied).toBe(1)
+  })
+
+  it('drops primary-relation events entirely (no calibration signal)', () => {
+    const capture = vi.fn()
+    recordCascadeDecision(
+      { ...CASCADE_EVENT, relation: 'primary' },
+      { telemetryEnabled: true, capture },
+    )
+    expect(useCascadeCalibrationStore.getState().counts.must.accepted).toBe(0)
+    expect(capture).not.toHaveBeenCalled()
+  })
+})
+
+describe('recordCascadeDecision — remote capture gating', () => {
+  it('does NOT capture when telemetryEnabled is false (the default)', () => {
+    const capture = vi.fn()
+    recordCascadeDecision(CASCADE_EVENT, { capture })
+    // Settings default is false — no deps override needed.
+    expect(useSettingsStore.getState().telemetryEnabled).toBe(false)
+    expect(capture).not.toHaveBeenCalled()
+    // Local aggregate still recorded.
+    expect(useCascadeCalibrationStore.getState().counts.must.accepted).toBe(1)
+  })
+
+  it('captures when telemetryEnabled is true', () => {
+    const capture = vi.fn()
+    recordCascadeDecision(CASCADE_EVENT, { telemetryEnabled: true, capture })
+    expect(capture).toHaveBeenCalledTimes(1)
+    expect(capture).toHaveBeenCalledWith(CASCADE_CALIBRATION_EVENT, {
+      severity: 'must',
+      edgeType: 'references',
+      relation: 'cascade',
+      action: 'accepted',
+      source: 'inline',
+    })
+  })
+
+  it('reads the settings-store flag when no override is given', () => {
+    const capture = vi.fn()
+    useSettingsStore.setState({ telemetryEnabled: true })
+    recordCascadeDecision(CASCADE_EVENT, { capture })
+    expect(capture).toHaveBeenCalledTimes(1)
+  })
+
+  it('payload contains ONLY closed-enum metadata — no text, no ids', () => {
+    const capture = vi.fn()
+    recordCascadeDecision(CASCADE_EVENT, { telemetryEnabled: true, capture })
+    const [, payload] = capture.mock.calls[0] as [string, Record<string, unknown>]
+    expect(Object.keys(payload).sort()).toEqual([
+      'action',
+      'edgeType',
+      'relation',
+      'severity',
+      'source',
+    ])
+    const ALLOWED = new Set([
+      'must', 'probably', 'optional',
+      'defines', 'references', 'depends-on', 'implements', 'tests', 'contradicts', 'duplicates',
+      'cascade', 'primary',
+      'accepted', 'rejected', 'applied',
+      'inline', 'list', 'modal',
+      null,
+    ])
+    for (const value of Object.values(payload)) {
+      expect(ALLOWED.has(value as string | null)).toBe(true)
+    }
+  })
+
+  // Compile-time shape lock: adding a text/id-bearing field to the event type
+  // must force this literal (and therefore this test file) to be revisited.
+  it('event type is exactly {severity, edgeType, relation, action, source}', () => {
+    const exhaustive: Record<keyof CascadeDecisionEvent, true> = {
+      severity: true,
+      edgeType: true,
+      relation: true,
+      action: true,
+      source: true,
+    }
+    expect(Object.keys(exhaustive)).toHaveLength(5)
+  })
+
+  it('a throwing capture sink never propagates (fire and forget)', () => {
+    expect(() =>
+      recordCascadeDecision(CASCADE_EVENT, {
+        telemetryEnabled: true,
+        capture: () => {
+          throw new Error('posthog exploded')
+        },
+      }),
+    ).not.toThrow()
+    // The local aggregate was still written before the sink threw.
+    expect(useCascadeCalibrationStore.getState().counts.must.accepted).toBe(1)
+  })
+})
+
+describe('recordCascadeStatusChange — status-change-only guard', () => {
+  it('records when the status actually changes', () => {
+    recordCascadeStatusChange(pendingEdit(), 'accepted', 'list')
+    expect(useCascadeCalibrationStore.getState().counts.probably.accepted).toBe(1)
+  })
+
+  it('does NOT record when the new status equals the current status', () => {
+    recordCascadeStatusChange(pendingEdit({ status: 'accepted' }), 'accepted', 'inline')
+    recordCascadeStatusChange(pendingEdit({ status: 'rejected' }), 'rejected', 'modal')
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+
+  it('records a flip from accepted to rejected (a real decision change)', () => {
+    recordCascadeStatusChange(pendingEdit({ status: 'accepted' }), 'rejected', 'modal')
+    expect(useCascadeCalibrationStore.getState().counts.probably.rejected).toBe(1)
+  })
+
+  it('ignores primary edits and uses evidence edge type for cascades', () => {
+    const capture = vi.fn()
+    recordCascadeStatusChange(pendingEdit({ relation: 'primary' }), 'accepted', 'inline', {
+      telemetryEnabled: true,
+      capture,
+    })
+    expect(capture).not.toHaveBeenCalled()
+
+    recordCascadeStatusChange(pendingEdit({ evidence: null }), 'accepted', 'inline', {
+      telemetryEnabled: true,
+      capture,
+    })
+    expect(capture).toHaveBeenCalledWith(
+      CASCADE_CALIBRATION_EVENT,
+      expect.objectContaining({ edgeType: null }),
+    )
+  })
+})

--- a/src/lib/telemetry/__tests__/modalDecisionBuffer.test.ts
+++ b/src/lib/telemetry/__tests__/modalDecisionBuffer.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createModalDecisionBuffer, type BufferedEditMeta } from '../modalDecisionBuffer'
+import {
+  useCascadeCalibrationStore,
+  emptyCalibrationCounts,
+} from '@/stores/cascadeCalibrationStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+import type { ProposedEditStatus } from '@/lib/annotations/types'
+
+const CASCADE_META: BufferedEditMeta = {
+  relation: 'cascade',
+  severity: 'must',
+  evidence: { sourceBlockId: 'b1', quotedText: '$50,000', edgeType: 'references' },
+}
+
+function buffer(
+  metas: Record<string, BufferedEditMeta>,
+  openStatuses: Record<string, ProposedEditStatus> = {},
+) {
+  return createModalDecisionBuffer(
+    new Map(Object.entries(metas)),
+    new Map(Object.entries(openStatuses)),
+  )
+}
+
+beforeEach(() => {
+  useCascadeCalibrationStore.getState().reset()
+  useSettingsStore.setState({ telemetryEnabled: false })
+})
+
+describe('createModalDecisionBuffer', () => {
+  it('cancel discards everything — an abandoned review records nothing', () => {
+    const buf = buffer({ e1: CASCADE_META, e2: CASCADE_META })
+    buf.toggle('e1', 'rejected')
+    buf.toggle('e2', 'accepted')
+    buf.cancel()
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+    // A confirm AFTER cancel also flushes nothing (buffer was cleared).
+    buf.confirm()
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+
+  it('confirm flushes ONE event per edit — last decision wins, flip inflation gone', () => {
+    const capture = vi.fn()
+    const buf = buffer({ e1: CASCADE_META, e2: { ...CASCADE_META, severity: 'probably' } })
+    // Flip e1 back and forth: only the final 'rejected' may count.
+    buf.toggle('e1', 'accepted')
+    buf.toggle('e1', 'rejected')
+    buf.toggle('e1', 'accepted')
+    buf.toggle('e1', 'rejected')
+    buf.toggle('e2', 'accepted')
+    buf.confirm({ telemetryEnabled: true, capture })
+
+    const counts = useCascadeCalibrationStore.getState().counts
+    expect(counts.must.rejected).toBe(1)
+    expect(counts.must.accepted).toBe(0) // the intermediate flips never landed
+    expect(counts.probably.accepted).toBe(1)
+    expect(capture).toHaveBeenCalledTimes(2)
+    expect(capture).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ action: 'rejected', severity: 'must', source: 'modal' }),
+    )
+  })
+
+  it('a decision ending at the modal-OPEN-time status flushes nothing (status-change guard)', () => {
+    const buf = buffer({ e1: CASCADE_META }, { e1: 'accepted' })
+    buf.toggle('e1', 'rejected')
+    buf.toggle('e1', 'accepted') // back where the review started
+    buf.confirm()
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+
+  it('guards against the OPEN-time status, not pending: open-rejected → accepted records', () => {
+    const buf = buffer({ e1: CASCADE_META }, { e1: 'rejected' })
+    buf.toggle('e1', 'accepted')
+    buf.confirm()
+    expect(useCascadeCalibrationStore.getState().counts.must.accepted).toBe(1)
+  })
+
+  it('confirm clears the buffer — a second confirm records nothing more', () => {
+    const buf = buffer({ e1: CASCADE_META })
+    buf.toggle('e1', 'accepted')
+    buf.confirm()
+    buf.confirm()
+    expect(useCascadeCalibrationStore.getState().counts.must.accepted).toBe(1)
+  })
+
+  it('ignores ids outside the review set (single-edit fallback rows)', () => {
+    const buf = buffer({ e1: CASCADE_META })
+    buf.toggle('annotation-id-not-an-edit', 'accepted')
+    buf.confirm()
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+
+  it('primary-relation edits flush no calibration events (no signal)', () => {
+    const buf = buffer({
+      prim: { ...CASCADE_META, relation: 'primary' },
+      casc: CASCADE_META,
+    })
+    buf.toggle('prim', 'rejected')
+    buf.toggle('casc', 'rejected')
+    buf.confirm()
+    const counts = useCascadeCalibrationStore.getState().counts
+    expect(counts.must.rejected).toBe(1) // only the cascade counted
+  })
+})

--- a/src/lib/telemetry/cascadeCalibration.ts
+++ b/src/lib/telemetry/cascadeCalibration.ts
@@ -1,0 +1,135 @@
+import type {
+  CascadeEdgeType,
+  CascadeEvidence,
+  CascadeSeverity,
+  ProposedEditRelation,
+  ProposedEditStatus,
+} from '@/lib/annotations/types'
+import { useCascadeCalibrationStore } from '@/stores/cascadeCalibrationStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+
+/**
+ * Severity-calibration telemetry for cascade review decisions — METADATA ONLY.
+ *
+ * Every event is exactly { severity, edgeType, relation, action, source }:
+ * closed enum values, no document text, no annotation/edit/document ids, no
+ * free-form strings. Two sinks:
+ *
+ * 1. ALWAYS: the local persisted aggregate (cascadeCalibrationStore) that
+ *    powers the settings readout. Never leaves the machine.
+ * 2. ONLY when the `telemetryEnabled` setting is true (default FALSE — this is
+ *    a public repo and other people run this app): a PostHog capture. No
+ *    PostHog client is wired into the app today, so the capture is a
+ *    clearly-marked stub calling `window.posthog?.capture` — it becomes live
+ *    the moment a user initializes posthog-js themselves, and is a silent
+ *    no-op until then.
+ *
+ * Recording is fire-and-forget: every entry point swallows all errors so
+ * telemetry can never block or break a review flow.
+ */
+
+export interface CascadeDecisionEvent {
+  severity: CascadeSeverity
+  /** Evidence edge type when the proposal was cited, else null. */
+  edgeType: CascadeEdgeType | null
+  relation: ProposedEditRelation
+  action: 'accepted' | 'rejected' | 'applied'
+  source: 'inline' | 'list' | 'modal'
+}
+
+/** Remote-sink payload — the event minus nothing, plus nothing. */
+type CapturePayload = Pick<
+  CascadeDecisionEvent,
+  'severity' | 'edgeType' | 'relation' | 'action' | 'source'
+>
+
+export type CaptureFn = (eventName: string, payload: CapturePayload) => void
+
+export const CASCADE_CALIBRATION_EVENT = 'cascade_calibration_decision'
+
+/**
+ * PostHog capture STUB: no posthog client is initialized anywhere in this app
+ * (grep: no posthog imports exist). If a user wires posthog-js up themselves,
+ * `window.posthog` exists and this starts capturing; otherwise it is a no-op.
+ */
+const defaultCapture: CaptureFn = (eventName, payload) => {
+  if (typeof window === 'undefined') return
+  const w = window as {
+    posthog?: { capture?: (name: string, props: Record<string, unknown>) => void }
+  }
+  w.posthog?.capture?.(eventName, { ...payload })
+}
+
+/** Test/caller injection points; production call sites pass nothing. */
+export interface RecordDeps {
+  capture?: CaptureFn
+  /** Override for the settings-store telemetryEnabled flag. */
+  telemetryEnabled?: boolean
+}
+
+/**
+ * Record one cascade review decision. Only `relation === 'cascade'` events
+ * carry calibration signal (primary edits are what the user explicitly asked
+ * for — accepting them says nothing about derived severities), so anything
+ * else is dropped. Never throws.
+ */
+export function recordCascadeDecision(event: CascadeDecisionEvent, deps: RecordDeps = {}): void {
+  try {
+    if (event.relation !== 'cascade') return
+
+    // Sink 1 (always): local aggregate for the settings readout.
+    useCascadeCalibrationStore.getState().record(event.severity, event.action)
+
+    // Sink 2 (opt-in, default off): anonymous remote capture.
+    const enabled = deps.telemetryEnabled ?? useSettingsStore.getState().telemetryEnabled
+    if (!enabled) return
+    const payload: CapturePayload = {
+      severity: event.severity,
+      edgeType: event.edgeType,
+      relation: event.relation,
+      action: event.action,
+      source: event.source,
+    }
+    ;(deps.capture ?? defaultCapture)(CASCADE_CALIBRATION_EVENT, payload)
+  } catch {
+    // Telemetry must never block a review flow.
+  }
+}
+
+/** The slice of a ProposedEdit / ProposedAnchor the guard needs. */
+export interface ReviewedEditLike {
+  relation: ProposedEditRelation
+  severity: CascadeSeverity
+  evidence: CascadeEvidence | null
+  status: ProposedEditStatus
+}
+
+/**
+ * Status-change guard shared by every accept/reject surface: records ONLY
+ * when `next` differs from the edit's CURRENT status (callers pass the live
+ * plugin anchor when available), so re-clicking Accept on an already-accepted
+ * edit — or the modal echoing a status the plugin already holds — never
+ * double-counts. Call BEFORE dispatching setProposedEditStatus.
+ */
+export function recordCascadeStatusChange(
+  edit: ReviewedEditLike,
+  next: 'accepted' | 'rejected',
+  source: CascadeDecisionEvent['source'],
+  deps: RecordDeps = {},
+): void {
+  try {
+    if (edit.status === next) return
+    recordCascadeDecision(
+      {
+        severity: edit.severity,
+        edgeType: edit.evidence?.edgeType ?? null,
+        relation: edit.relation,
+        action: next,
+        source,
+      },
+      deps,
+    )
+  } catch {
+    // Never block the review flow.
+  }
+}

--- a/src/lib/telemetry/modalDecisionBuffer.ts
+++ b/src/lib/telemetry/modalDecisionBuffer.ts
@@ -1,0 +1,70 @@
+import type { ProposedEditStatus } from '@/lib/annotations/types'
+import {
+  recordCascadeStatusChange,
+  type RecordDeps,
+  type ReviewedEditLike,
+} from './cascadeCalibration'
+
+/**
+ * Modal-source telemetry buffering. Toggles made INSIDE an open commit review
+ * are provisional — the user can flip a decision back and forth, or abandon
+ * the whole session with Cancel. Recording each toggle live would inflate the
+ * calibration counts with flip noise and count decisions that were never
+ * committed. So the modal buffers: last decision per edit id, flushed as ONE
+ * event per edit on CONFIRM (guarded against the modal-OPEN-time status, so a
+ * toggle that ends where it started records nothing), discarded on cancel.
+ *
+ * Inline and CascadeList sites are unaffected — their single clicks are final
+ * decisions and keep recording immediately.
+ */
+
+/** The per-edit metadata the flush needs (status comes from the open-time snapshot). */
+export type BufferedEditMeta = Omit<ReviewedEditLike, 'status'>
+
+export interface ModalDecisionBuffer {
+  /** Record the latest provisional decision for an edit (last one wins). */
+  toggle(id: string, status: 'accepted' | 'rejected'): void
+  /** CONFIRM: flush one event per decided edit, then clear. */
+  confirm(deps?: RecordDeps): void
+  /** CANCEL: discard everything — an abandoned review records nothing. */
+  cancel(): void
+}
+
+/**
+ * @param editsById   metadata for the edits under review; toggles for unknown
+ *                    ids (e.g. single-edit fallback rows) are ignored.
+ * @param openStatuses plugin statuses at modal-open time — the flush guard
+ *                    baseline (the live plugin status is useless here: the
+ *                    modal writes toggles through, so by confirm time it
+ *                    always equals the last toggle).
+ */
+export function createModalDecisionBuffer(
+  editsById: ReadonlyMap<string, BufferedEditMeta>,
+  openStatuses: ReadonlyMap<string, ProposedEditStatus>,
+): ModalDecisionBuffer {
+  const last = new Map<string, 'accepted' | 'rejected'>()
+  return {
+    toggle(id, status) {
+      if (editsById.has(id)) last.set(id, status)
+    },
+    confirm(deps) {
+      try {
+        for (const [id, status] of last) {
+          const meta = editsById.get(id)
+          if (!meta) continue
+          recordCascadeStatusChange(
+            { ...meta, status: openStatuses.get(id) ?? 'pending' },
+            status,
+            'modal',
+            deps,
+          )
+        }
+      } finally {
+        last.clear()
+      }
+    },
+    cancel() {
+      last.clear()
+    },
+  }
+}

--- a/src/stores/__tests__/cascadeCalibrationStore.test.ts
+++ b/src/stores/__tests__/cascadeCalibrationStore.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  useCascadeCalibrationStore,
+  emptyCalibrationCounts,
+  CALIBRATION_COUNT_CAP,
+} from '../cascadeCalibrationStore'
+
+beforeEach(() => {
+  useCascadeCalibrationStore.getState().reset()
+})
+
+describe('cascadeCalibrationStore', () => {
+  it('starts with all-zero counts for every severity × action', () => {
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+
+  it('record() increments exactly one severity × action counter', () => {
+    const { record } = useCascadeCalibrationStore.getState()
+    record('must', 'accepted')
+    record('must', 'accepted')
+    record('must', 'rejected')
+    record('probably', 'applied')
+
+    const counts = useCascadeCalibrationStore.getState().counts
+    expect(counts.must).toEqual({ accepted: 2, rejected: 1, applied: 0 })
+    expect(counts.probably).toEqual({ accepted: 0, rejected: 0, applied: 1 })
+    expect(counts.optional).toEqual({ accepted: 0, rejected: 0, applied: 0 })
+  })
+
+  it('caps each counter at CALIBRATION_COUNT_CAP', () => {
+    useCascadeCalibrationStore.setState((s) => ({
+      counts: {
+        ...s.counts,
+        optional: { ...s.counts.optional, rejected: CALIBRATION_COUNT_CAP },
+      },
+    }))
+    useCascadeCalibrationStore.getState().record('optional', 'rejected')
+    expect(useCascadeCalibrationStore.getState().counts.optional.rejected).toBe(
+      CALIBRATION_COUNT_CAP,
+    )
+  })
+
+  it('reset() zeroes everything', () => {
+    const { record, reset } = useCascadeCalibrationStore.getState()
+    record('must', 'accepted')
+    record('optional', 'rejected')
+    reset()
+    expect(useCascadeCalibrationStore.getState().counts).toEqual(emptyCalibrationCounts())
+  })
+})

--- a/src/stores/cascadeCalibrationStore.ts
+++ b/src/stores/cascadeCalibrationStore.ts
@@ -1,0 +1,83 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { CascadeSeverity } from '@/lib/annotations/types'
+
+/**
+ * Local severity-calibration aggregate for cascade review decisions.
+ *
+ * Pure counters — counts by severity × action only. NO document text, NO
+ * annotation/edit ids, NO timestamps ever enter this store; it exists so the
+ * settings panel can show whether the derived severities match how the user
+ * actually reviews (e.g. "must" proposals being rejected half the time means
+ * verification is miscalibrated). Always on: this aggregate never leaves the
+ * machine. The optional PostHog sink lives in lib/telemetry and is gated
+ * separately behind the telemetryEnabled setting (default off).
+ */
+
+export type CalibrationAction = 'accepted' | 'rejected' | 'applied'
+
+export type CalibrationCounts = Record<CascadeSeverity, Record<CalibrationAction, number>>
+
+/** Per-counter cap — keeps a years-long local aggregate bounded. */
+export const CALIBRATION_COUNT_CAP = 100_000
+
+export function emptyCalibrationCounts(): CalibrationCounts {
+  return {
+    must: { accepted: 0, rejected: 0, applied: 0 },
+    probably: { accepted: 0, rejected: 0, applied: 0 },
+    optional: { accepted: 0, rejected: 0, applied: 0 },
+  }
+}
+
+/** Backfill/clamp a possibly-partial persisted shape (older builds, tampering). */
+function normalizeCounts(raw: unknown): CalibrationCounts {
+  const counts = emptyCalibrationCounts()
+  if (!raw || typeof raw !== 'object') return counts
+  for (const severity of Object.keys(counts) as CascadeSeverity[]) {
+    const row = (raw as Record<string, unknown>)[severity]
+    if (!row || typeof row !== 'object') continue
+    for (const action of Object.keys(counts[severity]) as CalibrationAction[]) {
+      const value = (row as Record<string, unknown>)[action]
+      if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+        counts[severity][action] = Math.min(Math.floor(value), CALIBRATION_COUNT_CAP)
+      }
+    }
+  }
+  return counts
+}
+
+interface CascadeCalibrationState {
+  counts: CalibrationCounts
+  record: (severity: CascadeSeverity, action: CalibrationAction) => void
+  reset: () => void
+}
+
+export const useCascadeCalibrationStore = create<CascadeCalibrationState>()(
+  persist(
+    (set) => ({
+      counts: emptyCalibrationCounts(),
+      record: (severity, action) =>
+        set((s) => {
+          const current = s.counts[severity]?.[action] ?? 0
+          if (current >= CALIBRATION_COUNT_CAP) return s
+          return {
+            counts: {
+              ...s.counts,
+              [severity]: { ...s.counts[severity], [action]: current + 1 },
+            },
+          }
+        }),
+      reset: () => set({ counts: emptyCalibrationCounts() }),
+    }),
+    {
+      name: 'intent-ide-cascade-calibration',
+      onRehydrateStorage: () => (state) => {
+        if (!state) return
+        const normalized = normalizeCounts(state.counts)
+        state.counts = normalized
+      },
+    },
+  ),
+)

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -85,11 +85,20 @@ interface SettingsState {
    * derived severities stand unverified.
    */
   judgeEnabled: boolean
+  /**
+   * Anonymous severity-calibration telemetry (default OFF — public repo,
+   * other users). When on, cascade accept/reject decisions send metadata-only
+   * events (severity × action, never document content or ids) to PostHog if
+   * one is wired. The local calibration aggregate records regardless — it
+   * never leaves the machine.
+   */
+  telemetryEnabled: boolean
   setLLMConfig: (config: Partial<LLMConfig>) => void
   setWhisperKey: (key: string) => void
   setShowApiKeyModal: (show: boolean) => void
   setEmbeddingsEnabled: (enabled: boolean) => void
   setJudgeEnabled: (enabled: boolean) => void
+  setTelemetryEnabled: (enabled: boolean) => void
   hasKeys: () => boolean
 }
 
@@ -106,12 +115,14 @@ export const useSettingsStore = create<SettingsState>()(
       showApiKeyModal: false,
       embeddingsEnabled: true,
       judgeEnabled: true,
+      telemetryEnabled: false,
       setLLMConfig: (config) =>
         set((s) => ({ llmConfig: { ...s.llmConfig, ...config } })),
       setWhisperKey: (key) => set({ whisperApiKey: key }),
       setShowApiKeyModal: (show) => set({ showApiKeyModal: show }),
       setEmbeddingsEnabled: (enabled) => set({ embeddingsEnabled: enabled }),
       setJudgeEnabled: (enabled) => set({ judgeEnabled: enabled }),
+      setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
       hasKeys: () => {
         const s = get()
         // Ollama runs locally — no API key needed
@@ -135,6 +146,11 @@ export const useSettingsStore = create<SettingsState>()(
         }
         if (state && typeof (state as { judgeEnabled?: unknown }).judgeEnabled !== 'boolean') {
           state.setJudgeEnabled(true)
+        }
+        // Privacy-sensitive: anything other than an explicit stored `true`
+        // resolves to OFF.
+        if (state && typeof (state as { telemetryEnabled?: unknown }).telemetryEnabled !== 'boolean') {
+          state.setTelemetryEnabled(false)
         }
       },
     }


### PR DESCRIPTION
## Why

The final Cascade v2 consolidation: two cascade surfaces still coexisted (the old read-only Graphiti conflict decorations beside the editable proposals), and the evaluation loop had no feedback signal — user accept/reject decisions on severity-ranked proposals were recorded nowhere.

## What

**Graphiti entities as a third graph edge source — with the firehose engineered out on the right axis.** `augmentWithGraphitiEdges` reuses the MCP conversation but emits typed graph edges instead of decorations, bounded where it actually matters (the adversarial review caught the first version capping per-entity fan-out while leaving *entity count* unbounded and cross-document): ≤12 entities and ≤120 edges per build (count-only warns), stopword/short-name filters, 1500ms **abortable** deadline (the AbortSignal threads through to fetch, and the sequential subgraph loop checks it — no zombie MCP work after timeout). Background typing rebuilds skip it entirely.

**Source-aware candidate selection.** `getNeighborhood` now records the edge quality that discovered each block; the cascade's 24-block budget fills by `(hop, source priority, position)` — deterministic → LLM → embedding → graphiti — so entity co-mentions can never evict a true LLM-discovered dependent from the review set. Neighborhood truncation now warns (counts only) instead of slicing silently. `findEdgePath` prefers higher-precision evidence on ties, so "why this proposal?" cites the best edge.

**One cascade surface.** "Show affected" now points at the proposals themselves (scroll + pulse on the CascadeList) — status-gated to exactly when the list is mounted, with the conversational fallback otherwise (review caught the ungated version as a silently dead button post-apply). `cascadeCheck`'s read-only decorations remain only in the post-apply path and explicit impact analysis.

**Severity-calibration telemetry, privacy-first.** Metadata-only events (closed enums — severity, edge type, action, source; the review traced every field: no document text, no identifiers can reach the sink): a local persisted aggregate always powers a settings readout ("Must accepted: X/Y…", miscalibration hint gated on n≥5), while remote capture is opt-in and **default off** (and the copy discloses that a connected analytics client adds its own envelope metadata). Modal decisions are buffered and flushed only on confirm — cancelled reviews and toggle flip-flops don't pollute the aggregate; `applied` events record only after the all-or-nothing apply succeeds.

## Testing

579 passed + 10 skipped (main baseline 533; +46), typecheck/lint/build clean, cascade E2E green (it live-exercises the graphiti silent-failure path via its MCP route abort). Adversarial review pre-PR: NO-MERGE → both HIGH findings (entity-axis flooding into an unprioritized truncated selector; dead show-affected) fixed in `fc7e819` with regression tests, including a late-positioned deterministic block surviving the 24-slice ahead of graphiti co-mentions.

## Notes for reviewers

- Graphiti edges apply once per content hash (warm caches don't re-pay the FalkorDB connection attempt) — documented in-code.
- This completes the Cascade v2 roadmap (Waves A–E). Five waves, five pre-PR adversarial reviews, five NO-MERGE verdicts fixed before anything shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
