### PR TITLE
Fleet-autonomy machinery: loops manifest, status dashboard, aging ladder, gate integrity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Machinery is operator-owned: any change under .github/ requests review from
+# the repo owner.
+/.github/ @Vinylfigure

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,11 @@
+name: Question
+description: A question blocking autonomous work — an operator answer unblocks the fleet.
+labels: ["question:"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What needs an operator decision or answer, and what is blocked until it lands.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,29 @@
+name: Task
+description: A ready work item for the fleet — must carry a runnable "done means" check.
+labels: ["task:"]
+body:
+  - type: textarea
+    id: done-means
+    attributes:
+      label: Done means
+      description: The runnable/observable check that closes this — a command, test, or observable behavior a session can verify without asking anyone.
+      placeholder: "e.g. `npm run test -- semantic-commit` passes and the modal renders the diff preview"
+    validations:
+      required: true
+  - type: textarea
+    id: discovered-from
+    attributes:
+      label: Discovered from
+      description: Where this task came from — a PR, an incident, a dashboard finding, a conversation.
+    validations:
+      required: false
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P1 — do next
+        - P2 — soon
+        - P3 — whenever
+    validations:
+      required: false

--- a/.github/loops.yaml
+++ b/.github/loops.yaml
@@ -1,0 +1,46 @@
+# loops.yaml — git source of truth for the automations this repo EXPECTS to run.
+#
+# Why this file exists:
+#   Scheduled automations (Routines, GitHub Actions crons) live outside the
+#   repo, so git alone cannot tell you what is supposed to be running. This
+#   file declares the expected fleet so drift is detectable: an automation
+#   running that is not declared here, or declared here but not running, is a
+#   finding for the status dashboard — never something silently tolerated.
+#
+# Semantics:
+#   - `enabled: false` is a DECLARATIVE KILL SWITCH: the loop is designed and
+#     documented but must not be armed. Arming it is an explicit operator act,
+#     recorded in `armed_by` (and usually tracked in an issue — see `notes`).
+#   - This file is DETECT-ONLY. Nothing here starts or stops anything;
+#     `scripts/fleet-status.sh` merely reads it and reports each loop's
+#     declared state on the "Status dashboard" issue.
+#
+# Schema (one entry per loop):
+#   name:      unique loop identifier
+#   schedule:  5-field cron, UTC
+#   driver:    what fires it — `routine` (Claude Routine) | `github-action`
+#   skill:     (driver: routine)        the skill each firing invokes
+#   workflow:  (driver: github-action)  the workflow file under .github/workflows/
+#   enabled:   whether the loop SHOULD currently be running (see kill switch above)
+#   armed_by:  what actually arms it (workflow file, Routine id) — null until armed
+#   owner:     the human accountable for the loop
+#   notes:     free text — arming status, tracking issue, caveats
+
+loops:
+  - name: work-loop
+    schedule: "17 */4 * * *"
+    driver: routine
+    skill: work-loop
+    enabled: false
+    armed_by: null
+    owner: Vinylfigure
+    notes: "arming tracked in issue #23"
+
+  - name: fleet-status
+    schedule: "17 */4 * * *"
+    driver: github-action
+    workflow: fleet-status.yml
+    enabled: true
+    armed_by: .github/workflows/fleet-status.yml
+    owner: Vinylfigure
+    notes: "regenerates the Status dashboard issue in place; exits red on L-047 findings"

--- a/.github/workflows/fleet-status.yml
+++ b/.github/workflows/fleet-status.yml
@@ -1,0 +1,33 @@
+# Fleet status sweep — runs scripts/fleet-status.sh on a cron.
+#
+# Declared in .github/loops.yaml (loop: fleet-status). The run goes red exactly
+# when the script finds red findings (e.g. L-047 stale claude/* branches), so a
+# failing workflow badge means "the fleet needs operator attention", not "flaky
+# infra".
+name: Fleet status
+
+on:
+  schedule:
+    - cron: "17 */4 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: fleet-status
+  cancel-in-progress: false
+
+jobs:
+  fleet-status:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run fleet status sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/fleet-status.sh

--- a/.github/workflows/gate-integrity.yml
+++ b/.github/workflows/gate-integrity.yml
@@ -1,0 +1,80 @@
+# Gate integrity — protects the machinery and the test suite from silent edits.
+#
+# Fails any PR whose diff against its base:
+#   * modifies .github/workflows/** (the CI gates themselves), or
+#   * deletes test files (src/**/__tests__/**, tests/**), or
+#   * adds skipped tests (.skip( / xit( / xdescribe( on added lines),
+# unless the PR carries the `machinery-change` label — the explicit,
+# operator-visible way to say "yes, this PR is allowed to touch the machinery".
+# Adding or removing the label re-triggers the check.
+name: Gate integrity
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate-integrity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Allow via machinery-change label
+        id: gate
+        if: contains(github.event.pull_request.labels.*.name, 'machinery-change')
+        run: echo "PR carries the 'machinery-change' label — machinery edits are explicitly allowed."
+
+      - uses: actions/checkout@v5
+        if: "!contains(github.event.pull_request.labels.*.name, 'machinery-change')"
+        with:
+          fetch-depth: 0
+
+      - name: Check diff against base
+        if: "!contains(github.event.pull_request.labels.*.name, 'machinery-change')"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "Comparing $merge_base...$HEAD_SHA"
+
+          # 1. Workflow modifications.
+          workflow_changes="$(git diff --name-only "$merge_base" "$HEAD_SHA" -- '.github/workflows/**' || true)"
+          if [[ -n "$workflow_changes" ]]; then
+            echo "::error::PR modifies workflow files without the 'machinery-change' label:"
+            echo "$workflow_changes"
+            fail=1
+          fi
+
+          # 2. Deleted test files.
+          deleted_tests="$(git diff --name-only --diff-filter=D "$merge_base" "$HEAD_SHA" \
+            -- 'src/**/__tests__/**' 'tests/**' || true)"
+          if [[ -n "$deleted_tests" ]]; then
+            echo "::error::PR deletes test files without the 'machinery-change' label:"
+            echo "$deleted_tests"
+            fail=1
+          fi
+
+          # 3. Newly skipped tests: .skip( / xit( / xdescribe( on ADDED lines
+          #    in test files.
+          skipped="$(git diff --unified=0 "$merge_base" "$HEAD_SHA" \
+              -- 'src/**/__tests__/**' 'tests/**' '**/*.test.*' '**/*.spec.*' \
+            | grep -E '^\+' | grep -v '^\+\+\+' \
+            | grep -En '\.skip\(|\bxit\(|\bxdescribe\(' || true)"
+          if [[ -n "$skipped" ]]; then
+            echo "::error::PR adds skipped tests (.skip(/xit(/xdescribe() without the 'machinery-change' label:"
+            echo "$skipped"
+            fail=1
+          fi
+
+          if [[ "$fail" -ne 0 ]]; then
+            echo "::error::Gate integrity failed. If this machinery/test change is intentional, add the 'machinery-change' label to the PR."
+            exit 1
+          fi
+          echo "Gate integrity clean: no workflow edits, no deleted tests, no new skips."

--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -5,6 +5,17 @@ All notable changes to the Intent IDE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-16] Fleet-Autonomy Machinery (branch `claude/fleet-status-machinery`)
+
+Instantiated the Janus-style fleet-autonomy machinery — repo-level automation plumbing only, zero `src/` changes, 731-test suite untouched.
+
+### Added
+- **`.github/loops.yaml`:** git source of truth for expected automations (detect-only; `enabled: false` = declarative kill switch). Declares `work-loop` (routine, not armed — issue #23) and `fleet-status` (github-action, enabled).
+- **`.github/workflows/fleet-status.yml` + `scripts/fleet-status.sh`:** cron `17 */4 * * *` sweep — idempotent label vocabulary, aging/overdue ladder on `question:` issues and `claude/*` PRs (never closes; owner comment clears), L-047 stale-branch detector, and a single "Status dashboard" issue rewritten in place. Exits non-zero iff red findings; `--dry-run` supported for stubbed-`gh` testing.
+- **`.github/workflows/gate-integrity.yml`:** fails PRs that touch `.github/workflows/**`, delete test files, or add `.skip(`/`xit(`/`xdescribe(` — unless labeled `machinery-change`.
+- **`.github/ISSUE_TEMPLATE/`:** `task.yml` (required "Done means"), `question.yml`, `config.yml` (blank issues allowed).
+- **`.github/CODEOWNERS`:** `/.github/` owned by @Vinylfigure.
+
 ## [2026-07-09] Cascade v2 Complete (Waves B, C, D — PRs #9-#12)
 
 The Cascade v2 roadmap is CLOSED. After Waves A + E (PRs #5/#6), the final three waves landed as **PR #9** (Wave D3+D4: e2e + README), **PR #10** (Wave B: scale/recall), **PR #11** (Wave C: trust/flow-state UX), and **PR #12** (Wave D1+D2 finale: Graphiti bridge, consolidation, telemetry). Process record: **five waves, five pre-PR adversarial Troublemaker reviews, five NO-MERGE verdicts — every HIGH finding fixed with regression tests before anything was pushed.** Worktrees ran A∥E then B∥D3+D4 in parallel; B∥C was deliberately serialized (`docGraph.ts` overlap).

--- a/scripts/fleet-status.sh
+++ b/scripts/fleet-status.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# fleet-status.sh — fleet health sweep + "Status dashboard" issue regenerator.
+#
+# Run by .github/workflows/fleet-status.yml on a cron (and by hand via
+# workflow_dispatch or locally). Requires `gh` authenticated via GH_TOKEN and
+# `jq`. Repo is taken from $GITHUB_REPOSITORY, falling back to `gh repo view`.
+#
+# What it does, in order:
+#   (a) ensures the label vocabulary exists (idempotent, --force)
+#   (b) aging ladder: open `question:` issues and open PRs from claude/*
+#       branches get `aging` after >3 days without update and `overdue` after
+#       >7 days. Items are NEVER closed. Both labels are removed when the repo
+#       owner is the latest commenter (the operator has responded).
+#   (c) L-047 detector: a remote claude/* branch whose head commit is >24h old
+#       with no open PR is abandoned work-in-flight — a red finding.
+#   (d) regenerates the single "Status dashboard" issue (label `dashboard`),
+#       REWRITING its body in place (never appending, never opening a second
+#       dashboard issue).
+#   (e) exits non-zero iff there are red findings, so the workflow run goes
+#       red exactly when the fleet needs operator attention.
+#
+# Flags:
+#   --dry-run   print the dashboard body to stdout and perform NO mutations
+#               (no label creates/edits, no issue create/edit). Read-only gh
+#               calls still happen, so it can be tested with a stubbed `gh`.
+
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    *) echo "unknown argument: $arg" >&2; exit 2 ;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "fleet-status: gh not found" >&2; exit 2; }
+command -v jq >/dev/null || { echo "fleet-status: jq not found" >&2; exit 2; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOOPS_FILE="$ROOT/.github/loops.yaml"
+
+REPO="${GITHUB_REPOSITORY:-}"
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+OWNER="${REPO%%/*}"
+NOW_EPOCH="$(date -u +%s)"
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+AGING_DAYS=3
+OVERDUE_DAYS=7
+STALE_BRANCH_HOURS=24
+DASHBOARD_TITLE="Status dashboard"
+
+log() { echo "fleet-status: $*" >&2; }
+
+# mutate <gh args...> — run a mutating gh call, or log it in dry-run mode.
+mutate() {
+  if $DRY_RUN; then
+    log "[dry-run] would run: gh $*"
+  else
+    gh "$@"
+  fi
+}
+
+# age helpers ---------------------------------------------------------------
+epoch_of() { date -u -d "$1" +%s; }
+age_days() { echo $(( (NOW_EPOCH - $(epoch_of "$1")) / 86400 )); }
+age_hours() { echo $(( (NOW_EPOCH - $(epoch_of "$1")) / 3600 )); }
+
+# ---------------------------------------------------------------------------
+# (a) Label vocabulary — idempotent.
+# ---------------------------------------------------------------------------
+ensure_labels() {
+  local spec name color desc
+  local specs=(
+    "task:|0e8a16|Ready work item with a runnable done-means check"
+    "question:|d93f0b|Blocked on an operator answer"
+    "loop:hold|5319e7|Operator hold: automation loops must skip this item"
+    "aging|fbca04|No update in >${AGING_DAYS} days"
+    "overdue|b60205|No update in >${OVERDUE_DAYS} days — needs operator attention"
+    "dashboard|1d76db|The regenerated-in-place Status dashboard issue"
+  )
+  for spec in "${specs[@]}"; do
+    IFS='|' read -r name color desc <<<"$spec"
+    mutate label create "$name" --force --color "$color" --description "$desc"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Data collection (read-only).
+# ---------------------------------------------------------------------------
+fetch_data() {
+  PRS_JSON="$(gh pr list --state open --limit 100 \
+    --json number,title,headRefName,createdAt,updatedAt,labels,statusCheckRollup)"
+  QUESTIONS_JSON="$(gh issue list --state open --label "question:" --limit 100 \
+    --json number,title,createdAt,updatedAt,labels)"
+  TASKS_JSON="$(gh issue list --state open --label "task:" --limit 100 \
+    --json number,title,createdAt)"
+  BRANCHES_TSV="$(gh api "repos/$REPO/branches?per_page=100" \
+    --jq '.[] | [.name, .commit.sha] | @tsv')"
+}
+
+latest_commenter() { # <issue-or-pr number>
+  gh api "repos/$REPO/issues/$1/comments?per_page=100" \
+    --jq 'last.user.login // empty' 2>/dev/null || true
+}
+
+has_label() { # <labels-json-array> <label-name>
+  jq -e --arg l "$2" 'any(.[]; .name == $l)' >/dev/null 2>&1 <<<"$1"
+}
+
+add_label()    { mutate api -X POST   "repos/$REPO/issues/$1/labels" -f "labels[]=$2"; }
+remove_label() { mutate api -X DELETE "repos/$REPO/issues/$1/labels/$2"; }
+
+# ---------------------------------------------------------------------------
+# (b) Aging ladder — never closes anything; labels only.
+# ---------------------------------------------------------------------------
+apply_aging_ladder() { # <number> <updatedAt> <labels-json>
+  local num="$1" updated="$2" labels="$3" days commenter
+  days="$(age_days "$updated")"
+  commenter="$(latest_commenter "$num")"
+
+  if [[ -n "$commenter" && "$commenter" == "$OWNER" ]]; then
+    # Operator has responded: clear the ladder.
+    has_label "$labels" "aging"   && remove_label "$num" "aging"
+    has_label "$labels" "overdue" && remove_label "$num" "overdue"
+    return 0
+  fi
+  if (( days > AGING_DAYS )); then
+    has_label "$labels" "aging" || add_label "$num" "aging"
+  fi
+  if (( days > OVERDUE_DAYS )); then
+    has_label "$labels" "overdue" || add_label "$num" "overdue"
+  fi
+}
+
+run_aging_ladder() {
+  local row num updated labels
+  # Open question: issues.
+  while IFS=$'\t' read -r num updated; do
+    [[ -z "$num" ]] && continue
+    labels="$(jq -c --argjson n "$num" '.[] | select(.number == $n) | .labels' <<<"$QUESTIONS_JSON")"
+    apply_aging_ladder "$num" "$updated" "$labels"
+  done < <(jq -r '.[] | [.number, .updatedAt] | @tsv' <<<"$QUESTIONS_JSON")
+
+  # Open PRs from claude/* branches.
+  while IFS=$'\t' read -r num updated; do
+    [[ -z "$num" ]] && continue
+    labels="$(jq -c --argjson n "$num" '.[] | select(.number == $n) | .labels' <<<"$PRS_JSON")"
+    apply_aging_ladder "$num" "$updated" "$labels"
+  done < <(jq -r '.[] | select(.headRefName | startswith("claude/"))
+                  | [.number, .updatedAt] | @tsv' <<<"$PRS_JSON")
+}
+
+# ---------------------------------------------------------------------------
+# (c) L-047 detector: claude/* branches, head commit >24h old, no open PR.
+# ---------------------------------------------------------------------------
+RED_FINDINGS=()
+
+detect_stale_branches() {
+  local pr_heads branch sha head_date hours
+  pr_heads="$(jq -r '.[].headRefName' <<<"$PRS_JSON")"
+  while IFS=$'\t' read -r branch sha; do
+    [[ -z "$branch" ]] && continue
+    [[ "$branch" == claude/* ]] || continue
+    grep -qxF "$branch" <<<"$pr_heads" && continue
+    head_date="$(gh api "repos/$REPO/commits/$sha" --jq .commit.committer.date)"
+    hours="$(age_hours "$head_date")"
+    if (( hours > STALE_BRANCH_HOURS )); then
+      RED_FINDINGS+=("L-047: remote branch \`$branch\` head commit is ${hours}h old with no open PR — work-in-flight is going stale (open a PR or delete the branch).")
+    fi
+  done <<<"$BRANCHES_TSV"
+}
+
+# ---------------------------------------------------------------------------
+# (d) Dashboard body.
+# ---------------------------------------------------------------------------
+pr_checks_summary() { # <statusCheckRollup json>
+  jq -r '
+    if (. == null) or (length == 0) then "no checks"
+    else
+      ( [.[] | (.conclusion // .state // "")] ) as $c
+      | ($c | length) as $total
+      | ($c | map(select(. == "SUCCESS" or . == "success" or . == "NEUTRAL" or . == "SKIPPED")) | length) as $ok
+      | ($c | map(select(. == "FAILURE" or . == "failure" or . == "ERROR" or . == "TIMED_OUT" or . == "CANCELLED" or . == "ACTION_REQUIRED")) | length) as $bad
+      | if $bad > 0 then "\($bad) failing (\($ok)/\($total) green)"
+        elif $ok == $total then "\($ok)/\($total) green"
+        else "pending (\($ok)/\($total) green)"
+        end
+    end' <<<"$1"
+}
+
+build_loops_section() {
+  if [[ ! -f "$LOOPS_FILE" ]]; then
+    echo "_No \`.github/loops.yaml\` found — expected automations are undeclared._"
+    return 0
+  fi
+  awk '
+    function flush() {
+      if (name == "") return
+      what = (skill != "") ? "skill " skill : "workflow " workflow
+      state = (enabled == "true") ? "enabled" : "declared, not armed"
+      printf "- **%s** — `%s` via %s (%s) — **%s**", name, schedule, driver, what, state
+      if (notes != "") printf " — %s", notes
+      printf "\n"
+      name = schedule = driver = skill = workflow = enabled = notes = ""
+    }
+    function val(   s) { s = $0; sub(/^[^:]*:[[:space:]]*/, "", s); gsub(/^"|"$/, "", s); return s }
+    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*-[[:space:]]*name:/    { flush(); name = val() ; next }
+    /^[[:space:]]*schedule:/ { schedule = val(); next }
+    /^[[:space:]]*driver:/   { driver = val();   next }
+    /^[[:space:]]*skill:/    { skill = val();    next }
+    /^[[:space:]]*workflow:/ { workflow = val(); next }
+    /^[[:space:]]*enabled:/  { enabled = val();  next }
+    /^[[:space:]]*notes:/    { notes = val();    next }
+    END { flush() }
+  ' "$LOOPS_FILE"
+}
+
+build_body() {
+  local body="" row num title created updated head checks days labels
+
+  # -- Open PRs -------------------------------------------------------------
+  body+="## Open PRs"$'\n\n'
+  if [[ "$(jq 'length' <<<"$PRS_JSON")" -eq 0 ]]; then
+    body+="_None._"$'\n'
+  else
+    body+="| PR | Title | Age | Checks |"$'\n'
+    body+="| --- | --- | --- | --- |"$'\n'
+    while IFS=$'\t' read -r num title created; do
+      [[ -z "$num" ]] && continue
+      checks="$(pr_checks_summary "$(jq -c --argjson n "$num" \
+        '.[] | select(.number == $n) | .statusCheckRollup' <<<"$PRS_JSON")")"
+      body+="| #$num | $title | $(age_days "$created")d | $checks |"$'\n'
+    done < <(jq -r '.[] | [.number, .title, .createdAt] | @tsv' <<<"$PRS_JSON")
+  fi
+  body+=$'\n'
+
+  # -- Blocked on operator --------------------------------------------------
+  body+="## Blocked on operator"$'\n\n'
+  local blocked=""
+  while IFS=$'\t' read -r num title updated; do
+    [[ -z "$num" ]] && continue
+    blocked+="- \`question:\` #$num — $title (last update $(age_days "$updated")d ago)"$'\n'
+  done < <(jq -r '.[] | [.number, .title, .updatedAt] | @tsv' <<<"$QUESTIONS_JSON")
+  while IFS=$'\t' read -r num title updated; do
+    [[ -z "$num" ]] && continue
+    blocked+="- \`overdue\` PR #$num — $title (last update $(age_days "$updated")d ago)"$'\n'
+  done < <(jq -r '.[] | select(.labels | any(.name == "overdue"))
+                  | [.number, .title, .updatedAt] | @tsv' <<<"$PRS_JSON")
+  if [[ -n "$blocked" ]]; then body+="$blocked"; else body+="_Nothing blocked._"$'\n'; fi
+  body+=$'\n'
+
+  # -- Backlog --------------------------------------------------------------
+  body+="## Backlog"$'\n\n'
+  local task_count oldest
+  task_count="$(jq 'length' <<<"$TASKS_JSON")"
+  if [[ "$task_count" -eq 0 ]]; then
+    body+="_No open \`task:\` issues._"$'\n'
+  else
+    oldest="$(jq -r 'sort_by(.createdAt) | first | "#\(.number) — \(.title) (\(.createdAt))"' <<<"$TASKS_JSON")"
+    body+="Open \`task:\` issues: **$task_count**. Oldest: $oldest."$'\n'
+  fi
+  body+=$'\n'"> Note: #19 is blocked on a live provider key — an operator must supply it before that task can move."$'\n\n'
+
+  # -- Loops ----------------------------------------------------------------
+  body+="## Loops"$'\n\n'
+  body+="$(build_loops_section)"$'\n\n'
+
+  # -- Red findings ---------------------------------------------------------
+  body+="## Red findings"$'\n\n'
+  if (( ${#RED_FINDINGS[@]} == 0 )); then
+    body+="_None._"$'\n'
+  else
+    local f
+    for f in "${RED_FINDINGS[@]}"; do
+      body+="- :red_circle: $f"$'\n'
+    done
+  fi
+  body+=$'\n'
+
+  # -- Footer ---------------------------------------------------------------
+  body+="_Last updated: ${NOW_ISO}. This issue is regenerated in place by \`scripts/fleet-status.sh\` — the body is rewritten on every run; do not edit it by hand (comments are fine and are how the operator responds)._"$'\n\n'
+  body+="---"$'\n'
+  body+="_Generated by [Claude Code](https://claude.ai/code)_"$'\n'
+
+  printf '%s' "$body"
+}
+
+publish_dashboard() { # <body>
+  local body="$1" num
+  if $DRY_RUN; then
+    printf '%s\n' "$body"
+    log "[dry-run] dashboard body printed above; no issue was created or edited."
+    return 0
+  fi
+  local body_file
+  body_file="$(mktemp)"
+  printf '%s' "$body" > "$body_file"
+  num="$(gh issue list --state open --label dashboard --limit 10 --json number,title \
+    --jq "[.[] | select(.title == \"$DASHBOARD_TITLE\")] | first.number // empty")"
+  if [[ -n "$num" ]]; then
+    gh issue edit "$num" --body-file "$body_file"
+    log "rewrote dashboard issue #$num in place."
+  else
+    gh issue create --title "$DASHBOARD_TITLE" --label dashboard --body-file "$body_file"
+    log "created dashboard issue."
+  fi
+  rm -f "$body_file"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+  log "repo=$REPO owner=$OWNER dry_run=$DRY_RUN"
+  ensure_labels
+  fetch_data
+  run_aging_ladder
+  detect_stale_branches
+  publish_dashboard "$(build_body)"
+
+  # (e) go red iff there are red findings.
+  if (( ${#RED_FINDINGS[@]} > 0 )); then
+    log "${#RED_FINDINGS[@]} red finding(s) — exiting non-zero."
+    exit 1
+  fi
+  log "no red findings."
+}
+
+main


### PR DESCRIPTION
Instantiates the fleet-autonomy machinery from the 2026-08-16 bottleneck audit (deterministic fixes with declared escape hatches; detect-only — nothing auto-closes, auto-applies, or auto-merges).

## What this adds (zero `src/` changes; 731-test suite untouched)

- **`.github/loops.yaml`** — the git source of truth for expected scheduled automations. The work-loop Routine is declared `enabled: false` ("declared, not armed" — arming tracked in #23); `enabled: false` is the declarative kill switch.
- **`fleet-status.yml` + `scripts/fleet-status.sh`** (cron `17 */4 * * *` + manual dispatch): regenerates a single **Status dashboard** issue in place — open PRs with check states and ages, operator-blocked items, backlog, loop declarations, red findings. Applies the aging ladder (`aging` >3d → `overdue` >7d) to `question:` issues and `claude/*` PRs; **never closes anything**; labels clear when the operator comments. Detects `claude/*` branches >24h old with no PR (L-047 at CI rung) and turns the run red.
- **Issue forms**: `task:` with a *required* "Done means" field (backlog readiness becomes machine-checkable), `question:` for operator decisions; blank issues stay enabled.
- **`gate-integrity.yml`**: fails any PR that edits workflows or deletes/skips tests, unless the operator applies the `machinery-change` label. **This PR trips its own check by design** — apply `machinery-change` to merge; that's the seatbelt working.
- **CODEOWNERS** on `/.github/` — agents cannot alter the fleet's machinery without explicit approval.

## Verification

All YAML parses; `fleet-status.sh --dry-run` with a stubbed `gh` renders all five dashboard sections and exits 0; injecting a 72h-old unPR'd branch produces the red finding and exit 1. First real run: trigger `fleet-status` via workflow_dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4GAPr25qRRVyPzffqQ5iC

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4GAPr25qRRVyPzffqQ5iC)_