### PR TITLE
Document Invariant Ledger — Phase 1 (data model + capture)

### DIFF
--- a/prisma/migrations/20260818042142_add_doc_invariant_ledger/migration.sql
+++ b/prisma/migrations/20260818042142_add_doc_invariant_ledger/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "DocInvariant" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "documentId" TEXT NOT NULL,
+    "statement" TEXT NOT NULL,
+    "blockIds" TEXT NOT NULL DEFAULT '[]',
+    "checkKind" TEXT NOT NULL DEFAULT 'deterministic',
+    "status" TEXT NOT NULL DEFAULT 'active',
+    "provenanceCommitHash" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE INDEX "DocInvariant_documentId_createdAt_idx" ON "DocInvariant"("documentId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,3 +80,25 @@ model DocCommit {
   @@index([documentId, createdAt])
   @@index([documentId, parentHash])
 }
+
+/// Document Invariant Ledger — Phase 1 (data model + capture only; see #26).
+/// A user-declared fact, captured at SemanticCommitModal confirm time and
+/// linked to the block(s) that evidence it. The check runner that regression-
+/// tests these against later DocCommits, and CascadeList surfacing of a
+/// failing invariant, are out of scope until a follow-up task lands (#20
+/// steps 2-3); `status` and `checkKind` exist now so that runner has a stable
+/// schema to read, but nothing in this phase writes anything other than
+/// `active`/`deterministic`.
+/// Append-only: no update/delete operations permitted on invariant records.
+model DocInvariant {
+  id                   String   @id @default(cuid())
+  documentId           String
+  statement            String
+  blockIds             String   @default("[]") // JSON string[] — evidence links
+  checkKind            String   @default("deterministic") // 'deterministic' | 'entailment'
+  status               String   @default("active") // reserved for the future check runner
+  provenanceCommitHash String? // DocCommit.hash of the commit that declared this fact
+  createdAt            DateTime @default(now())
+
+  @@index([documentId, createdAt])
+}

--- a/src/app/api/invariants/__tests__/route.test.ts
+++ b/src/app/api/invariants/__tests__/route.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// In-memory Prisma double for the DocInvariant table. The route only uses
+// findMany / create, so the double implements exactly those query shapes.
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string
+  documentId: string
+  statement: string
+  blockIds: string
+  checkKind: string
+  status: string
+  provenanceCommitHash: string | null
+  createdAt: Date
+}
+
+let rows: Row[] = []
+let clock = 0
+let nextId = 0
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    docInvariant: {
+      findMany: async (args: any) => {
+        return rows
+          .filter((r) => (args.where?.documentId ? r.documentId === args.where.documentId : true))
+          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .slice(0, args.take)
+      },
+      create: async ({ data }: any) => {
+        const row: Row = {
+          id: `inv-${nextId++}`,
+          documentId: data.documentId,
+          statement: data.statement,
+          blockIds: data.blockIds,
+          checkKind: data.checkKind,
+          status: 'active',
+          provenanceCommitHash: data.provenanceCommitHash ?? null,
+          createdAt: new Date(1700000000000 + clock++ * 1000),
+        }
+        rows.push(row)
+        return row
+      },
+    },
+  },
+}))
+
+// Import AFTER the mock so route.ts binds to the double.
+import { GET, POST } from '../route'
+
+beforeEach(() => {
+  rows = []
+  clock = 0
+  nextId = 0
+})
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/invariants', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function getRequest(query: string) {
+  return new NextRequest(`http://localhost/api/invariants?${query}`)
+}
+
+describe('POST /api/invariants', () => {
+  it('captures a declared fact linked to its block evidence — the founder fixture', async () => {
+    const res = await POST(
+      postRequest({
+        documentId: 'doc-1',
+        statement: 'Terminations are now 30 days.',
+        blockIds: ['blk-terminations'],
+        provenanceCommitHash: 'commit-abc',
+      }),
+    )
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.invariant.statement).toBe('Terminations are now 30 days.')
+    expect(JSON.parse(data.invariant.blockIds)).toEqual(['blk-terminations'])
+    expect(data.invariant.checkKind).toBe('deterministic')
+    expect(data.invariant.status).toBe('active')
+    expect(data.invariant.provenanceCommitHash).toBe('commit-abc')
+    expect(rows).toHaveLength(1)
+  })
+
+  it('defaults blockIds to [] and checkKind to deterministic when omitted', async () => {
+    const res = await POST(postRequest({ documentId: 'doc-1', statement: 'A fact.' }))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(JSON.parse(data.invariant.blockIds)).toEqual([])
+    expect(data.invariant.checkKind).toBe('deterministic')
+    expect(data.invariant.provenanceCommitHash).toBeNull()
+  })
+
+  it('rejects a missing documentId or statement', async () => {
+    const res1 = await POST(postRequest({ statement: 'A fact.' }))
+    expect(res1.status).toBe(400)
+    const res2 = await POST(postRequest({ documentId: 'doc-1', statement: '' }))
+    expect(res2.status).toBe(400)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('rejects an oversize statement', async () => {
+    const res = await POST(
+      postRequest({ documentId: 'doc-1', statement: 'x'.repeat(2001) }),
+    )
+    expect(res.status).toBe(400)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('rejects a non-string-array blockIds', async () => {
+    const res = await POST(
+      postRequest({ documentId: 'doc-1', statement: 'A fact.', blockIds: [1, 2] }),
+    )
+    expect(res.status).toBe(400)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('rejects an unknown checkKind', async () => {
+    const res = await POST(
+      postRequest({ documentId: 'doc-1', statement: 'A fact.', checkKind: 'vibes' }),
+    )
+    expect(res.status).toBe(400)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('never updates or deletes — every capture is a new append-only row', async () => {
+    await POST(postRequest({ documentId: 'doc-1', statement: 'Terminations are 30 days.' }))
+    await POST(postRequest({ documentId: 'doc-1', statement: 'Terminations are 45 days.' }))
+    expect(rows).toHaveLength(2)
+    expect(rows[0].statement).toBe('Terminations are 30 days.')
+    expect(rows[1].statement).toBe('Terminations are 45 days.')
+    // The route module exposes no PATCH/DELETE handler at all.
+    const routeModule: Record<string, unknown> = await import('../route')
+    expect(routeModule.PATCH).toBeUndefined()
+    expect(routeModule.DELETE).toBeUndefined()
+    expect(routeModule.PUT).toBeUndefined()
+  })
+})
+
+describe('GET /api/invariants', () => {
+  it('requires a documentId', async () => {
+    const res = await GET(getRequest(''))
+    expect(res.status).toBe(400)
+  })
+
+  it('round-trips a captured fact, newest first, scoped to its document', async () => {
+    await POST(
+      postRequest({
+        documentId: 'doc-1',
+        statement: 'Terminations are now 30 days.',
+        blockIds: ['blk-terminations'],
+      }),
+    )
+    await POST(postRequest({ documentId: 'doc-2', statement: 'Unrelated fact.' }))
+    await POST(
+      postRequest({
+        documentId: 'doc-1',
+        statement: 'Termination notices go through HR.',
+        blockIds: ['blk-hr'],
+      }),
+    )
+
+    const res = await GET(getRequest('documentId=doc-1'))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.invariants).toHaveLength(2)
+    // Newest first.
+    expect(data.invariants[0].statement).toBe('Termination notices go through HR.')
+    expect(JSON.parse(data.invariants[0].blockIds)).toEqual(['blk-hr'])
+    expect(data.invariants[1].statement).toBe('Terminations are now 30 days.')
+    expect(JSON.parse(data.invariants[1].blockIds)).toEqual(['blk-terminations'])
+  })
+
+  it('caps and sanitizes the limit param', async () => {
+    for (let i = 0; i < 5; i++) {
+      await POST(postRequest({ documentId: 'doc-1', statement: `fact ${i}` }))
+    }
+    const res = await GET(getRequest('documentId=doc-1&limit=2'))
+    const data = await res.json()
+    expect(data.invariants).toHaveLength(2)
+  })
+})

--- a/src/app/api/invariants/route.ts
+++ b/src/app/api/invariants/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+/**
+ * /api/invariants — Document Invariant Ledger, Phase 1 (data model + capture
+ * only; see issue #26). A user-declared fact ("terminations are now 30
+ * days"), captured at SemanticCommitModal confirm time and linked to the
+ * block(s) that evidence it.
+ *
+ * This endpoint ONLY creates and reads records — no update or delete
+ * operations exist. The check runner that regression-tests these against
+ * later document edits, and CascadeList surfacing of a failing invariant,
+ * are a separate follow-up task (#20 steps 2-3); this route only stores what
+ * that runner will eventually read.
+ */
+
+const VALID_CHECK_KINDS = new Set(['deterministic', 'entailment'])
+
+const MAX_STATEMENT_CHARS = 2000
+const MAX_BLOCK_IDS = 50
+const MAX_BLOCK_ID_CHARS = 200
+
+const DEFAULT_LIMIT = 100
+const MAX_LIMIT = 200
+
+const INVARIANT_SELECT = {
+  id: true,
+  documentId: true,
+  statement: true,
+  blockIds: true,
+  checkKind: true,
+  status: true,
+  provenanceCommitHash: true,
+  createdAt: true,
+} as const
+
+/**
+ * GET /api/invariants?documentId=... — list a document's invariants, newest
+ * first (default page of 100, ?limit=N up to 200).
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl
+    const documentId = searchParams.get('documentId')
+    if (!documentId) {
+      return NextResponse.json({ error: 'documentId query param required' }, { status: 400 })
+    }
+
+    const rawLimit = Number(searchParams.get('limit') ?? DEFAULT_LIMIT)
+    const limit = Number.isFinite(rawLimit)
+      ? Math.min(Math.max(Math.floor(rawLimit), 1), MAX_LIMIT)
+      : DEFAULT_LIMIT
+
+    const invariants = await prisma.docInvariant.findMany({
+      where: { documentId },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      select: INVARIANT_SELECT,
+    })
+    return NextResponse.json({ invariants })
+  } catch (err) {
+    console.error('[/api/invariants GET] Error:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Failed to fetch invariants' },
+      { status: 500 },
+    )
+  }
+}
+
+/**
+ * POST /api/invariants — append-only invariant writer.
+ *
+ * Body: { documentId, statement, blockIds?: string[], checkKind?:
+ *         'deterministic' | 'entailment', provenanceCommitHash?: string }
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const documentId = typeof body.documentId === 'string' ? body.documentId : ''
+    const statement = typeof body.statement === 'string' ? body.statement.trim() : ''
+    if (!documentId || !statement) {
+      return NextResponse.json(
+        { error: 'documentId and statement are required' },
+        { status: 400 },
+      )
+    }
+    if (statement.length > MAX_STATEMENT_CHARS) {
+      return NextResponse.json(
+        { error: `statement too long (max ${MAX_STATEMENT_CHARS} chars)` },
+        { status: 400 },
+      )
+    }
+
+    const rawBlockIds: unknown = body.blockIds
+    let blockIds: string[] = []
+    if (rawBlockIds !== undefined) {
+      if (
+        !Array.isArray(rawBlockIds) ||
+        rawBlockIds.some((id) => typeof id !== 'string')
+      ) {
+        return NextResponse.json({ error: 'blockIds must be an array of strings' }, { status: 400 })
+      }
+      if (rawBlockIds.length > MAX_BLOCK_IDS) {
+        return NextResponse.json(
+          { error: `too many blockIds (max ${MAX_BLOCK_IDS})` },
+          { status: 400 },
+        )
+      }
+      if (rawBlockIds.some((id) => id.length > MAX_BLOCK_ID_CHARS)) {
+        return NextResponse.json({ error: 'blockId too long' }, { status: 400 })
+      }
+      blockIds = rawBlockIds
+    }
+
+    const checkKind = typeof body.checkKind === 'string' ? body.checkKind : 'deterministic'
+    if (!VALID_CHECK_KINDS.has(checkKind)) {
+      return NextResponse.json(
+        { error: `checkKind must be one of: ${[...VALID_CHECK_KINDS].join(', ')}` },
+        { status: 400 },
+      )
+    }
+
+    const provenanceCommitHash =
+      typeof body.provenanceCommitHash === 'string' && body.provenanceCommitHash.length > 0
+        ? body.provenanceCommitHash
+        : null
+
+    const record = await prisma.docInvariant.create({
+      data: {
+        documentId,
+        statement,
+        blockIds: JSON.stringify(blockIds),
+        checkKind,
+        provenanceCommitHash: provenanceCommitHash ?? undefined,
+      },
+      select: INVARIANT_SELECT,
+    })
+    return NextResponse.json({ invariant: record })
+  } catch (err) {
+    console.error('[/api/invariants] Error:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Invariant capture failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -29,7 +29,7 @@ import {
 import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
-import { recordInvariant } from '@/lib/invariants/captureInvariant'
+import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
@@ -573,7 +573,9 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           modalDecisionsRef.current?.confirm()
           modalDecisionsRef.current = null
           commitSnapshotRef.current = null
-          pendingInvariantRef.current = invariant
+          const primaryId = primaryEdit?.id ?? annotation.id
+          pendingInvariantRef.current =
+            invariant && shouldCaptureInvariant(ids, primaryId) ? invariant : null
           applyConfirmedEdit(ids)
         }}
         onCancel={() => {

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -29,7 +29,8 @@ import {
 import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
-import { SemanticCommitModal } from '@/components/Editor/SemanticCommitModal'
+import { recordInvariant } from '@/lib/invariants/captureInvariant'
+import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
 
@@ -51,6 +52,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   // (last decision per edit wins), flushed on CONFIRM only, discarded on
   // cancel — so flip noise and abandoned sessions never inflate calibration.
   const modalDecisionsRef = useRef<ModalDecisionBuffer | null>(null)
+  // Document Invariant Ledger: the fact the user chose to declare at
+  // confirm time (or null), captured once the resulting apply commit's hash
+  // is known so the ledger row carries real provenance.
+  const pendingInvariantRef = useRef<InvariantCapture | null>(null)
 
   if (!annotation.resolution) return null
 
@@ -138,6 +143,18 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         if (changeSetId) {
           useChangesStore.getState().setChangeSetCommitHash(changeSetId, hash)
         }
+        // The user may have declared a fact in the commit modal — capture it
+        // now that we have the real provenance commit hash for this version.
+        const invariant = pendingInvariantRef.current
+        pendingInvariantRef.current = null
+        if (invariant) {
+          recordInvariant({
+            documentId: annotation.documentId,
+            statement: invariant.statement,
+            blockIds: invariant.blockIds,
+            provenanceCommitHash: hash,
+          })
+        }
       })
       .catch((err) => console.warn('[history] Failed to record version:', err))
   }
@@ -152,12 +169,14 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     if (proposed && proposed.length > 1 && view) {
       const ids = acceptedIds ?? proposed.map((e) => e.id)
       if (ids.length === 0) {
+        pendingInvariantRef.current = null
         setShowDiffModal(false)
         setPendingHandler(null)
         return
       }
       const result = applyProposedEdits(view, ids)
       if (!result.ok) {
+        pendingInvariantRef.current = null
         useToastStore.getState().addToast(result.reason, 'error')
         setShowDiffModal(false)
         setPendingHandler(null)
@@ -219,6 +238,9 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
           'No changes were needed — the text already matches',
           'info',
         )
+        // No commit will be recorded for a no-op apply — a declared fact with
+        // no real version to attribute it to would be a fabricated record.
+        pendingInvariantRef.current = null
       }
       setShowDiffModal(false)
       setPendingHandler(null)
@@ -228,6 +250,7 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     // Honor an explicit empty selection from the modal (defensive — single-edit
     // modals can't normally produce one).
     if (acceptedIds && acceptedIds.length === 0) {
+      pendingInvariantRef.current = null
       setShowDiffModal(false)
       setPendingHandler(null)
       return
@@ -494,6 +517,22 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             after: annotation.resolution.suggestedEdit.newText,
           }]
         : []
+  // Document Invariant Ledger default: derived from the primary change only
+  // (a cascade's collateral edit isn't the fact the user just declared).
+  const primaryEdit = resolutionEdits?.find((e) => e.relation === 'primary') ?? null
+  const primaryBlockId = primaryEdit
+    ? (primaryEdit.blockId ?? null)
+    : view && annotation.resolution?.suggestedEdit
+      ? blockIdAtPos(view.state.doc, annotation.resolution.suggestedEdit.from)
+      : null
+  const primaryStatement = (
+    primaryEdit ? primaryEdit.newText : annotation.resolution?.suggestedEdit?.newText ?? ''
+  ).trim()
+  const invariantDefault =
+    primaryStatement.length > 0
+      ? { statement: primaryStatement, blockIds: primaryBlockId ? [primaryBlockId] : [] }
+      : null
+
   const commitInitialRejected: Record<string, boolean> = {}
   {
     const anchors = view ? getProposedAnchors(view.state) : null
@@ -527,12 +566,14 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             setProposedEditStatus(view, id, status)
           }
         }}
-        onConfirm={(ids) => {
+        invariantDefault={invariantDefault}
+        onConfirm={(ids, invariant) => {
           // Confirm: the live statuses stand — drop the snapshot, no restore.
           // Flush the buffered modal decisions (one event per decided edit).
           modalDecisionsRef.current?.confirm()
           modalDecisionsRef.current = null
           commitSnapshotRef.current = null
+          pendingInvariantRef.current = invariant
           applyConfirmedEdit(ids)
         }}
         onCancel={() => {

--- a/src/components/Editor/SemanticCommitModal.tsx
+++ b/src/components/Editor/SemanticCommitModal.tsx
@@ -21,11 +21,29 @@ const SEVERITY_BADGE_STYLES: Record<CascadeSeverity, string> = {
   optional: 'bg-stone-200 text-stone-700',
 }
 
+/** A derivable "you just declared a fact" default — shown only when one exists. */
+interface InvariantDefault {
+  statement: string
+  blockIds: string[]
+}
+
+/** What the user decided about capturing the declared fact, or null to skip it. */
+export interface InvariantCapture {
+  statement: string
+  blockIds: string[]
+}
+
 interface SemanticCommitModalProps {
   changes: SemanticChange[]
-  /** Receives the ids of the changes the user chose to apply. */
-  onConfirm: (acceptedIds: string[]) => void
+  /**
+   * Receives the ids of the changes the user chose to apply, plus the fact
+   * to capture into the Document Invariant Ledger (or null when the user
+   * opted out / there was nothing to declare).
+   */
+  onConfirm: (acceptedIds: string[], invariant: InvariantCapture | null) => void
   onCancel: () => void
+  /** Pre-filled "you just declared a fact" suggestion — omit to hide the capture UI entirely. */
+  invariantDefault?: InvariantDefault | null
   /** Provocation from MADS Troublemaker — shown as amber callout, gates Apply for high-risk */
   provocation?: string | null
   /** Whether this edit came through MADS (multi-agent debate) — indicates higher scrutiny needed */
@@ -58,6 +76,7 @@ export function SemanticCommitModal({
   isHighRisk = false,
   initialRejected,
   onToggle,
+  invariantDefault,
 }: SemanticCommitModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const [acknowledged, setAcknowledged] = useState(false)
@@ -66,6 +85,11 @@ export function SemanticCommitModal({
   const [rejected, setRejected] = useState<Record<string, boolean>>(
     () => initialRejected ?? {},
   )
+  // Document Invariant Ledger capture (opt-out, editable fact text). Defaults
+  // to captured-on when there's a derivable statement; the user can uncheck
+  // or edit before confirming.
+  const [invariantOn, setInvariantOn] = useState(!!invariantDefault)
+  const [invariantText, setInvariantText] = useState(invariantDefault?.statement ?? '')
 
   const multi = changes.length > 1
   const acceptedIds = changes.filter((c) => !rejected[c.id]).map((c) => c.id)
@@ -105,7 +129,17 @@ export function SemanticCommitModal({
           confirmLabel={confirmLabel}
           cancelLabel="Discard"
           variant="destructive"
-          onConfirm={blocked ? () => {} : () => onConfirm(acceptedIds)}
+          onConfirm={
+            blocked
+              ? () => {}
+              : () =>
+                  onConfirm(
+                    acceptedIds,
+                    invariantOn && invariantText.trim()
+                      ? { statement: invariantText.trim(), blockIds: invariantDefault?.blockIds ?? [] }
+                      : null,
+                  )
+          }
           onCancel={onCancel}
         >
           <div className="semantic-commit-diffs">
@@ -167,6 +201,32 @@ export function SemanticCommitModal({
               )
             })}
           </div>
+
+          {/* Document Invariant Ledger capture — opt-out, editable fact text. */}
+          {invariantDefault && (
+            <div className="mt-3 p-3 border border-border rounded-md bg-warm/40">
+              <label className="flex items-start gap-2 text-xs cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={invariantOn}
+                  onChange={(e) => setInvariantOn(e.target.checked)}
+                  className="mt-0.5"
+                />
+                <span className="font-medium text-ink">
+                  Remember this as a fact I can check against later
+                </span>
+              </label>
+              {invariantOn && (
+                <textarea
+                  value={invariantText}
+                  onChange={(e) => setInvariantText(e.target.value)}
+                  rows={2}
+                  className="mt-2 w-full text-xs border border-border rounded px-2 py-1.5 bg-white focus:outline-none focus:ring-1 focus:ring-accent/30"
+                  placeholder="What did you just declare?"
+                />
+              )}
+            </div>
+          )}
 
           {/* Provocation callout */}
           {provocation && (

--- a/src/lib/invariants/__tests__/captureInvariant.test.ts
+++ b/src/lib/invariants/__tests__/captureInvariant.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { captureInvariant, listInvariants, recordInvariant, type Invariant } from '../captureInvariant'
+
+// ---------------------------------------------------------------------------
+// In-memory fetch double for /api/invariants — mirrors the real route's
+// contract (append-only create + list) closely enough to exercise the client
+// wrapper without re-testing the route itself (covered in route.test.ts).
+// ---------------------------------------------------------------------------
+
+let store: Invariant[] = []
+let nextId = 0
+let failNextPost = false
+
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response
+}
+
+function fetchStub(url: string, init?: RequestInit) {
+  if (init?.method === 'POST') {
+    if (failNextPost) {
+      failNextPost = false
+      return Promise.resolve(jsonResponse({ error: 'boom' }, 500))
+    }
+    const body = JSON.parse(String(init.body))
+    const invariant: Invariant = {
+      id: `inv-${nextId++}`,
+      documentId: body.documentId,
+      statement: body.statement,
+      blockIds: JSON.stringify(body.blockIds ?? []),
+      checkKind: body.checkKind ?? 'deterministic',
+      status: 'active',
+      provenanceCommitHash: body.provenanceCommitHash ?? null,
+      createdAt: new Date(1700000000000 + nextId * 1000).toISOString(),
+    }
+    store.push(invariant)
+    return Promise.resolve(jsonResponse({ invariant }))
+  }
+  // GET
+  const documentId = new URL(url, 'http://localhost').searchParams.get('documentId')
+  const invariants = [...store]
+    .filter((r) => r.documentId === documentId)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  return Promise.resolve(jsonResponse({ invariants }))
+}
+
+beforeEach(() => {
+  store = []
+  nextId = 0
+  failNextPost = false
+  vi.stubGlobal('fetch', vi.fn(fetchStub))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('captureInvariant', () => {
+  it('POSTs the declared fact and returns the stored row — the founder fixture', async () => {
+    const invariant = await captureInvariant({
+      documentId: 'doc-1',
+      statement: 'Terminations are now 30 days.',
+      blockIds: ['blk-terminations'],
+      provenanceCommitHash: 'commit-abc',
+    })
+    expect(invariant.statement).toBe('Terminations are now 30 days.')
+    expect(JSON.parse(invariant.blockIds)).toEqual(['blk-terminations'])
+    expect(invariant.provenanceCommitHash).toBe('commit-abc')
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/invariants',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('throws on a failed capture', async () => {
+    failNextPost = true
+    await expect(
+      captureInvariant({ documentId: 'doc-1', statement: 'A fact.' }),
+    ).rejects.toThrow('boom')
+  })
+})
+
+describe('recordInvariant', () => {
+  // recordInvariant no-ops outside a browser (vitest's environment is
+  // 'node'); stub `window` so these tests exercise the real capture path,
+  // matching how it runs in the SemanticCommitModal confirm handler.
+  beforeEach(() => {
+    vi.stubGlobal('window', {})
+  })
+
+  it('fires the capture (fire-and-forget) — this is the call SemanticCommitModal confirm makes', async () => {
+    recordInvariant({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' })
+    // Let the fire-and-forget promise chain flush.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(store).toHaveLength(1)
+    expect(store[0].statement).toBe('Terminations are now 30 days.')
+  })
+
+  it('never throws into the caller even when the capture fails', async () => {
+    failNextPost = true
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(() =>
+      recordInvariant({ documentId: 'doc-1', statement: 'A fact.' }),
+    ).not.toThrow()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})
+
+describe('listInvariants', () => {
+  it('round-trips every fact declared for a document, newest first', async () => {
+    await captureInvariant({
+      documentId: 'doc-1',
+      statement: 'Terminations are now 30 days.',
+      blockIds: ['blk-terminations'],
+    })
+    await captureInvariant({ documentId: 'doc-2', statement: 'Unrelated fact.' })
+    await captureInvariant({
+      documentId: 'doc-1',
+      statement: 'Termination notices go through HR.',
+      blockIds: ['blk-hr'],
+    })
+
+    const invariants = await listInvariants('doc-1')
+    expect(invariants).toHaveLength(2)
+    expect(invariants[0].statement).toBe('Termination notices go through HR.')
+    expect(invariants[1].statement).toBe('Terminations are now 30 days.')
+    expect(JSON.parse(invariants[1].blockIds)).toEqual(['blk-terminations'])
+  })
+})

--- a/src/lib/invariants/__tests__/captureInvariant.test.ts
+++ b/src/lib/invariants/__tests__/captureInvariant.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { captureInvariant, listInvariants, recordInvariant, type Invariant } from '../captureInvariant'
+import {
+  captureInvariant,
+  listInvariants,
+  recordInvariant,
+  shouldCaptureInvariant,
+  type Invariant,
+} from '../captureInvariant'
 
 // ---------------------------------------------------------------------------
 // In-memory fetch double for /api/invariants — mirrors the real route's
@@ -108,6 +114,27 @@ describe('recordInvariant', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
     expect(warn).toHaveBeenCalled()
     warn.mockRestore()
+  })
+})
+
+describe('shouldCaptureInvariant', () => {
+  // Regression for a review-caught bug: the capture checkbox/text in
+  // SemanticCommitModal is derived from the PRIMARY change but is a
+  // separate control from that row's own accept/reject toggle. Confirming
+  // with the checkbox on must NOT capture the declared fact if the primary
+  // edit itself was rejected — its claim never lands in the document, and
+  // capturing it anyway would append a false, permanently unfixable
+  // (append-only) ledger row with a real but misleading provenance hash.
+  it('captures when the primary edit is among the accepted ids', () => {
+    expect(shouldCaptureInvariant(['primary-1', 'cascade-2'], 'primary-1')).toBe(true)
+  })
+
+  it('does NOT capture when the primary edit was rejected, even if a cascade edit was accepted and applied', () => {
+    expect(shouldCaptureInvariant(['cascade-2'], 'primary-1')).toBe(false)
+  })
+
+  it('does not capture when nothing was accepted', () => {
+    expect(shouldCaptureInvariant([], 'primary-1')).toBe(false)
   })
 })
 

--- a/src/lib/invariants/captureInvariant.ts
+++ b/src/lib/invariants/captureInvariant.ts
@@ -67,6 +67,20 @@ export function recordInvariant(params: CaptureInvariantParams): void {
   })
 }
 
+/**
+ * Gate for whether a declared fact should actually be captured. The capture
+ * checkbox/text in SemanticCommitModal is derived from the PRIMARY change's
+ * proposed text but is a separate control from that row's own accept/reject
+ * toggle — so a caller must not treat "checkbox on" alone as license to
+ * capture. If the primary edit isn't among the ids the user actually chose
+ * to apply, its claim never lands in the document; capturing it anyway would
+ * append a false, permanently unfixable (append-only) ledger row pointing at
+ * a real commit hash that doesn't actually contain it.
+ */
+export function shouldCaptureInvariant(acceptedIds: string[], primaryId: string): boolean {
+  return acceptedIds.includes(primaryId)
+}
+
 /** All invariants declared for a document, newest first. */
 export async function listInvariants(documentId: string): Promise<Invariant[]> {
   const res = await fetch(`/api/invariants?documentId=${encodeURIComponent(documentId)}`)

--- a/src/lib/invariants/captureInvariant.ts
+++ b/src/lib/invariants/captureInvariant.ts
@@ -1,0 +1,76 @@
+/**
+ * Client-side capture for the Document Invariant Ledger — Phase 1 (data
+ * model + capture only, issue #26). A user-declared fact ("terminations are
+ * now 30 days"), recorded at SemanticCommitModal confirm time and linked to
+ * the block(s) that evidence it, plus the DocCommit hash of the version that
+ * declared it (provenance).
+ *
+ * The check runner that regression-tests these against later document edits,
+ * and CascadeList surfacing of a failing invariant, are a separate follow-up
+ * task (#20 steps 2-3) — this module only writes and reads the ledger.
+ */
+
+export type InvariantCheckKind = 'deterministic' | 'entailment'
+
+export interface Invariant {
+  id: string
+  documentId: string
+  statement: string
+  blockIds: string // JSON string[] — evidence links
+  checkKind: InvariantCheckKind
+  status: string
+  provenanceCommitHash: string | null
+  createdAt: string
+}
+
+export interface CaptureInvariantParams {
+  documentId: string
+  statement: string
+  blockIds?: string[]
+  checkKind?: InvariantCheckKind
+  provenanceCommitHash?: string | null
+}
+
+/**
+ * Append one declared fact to the ledger. Throws on failure — UI paths that
+ * must never block should use `recordInvariant` instead.
+ */
+export async function captureInvariant(params: CaptureInvariantParams): Promise<Invariant> {
+  const res = await fetch('/api/invariants', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      documentId: params.documentId,
+      statement: params.statement,
+      blockIds: params.blockIds ?? [],
+      checkKind: params.checkKind ?? 'deterministic',
+      provenanceCommitHash: params.provenanceCommitHash ?? undefined,
+    }),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error ?? `Failed to capture invariant (HTTP ${res.status})`)
+  }
+  const data = await res.json()
+  return data.invariant
+}
+
+/**
+ * Fire-and-forget wrapper for UI paths (mirrors `recordCommit`): never
+ * throws, never blocks the apply flow. Server-side renders and non-browser
+ * test environments are a silent no-op.
+ */
+export function recordInvariant(params: CaptureInvariantParams): void {
+  if (typeof window === 'undefined') return
+  captureInvariant(params).catch((err) => {
+    console.warn('[invariants] Failed to capture invariant:', err)
+  })
+}
+
+/** All invariants declared for a document, newest first. */
+export async function listInvariants(documentId: string): Promise<Invariant[]> {
+  const res = await fetch(`/api/invariants?documentId=${encodeURIComponent(documentId)}`)
+  if (!res.ok) throw new Error(`Failed to load invariants (HTTP ${res.status})`)
+  const data = await res.json()
+  return data.invariants ?? []
+}


### PR DESCRIPTION
## Summary

- Adds the `DocInvariant` Prisma model (statement, blockId evidence links, check-kind `deterministic|entailment`, status, provenance commit hash; append-only — only `GET`/`POST` exist, no update/delete route) alongside `DocCommit`, plus a `/api/invariants` route and a `captureInvariant()`/`recordInvariant()` client wrapper (`src/lib/invariants/captureInvariant.ts`) mirroring the `createCommit`/`recordCommit` pattern in `src/lib/history/commits.ts`.
- Wires capture into `SemanticCommitModal` confirm: an opt-out checkbox + editable fact text, defaulting from the primary change's proposed text and blockId. The declared fact is captured only after the resulting apply commit's hash is known, so each ledger row's `provenanceCommitHash` points at a real document version.
- **Review-caught fix included:** an adversarial pass on this branch found that the capture checkbox was wired independent of the primary edit's own accept/reject toggle — rejecting the primary edit while accepting an unrelated cascade edit could still capture the primary's (unapplied) claim into the append-only ledger with a real but misleading provenance hash. Added `shouldCaptureInvariant(acceptedIds, primaryId)` as the single gate, with regression tests pinning the exact scenario.
- Explicitly out of scope for this slice (per issue #26): the check runner that regression-tests the ledger against later edits, and `CascadeList` surfacing of a failing invariant — tracked as a follow-up once this data model lands.

Closes #26

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 749 passing + 10 skipped (was 731 before this change)
- [x] `npm run build` — clean
- [x] `npx prisma migrate deploy` against a fresh SQLite DB (mirrors the CI step) — the new migration applies cleanly on top of the three existing ones
- [x] Adversarial review (troublemaker agent) run before push; the one CRITICAL finding was fixed and regression-tested before this PR was opened

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve3pxipBj49jMW7NDF4Gqz)_