### PR TITLE
Add the dispatch workflow so the registry stops lying

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,73 @@
+name: Claude
+
+on:
+  issues:
+    types: [opened, assigned]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+# Two @claude events on one issue never run simultaneously. This is a collision
+# control, not a dedup control — a duplicate event still queues and runs after
+# the first finishes. Dedup is handled one layer up by the
+# `overlord-work-order:` body-line check at dispatch time.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    # The primary cost bound. A stuck agent otherwise runs to GitHub's 6-hour
+    # default, burning the shared subscription quota that also feeds live
+    # sessions.
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      # Floating major includes the >= v1.0.94 bot-trigger security fix
+      # (CVE-2025-66032). Note: dispatch issues here are NOT bot-authored —
+      # verified 2026-07-30, the overlord writes as `Vinylfigure` (type User)
+      # via the claude-github-mcp-connector app; only the child's own comments
+      # are `claude[bot]`. The pin is ordinary dependency hygiene, not a
+      # response to bot-authored dispatch.
+      # Echo-retrigger needs no actor guard: `allowed_bots` defaults to "",
+      # so no bot can trigger this workflow at all.
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # --max-turns is the runaway bound, not the effort budget; per-order
+          # effort budgets live in the work-order spec.
+          #
+          # --allowedTools: derived from this repo's own ci.yml (npm ci, prisma
+          # generate, typecheck, lint, test, build) rather than copied from
+          # another stream's stack.
+          #
+          # Deliberately NOT granted: Bash(npx:*), Bash(npm:*), Bash(node:*).
+          # Those are environment runners -- they execute whatever follows, so
+          # such a rule is an arbitrary-execution grant wearing a narrow
+          # costume. Each command is named in full instead.
+          #
+          # Also NOT granted: `npx prisma migrate deploy`. CI runs it against a
+          # throwaway service container; a dispatched agent must never point a
+          # migration at a real database.
+          #
+          # Caveat for order authors: `npm run test` may require DATABASE_URL.
+          # If a done-means check needs it, say so in the order rather than
+          # assuming the runner has it.
+          claude_args: --max-turns 120 --allowedTools "Bash(npm ci),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run test),Bash(npm run build),Bash(npx prisma generate),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git checkout:*),Bash(git log:*)"


### PR DESCRIPTION
## In plain words

- The portfolio registry says this stream accepts dispatched work orders. It couldn't — there was no dispatch workflow here at all.
- This adds one, with permissions derived from this repo's own CI rather than copied from another project.
- It does not grant anything that touches a real database.
- After this merges the stream still needs its dispatch secret set before an order can actually run.

## Why

A portfolio audit on 2026-08-18 probed every registered stream against GitHub. This one was the sharpest gap between what the registry claimed and what exists:

| | |
|---|---|
| `PORTFOLIO.md` says | `Dispatch channel: action`, `Verified green: 2026-08-16`, `Status: active` |
| Default branch actually has | `ci.yml`, `fleet-status.yml`, `gate-integrity.yml` — **no `claude.yml`** |

So an `@claude` work order sent to this stream would have landed as an issue that nothing consumed, and the conductor would have waited on a PR that could never arrive.

## The grant

Derived from this repo's own `ci.yml` — `npm ci`, `npx prisma generate`, `npm run typecheck`, `npm run lint`, `npm run test`, `npm run build` — rather than copied from another stream's stack.

```
Bash(npm ci),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run test),
Bash(npm run build),Bash(npx prisma generate),
Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git checkout:*),Bash(git log:*)
```

**Deliberately withheld:**

- `Bash(npx:*)`, `Bash(npm:*)`, `Bash(node:*)` — environment runners execute whatever follows them, so such a rule is an arbitrary-execution grant wearing a narrow costume. Each command is named in full instead.
- `npx prisma migrate deploy` — CI runs it against a throwaway service container. A dispatched agent must never point a migration at a real database.

**Caveat recorded in the file for order authors:** `npm run test` may require `DATABASE_URL`. An order whose done-means depends on it should say so rather than assume the runner has it.

`--max-turns 120` matches the rest of the fleet, raised from 50 today after a 50-turn cap killed a job-search run *after* it finished its work but *before* it opened a PR.

## Still required after this

The dispatch secret is not set on this repo. `channel-check.sh` will report `not wired: secret` until it is, and preflight now refuses to send an order into a secretless target — so this PR makes the channel real but not yet live. That last step is the repo owner's.
