### PR TITLE
Ablation harness scaffolding for arms B/D/E (no live key required)

### DIFF
--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,4 +1,5 @@
 import type { EditorState } from 'prosemirror-state'
+import type { Node as PMNode } from 'prosemirror-model'
 import type {
   CascadeEdgeType,
   CascadeEvidence,
@@ -35,7 +36,7 @@ const EDGE_TYPES: ReadonlySet<string> = new Set([
   'duplicates',
 ])
 
-const PROPOSE_EDIT_TOOL = {
+export const PROPOSE_EDIT_TOOL = {
   name: 'propose_edit',
   description:
     'Propose a change to one of the listed blocks that becomes inconsistent because of the primary edit. Call once per distinct affected block. Only propose edits where a figure, claim, name, or statement must be brought into agreement with the primary edit.',
@@ -186,13 +187,13 @@ export function deriveSeverity(
 }
 
 function buildEvidence(
-  state: EditorState,
+  doc: PMNode,
   input: ToolCallInput,
 ): CascadeEvidence | null {
   const sourceBlockId = input.source_block_id
   const quotedText = input.quoted_text?.trim()
   if (!sourceBlockId || !quotedText) return null
-  if (!blockTextRange(state.doc, sourceBlockId, quotedText)) return null
+  if (!blockTextRange(doc, sourceBlockId, quotedText)) return null
   const edgeType: CascadeEdgeType = EDGE_TYPES.has(input.edge_type ?? '')
     ? (input.edge_type as CascadeEdgeType)
     : 'references'
@@ -244,7 +245,74 @@ async function judgeEnabledFromStore(): Promise<boolean> {
  * a judge failure keeps the derived severities unchanged, never blocks.
  * Mutates the edits in place; returns true when any severity changed.
  */
-async function applyRelevanceJudge(
+/**
+ * Parse `propose_edit` tool calls into anchored, evidence-verified,
+ * severity-derived ProposedEdits. Pure with respect to the model: shared by
+ * every cascade mechanism that generates candidates via the propose_edit tool
+ * (the graph-scoped pipeline below, and the whole-doc ablation arms in
+ * `ablationArms.ts`) so anchoring/evidence/severity rules — the substrate the
+ * ablation holds constant — stay byte-identical across arms; only candidate
+ * SCOPING and the verify stage differ between them.
+ */
+export function resolveProposedEdits(
+  doc: PMNode,
+  toolCalls: { name: string; input: unknown }[],
+  scope: ReadonlySet<string>,
+  primary: { from: number; to: number; newText: string },
+  primaryBefore: string,
+): ProposedEdit[] {
+  const edits: ProposedEdit[] = []
+  for (const call of toolCalls) {
+    if (call.name !== 'propose_edit') continue
+    const input = call.input as ToolCallInput
+    const targetText = input?.target_text?.trim()
+    const newText = input?.new_text
+    if (!targetText || newText === undefined) continue
+
+    // Anchor by blockId first; fall back to first-occurrence only when the
+    // block can't be located, then re-derive which block we actually landed in.
+    let located = input.block_id ? blockTextRange(doc, input.block_id, targetText) : null
+    let resolvedBlockId = located ? input.block_id! : null
+    if (!located) {
+      located = findTextInDoc(doc, targetText)
+      if (located) resolvedBlockId = blockIdAtPos(doc, located.from)
+    }
+    if (!located || !resolvedBlockId) continue // unanchorable — drop rather than guess
+
+    // Scope gate: the edit must land inside the candidate set we sent.
+    if (!scope.has(resolvedBlockId)) continue
+    // Skip anything overlapping the primary range to avoid double-editing it.
+    if (located.from < primary.to && located.to > primary.from) continue
+    // Duplicate gate: repeated tool calls anchor to the same range (blockTextRange
+    // returns the first occurrence), and applying two replacements over one region
+    // in a single transaction corrupts the text — first proposal wins.
+    const anchored = located
+    if (edits.some((e) => anchored.from < e.to && anchored.to > e.from)) continue
+
+    const targetBlockText = findBlockById(doc, resolvedBlockId)?.node.textContent ?? ''
+    const evidence = buildEvidence(doc, input)
+    const severity = deriveSeverity(evidence, targetBlockText, primaryBefore, primary.newText)
+
+    edits.push({
+      id: newId(),
+      from: located.from,
+      to: located.to,
+      newText,
+      reason: input?.reason ?? 'Consistency with the primary edit.',
+      relation: 'cascade',
+      status: 'pending',
+      targetText,
+      blockId: resolvedBlockId,
+      severity,
+      evidence,
+    })
+  }
+
+  edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+  return edits
+}
+
+export async function applyRelevanceJudge(
   edits: ProposedEdit[],
   primary: { before: string; newText: string },
   doc: EditorState['doc'],
@@ -385,54 +453,7 @@ export async function proposeCascadeEdits(
     return []
   }
 
-  const edits: ProposedEdit[] = []
-  for (const call of toolCalls) {
-    if (call.name !== 'propose_edit') continue
-    const input = call.input as ToolCallInput
-    const targetText = input?.target_text?.trim()
-    const newText = input?.new_text
-    if (!targetText || newText === undefined) continue
-
-    // Anchor by blockId first; fall back to first-occurrence only when the
-    // block can't be located, then re-derive which block we actually landed in.
-    let located = input.block_id ? blockTextRange(doc, input.block_id, targetText) : null
-    let resolvedBlockId = located ? input.block_id! : null
-    if (!located) {
-      located = findTextInDoc(doc, targetText)
-      if (located) resolvedBlockId = blockIdAtPos(doc, located.from)
-    }
-    if (!located || !resolvedBlockId) continue // unanchorable — drop rather than guess
-
-    // Scope gate: the edit must land inside the neighborhood we sent.
-    if (!sentIds.has(resolvedBlockId)) continue
-    // Skip anything overlapping the primary range to avoid double-editing it.
-    if (located.from < primary.to && located.to > primary.from) continue
-    // Duplicate gate: repeated tool calls anchor to the same range (blockTextRange
-    // returns the first occurrence), and applying two replacements over one region
-    // in a single transaction corrupts the text — first proposal wins.
-    const anchored = located
-    if (edits.some((e) => anchored.from < e.to && anchored.to > e.from)) continue
-
-    const targetBlockText = findBlockById(doc, resolvedBlockId)?.node.textContent ?? ''
-    const evidence = buildEvidence(state, input)
-    const severity = deriveSeverity(evidence, targetBlockText, primaryBefore, primary.newText)
-
-    edits.push({
-      id: newId(),
-      from: located.from,
-      to: located.to,
-      newText,
-      reason: input?.reason ?? 'Consistency with the primary edit.',
-      relation: 'cascade',
-      status: 'pending',
-      targetText,
-      blockId: resolvedBlockId,
-      severity,
-      evidence,
-    })
-  }
-
-  edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+  const edits = resolveProposedEdits(doc, toolCalls, sentIds, primary, primaryBefore)
 
   // User toggle ("Verify must-severity citations"): when off, skip the judge
   // entirely — severities stay derived from graph structure + conflict checks.

--- a/src/lib/graphrag/__tests__/ablationBench.test.ts
+++ b/src/lib/graphrag/__tests__/ablationBench.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { CallStructuredFn, StructuredRequest } from '@/lib/ai/structuredClient'
+import type { ProposedEdit } from '@/lib/annotations/types'
+import { judgeMustCandidates, type JudgeFn, type JudgeVerdict } from '@/lib/ai/relevanceJudge'
+import { buildDeterministicGraph, augmentWithLlmEdges, invalidateDocGraphCache, type DocGraph } from '../docGraph'
+import { runAblationArm, ABLATION_ARMS, type ArmId } from '../ablationArms'
+import { CASCADE_FIXTURES, resolvePrimary, type CascadeFixture } from './editPropBench.fixtures'
+
+/**
+ * Ablation harness SCAFFOLDING (issue #27, precursor to issue #19's live
+ * comparative run). Runs arms B, C, D — and their cheap-model (arm E)
+ * variants — against the existing EditPropBench fixtures with the SCRIPTED
+ * model (never a live provider; BENCH_LIVE is irrelevant here and never
+ * read). The fixtures' scripted tool calls are model-agnostic canned
+ * responses, so the SAME `scriptedCascadeCalls` exercise every arm's real
+ * anchoring/evidence/severity/verify pipeline without a network call.
+ *
+ * This file asserts the harness RUNS CLEANLY and produces the metrics shape
+ * end to end — it is deliberately NOT a quality gate on arms B/D the way
+ * `editPropBench.test.ts` is for arm C: those arms are unproven scaffolding
+ * whose actual recall/collateral-damage numbers are exactly what the live
+ * comparative run (blocked on an operator-supplied key, #19) exists to
+ * measure. Fixture `extraAssertions` are arm-C-specific (they assert on
+ * graph-SCOPED prompt content, e.g. "far filler blocks are never sent") and
+ * are intentionally not replayed for B/D, which see the whole document by
+ * design.
+ */
+
+const CONFIG: LLMConfig = { provider: 'claude', apiKey: 'bench-key', model: 'bench-model' }
+
+// Provider-failure fixtures exist to script a dead transport for one arm's
+// call shape; every arm must degrade to [] on a thrown call, so keep them.
+const FIXTURES = CASCADE_FIXTURES
+
+interface AblationMetrics {
+  fixture: string
+  arm: string
+  cheapModel: boolean
+  recall: number | null
+  /** must/probably proposals landing on a protected span — precision gate. */
+  protectedSpanViolations: number
+  /** ANY proposal (any severity) landing on a protected span — broader collateral measure. */
+  collateralDamageCount: number
+  proposals: number
+  musts: number
+  validCitations: number
+}
+
+const collected: AblationMetrics[] = []
+
+function scripted(
+  calls: Array<{ name: string; input: Record<string, unknown> }>,
+  capture: StructuredRequest[],
+  throwOnCall = false,
+): CallStructuredFn {
+  return async (req) => {
+    capture.push(req)
+    if (throwOnCall) throw new Error('bench: provider down')
+    return { toolCalls: calls }
+  }
+}
+
+const confirmAllJudge: JudgeFn = async (candidates) =>
+  new Map(
+    candidates.map((_, i): [number, JudgeVerdict] => [
+      i,
+      { genuinelyConflicts: true, reason: 'confirmed' },
+    ]),
+  )
+
+function scriptedJudge(
+  calls: Array<{ name: string; input: Record<string, unknown> }>,
+  capture: StructuredRequest[],
+): JudgeFn {
+  return (candidates, primary, doc, config) =>
+    judgeMustCandidates(candidates, primary, doc, config, scripted(calls, capture))
+}
+
+function computeMetrics(
+  fixture: CascadeFixture,
+  arm: string,
+  cheapModel: boolean,
+  edits: ProposedEdit[],
+): AblationMetrics {
+  const { requiredDownstream, protectedUnchanged } = fixture.labels
+  const proposedBlockIds = new Set(edits.map((e) => e.blockId).filter(Boolean))
+
+  const recall =
+    requiredDownstream.length === 0
+      ? null
+      : requiredDownstream.filter((id) => proposedBlockIds.has(id)).length /
+        requiredDownstream.length
+
+  const protectedSpanViolations = edits.filter(
+    (e) =>
+      (e.severity === 'must' || e.severity === 'probably') &&
+      e.blockId !== undefined &&
+      protectedUnchanged.includes(e.blockId),
+  ).length
+
+  const collateralDamageCount = edits.filter(
+    (e) => e.blockId !== undefined && protectedUnchanged.includes(e.blockId),
+  ).length
+
+  const musts = edits.filter((e) => e.severity === 'must')
+  return {
+    fixture: fixture.name,
+    arm,
+    cheapModel,
+    recall,
+    protectedSpanViolations,
+    collateralDamageCount,
+    proposals: edits.length,
+    musts: musts.length,
+    validCitations: musts.filter((m) => m.evidence !== null).length,
+  }
+}
+
+beforeEach(() => {
+  invalidateDocGraphCache()
+})
+
+describe('Ablation harness — arms B/C/D × cheap-model dry run (scripted model, no live key)', () => {
+  for (const armId of ABLATION_ARMS) {
+    for (const cheapModel of [false, true]) {
+      describe(`arm ${armId}${cheapModel ? ' (cheap-model / arm E variant)' : ''}`, () => {
+        for (const fixture of FIXTURES) {
+          it(fixture.name, async () => {
+            const doc = fixture.buildDoc()
+            const state = EditorState.create({ schema, doc })
+            const primary = resolvePrimary(doc, fixture)
+            const captured: StructuredRequest[] = []
+
+            let graph: DocGraph | undefined
+            if (armId === 'C') {
+              graph = buildDeterministicGraph(doc)
+              if (fixture.scriptedGraphCalls) {
+                await augmentWithLlmEdges(graph, CONFIG, scripted(fixture.scriptedGraphCalls, []))
+              }
+            }
+
+            const edits = await runAblationArm(armId as ArmId, state, primary, CONFIG, {
+              graph,
+              callStructured: scripted(fixture.scriptedCascadeCalls, captured, fixture.throwOnCascade),
+              judge: fixture.scriptedJudgeCalls
+                ? scriptedJudge(fixture.scriptedJudgeCalls, captured)
+                : confirmAllJudge,
+              cheapModel,
+            })
+
+            // No throw, and the metrics shape computes cleanly from whatever
+            // came back — that IS the done-means for this scaffolding task.
+            const metrics = computeMetrics(fixture, armId, cheapModel, edits)
+            collected.push(metrics)
+
+            expect(Array.isArray(edits)).toBe(true)
+            expect(metrics.recall === null || (metrics.recall >= 0 && metrics.recall <= 1)).toBe(true)
+            expect(metrics.protectedSpanViolations).toBeGreaterThanOrEqual(0)
+            expect(metrics.collateralDamageCount).toBeGreaterThanOrEqual(0)
+            expect(metrics.collateralDamageCount).toBeGreaterThanOrEqual(metrics.protectedSpanViolations)
+
+            // The primary's own block must never come back as a cascade,
+            // regardless of arm — this is anchoring behavior every arm shares.
+            for (const edit of edits) {
+              expect(fixture.labels.directTargets).not.toContain(edit.blockId)
+            }
+
+            // Citation validity is unconditional: every 'must' this harness
+            // ever returns re-verifies verbatim against the live document,
+            // because 'must' can only come from deriveSeverity's own
+            // verbatim check inside resolveProposedEdits — shared by every arm.
+            for (const must of edits.filter((e) => e.severity === 'must')) {
+              expect(must.evidence).not.toBeNull()
+            }
+          })
+        }
+      })
+    }
+  }
+
+  it('aggregate: every arm × fixture combination produced a well-formed metrics row', () => {
+    // 3 arms × 2 model tiers × N fixtures.
+    expect(collected.length).toBe(ABLATION_ARMS.length * 2 * FIXTURES.length)
+    for (const m of collected) {
+      expect(Number.isFinite(m.proposals)).toBe(true)
+      expect(Number.isFinite(m.musts)).toBe(true)
+      expect(Number.isFinite(m.validCitations)).toBe(true)
+      expect(m.validCitations).toBeLessThanOrEqual(m.musts)
+    }
+  })
+})

--- a/src/lib/graphrag/ablationArms.ts
+++ b/src/lib/graphrag/ablationArms.ts
@@ -27,11 +27,13 @@ import { buildDeterministicGraph, getNeighborhood, type DocGraph } from './docGr
  * Design choice held constant across arms: candidate parsing, blockId
  * anchoring, evidence verification, and numeric-conflict severity derivation
  * all run through the SAME `resolveProposedEdits` helper the production
- * pipeline (arm C) uses. Arms differ only in what candidates they generate
- * from — whole document (B, D) vs 2-hop graph neighborhood (C) — and what
- * "verify" pass runs after generation. That isolates the variable the
- * ablation is actually testing (scoping mechanism) instead of also varying
- * the anchoring/evidence substrate, which would confound the comparison.
+ * pipeline (arm C) uses. Arms differ in candidate SCOPING — arm D free-edits
+ * the whole document in one pass, arm B plans over the whole document then
+ * patches only the planned blocks, arm C sends only a 2-hop graph
+ * neighborhood — and in what "verify" pass runs after generation (LLM judge
+ * for B/C, deterministic-graph repair for D). That isolates the variables the
+ * ablation is actually testing instead of also varying the anchoring/evidence
+ * substrate, which would confound the comparison.
  */
 
 export type ArmId = 'B' | 'C' | 'D'
@@ -42,7 +44,14 @@ export interface AblationOptions {
   judge?: JudgeFn
   /** Pre-built graph — arm C only (passed through to proposeCascadeEdits). */
   graph?: DocGraph
-  /** Route generation (and, for B, self-verify) through pickUtilityModel — arm E. */
+  /**
+   * Route GENERATION (arm B's plan + patch calls; arm C/D's single call)
+   * through pickUtilityModel — arm E. Self-verify is NOT affected by this
+   * flag: `judgeMustCandidates` already unconditionally pins every judge call
+   * (arm B's self-verify, arm C's production judge) to the utility model
+   * regardless of `cheapModel` — see relevanceJudge.ts. So B vs cheap-B only
+   * differs in what generated the candidates, not in verify cost.
+   */
   cheapModel?: boolean
   /** Deterministic-graph connectivity radius for arm D's repair step. */
   hops?: number
@@ -50,6 +59,52 @@ export interface AblationOptions {
 
 const WHOLE_DOC_SYSTEM =
   'You keep a document internally consistent. You are given a primary edit and the FULL document, each block listed as [blockId] text. Find blocks that become inconsistent, outdated, or contradictory because of the primary edit and call propose_edit once for each. Only edit listed blocks; reference them by their block_id. Copy target_text verbatim from the block. Never propose an edit to the primary block itself. Cite your evidence: source_block_id plus a verbatim quoted_text showing the conflict. If nothing needs to change, call nothing.'
+
+// --- Arm B: plan-then-patch ------------------------------------------------
+
+const PLAN_TOOL = {
+  name: 'plan_edit',
+  description:
+    'Identify ONE block that becomes inconsistent, outdated, or contradictory because of the primary edit — planning only, no replacement text yet. Call once per affected block. Never plan the primary block itself.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      block_id: { type: 'string', description: 'Id of the affected block.' },
+      reason: { type: 'string', description: 'Why this block is affected.' },
+    },
+    required: ['block_id'],
+  },
+}
+
+const PLAN_SYSTEM =
+  'You keep a document internally consistent. You are given a primary edit and the FULL document, each block listed as [blockId] text. PLAN which blocks become inconsistent, outdated, or contradictory because of the primary edit — call plan_edit once per affected block. Do NOT write replacement text yet; that is a later step. Never plan the primary block itself. If nothing is affected, call nothing.'
+
+const PATCH_SYSTEM =
+  'You write the replacement text for blocks a prior planning pass already identified as affected by a primary edit. For each listed block, call propose_edit with the exact verbatim target_text to replace, its replacement new_text, and evidence (source_block_id + verbatim quoted_text) showing the conflict. Only patch the listed blocks.'
+
+interface PlanInput {
+  block_id?: unknown
+  reason?: unknown
+}
+
+/** Parse a plan-stage response into unique, in-scope block ids. */
+function parsePlannedBlockIds(
+  toolCalls: { name: string; input: unknown }[],
+  allBlockIds: ReadonlySet<string>,
+  primaryBlockId: string,
+): string[] {
+  const planned: string[] = []
+  const seen = new Set<string>()
+  for (const tc of toolCalls) {
+    const input = tc.input as PlanInput
+    const blockId = typeof input?.block_id === 'string' ? input.block_id : undefined
+    if (!blockId || blockId === primaryBlockId) continue
+    if (!allBlockIds.has(blockId) || seen.has(blockId)) continue
+    seen.add(blockId)
+    planned.push(blockId)
+  }
+  return planned
+}
 
 function primaryBeforeText(state: EditorState, primary: SuggestedEdit): string {
   const doc = state.doc
@@ -65,8 +120,9 @@ function effectiveConfig(config: LLMConfig, cheapModel?: boolean): LLMConfig {
 
 /**
  * Generate free (unscoped) proposals over every textblock in the document —
- * the "whole doc" half of arms B and D. Best-effort: any transport failure
- * degrades to zero proposals, same contract as the graph-scoped pipeline.
+ * arm D's single whole-doc pass (arm B has its own two-stage plan+patch
+ * calls below). Best-effort: any transport failure degrades to zero
+ * proposals, same contract as the graph-scoped pipeline.
  */
 async function generateWholeDocProposals(
   state: EditorState,
@@ -112,12 +168,24 @@ async function generateWholeDocProposals(
 }
 
 /**
- * Arm B — whole-doc plan-then-patch + self-verify. The "plan" (which blocks
- * are affected) and "patch" (what they become) collapse into one generation
- * call — a scripted model already knows its answer, so a separate plan call
- * would only add a second scripted round-trip without changing pipeline
- * behavior. The self-verify pass is real: the same LLM judge arm C uses
- * re-examines every derived 'must' and demotes unconfirmed ones.
+ * Arm B — whole-doc plan-then-patch + self-verify: THREE real structured
+ * calls, matching issue #19's arm definition literally rather than
+ * collapsing it into "single pass + verify" (which is arm A, not B).
+ *
+ * 1. PLAN: whole document, plan_edit tool — identify affected blocks only,
+ *    no replacement text.
+ * 2. PATCH: only the planned blocks, propose_edit tool — write the actual
+ *    replacement + evidence. Scoped narrower than the plan call by design:
+ *    patching should reason about the specific passages the plan flagged,
+ *    not the whole document again.
+ * 3. SELF-VERIFY: the same LLM judge arm C's production judge uses,
+ *    re-examining every derived 'must' and demoting unconfirmed ones.
+ *
+ * Under the scripted test harness all three calls hit the same canned
+ * response list (a script has no concept of "this is the plan prompt vs the
+ * patch prompt"), so the scripted result is identical to a single-call
+ * version — but the CALL STRUCTURE is real, and a live model sees a
+ * genuinely different, narrower prompt at each stage.
  */
 export async function runArmB(
   state: EditorState,
@@ -127,15 +195,85 @@ export async function runArmB(
 ): Promise<ProposedEdit[]> {
   const doc = state.doc
   const primaryBlockId = blockIdAtPos(doc, primary.from)
-  if (!primaryBlockId) return []
+  if (!primaryBlockId) {
+    console.warn('ablation arm B: primary edit has no blockId — skipping')
+    return []
+  }
 
   const cfg = effectiveConfig(config, opts.cheapModel)
   const call = opts.callStructured ?? fetchStructured
   const primaryBefore = primaryBeforeText(state, primary)
 
-  const edits = await generateWholeDocProposals(state, primary, primaryBlockId, primaryBefore, cfg, call)
+  const blocks = collectTextblocks(doc).filter((b) => b.blockId)
+  const allBlockIds = new Set(blocks.map((b) => b.blockId!))
+
+  const wholeDocPrompt = [
+    `PRIMARY EDIT (in block [${primaryBlockId}], just applied or about to apply):`,
+    `- Was: "${primaryBefore}"`,
+    `- Now: "${primary.newText}"`,
+    '',
+    'DOCUMENT BLOCKS:',
+    ...blocks.map((b) => `[${b.blockId}] ${b.node.textContent}`),
+  ].join('\n')
+
+  // 1. Plan.
+  let planCalls: { name: string; input: unknown }[]
+  try {
+    const res = await call(
+      {
+        messages: [
+          { role: 'system', content: PLAN_SYSTEM },
+          { role: 'user', content: wholeDocPrompt },
+        ],
+        tools: [PLAN_TOOL],
+        maxTokens: 1500,
+        temperature: 0.2,
+      },
+      cfg,
+    )
+    planCalls = res.toolCalls
+  } catch {
+    return []
+  }
+  const plannedBlockIds = parsePlannedBlockIds(planCalls, allBlockIds, primaryBlockId)
+  if (plannedBlockIds.length === 0) return []
+
+  // 2. Patch — scoped to only the planned blocks.
+  const plannedSet = new Set(plannedBlockIds)
+  const patchPrompt = [
+    `PRIMARY EDIT (in block [${primaryBlockId}], just applied or about to apply):`,
+    `- Was: "${primaryBefore}"`,
+    `- Now: "${primary.newText}"`,
+    '',
+    'BLOCKS A PRIOR PLANNING PASS FLAGGED AS AFFECTED (patch each):',
+    ...blocks
+      .filter((b) => plannedSet.has(b.blockId!))
+      .map((b) => `[${b.blockId}] ${b.node.textContent}`),
+  ].join('\n')
+
+  let patchCalls: { name: string; input: unknown }[]
+  try {
+    const res = await call(
+      {
+        messages: [
+          { role: 'system', content: PATCH_SYSTEM },
+          { role: 'user', content: patchPrompt },
+        ],
+        tools: [PROPOSE_EDIT_TOOL],
+        maxTokens: 4000,
+        temperature: 0.2,
+      },
+      cfg,
+    )
+    patchCalls = res.toolCalls
+  } catch {
+    return []
+  }
+
+  const edits = resolveProposedEdits(doc, patchCalls, plannedSet, primary, primaryBefore)
   if (edits.length === 0) return edits
 
+  // 3. Self-verify.
   const demoted = await applyRelevanceJudge(
     edits,
     { before: primaryBefore, newText: primary.newText },
@@ -168,7 +306,10 @@ export async function runArmD(
 ): Promise<ProposedEdit[]> {
   const doc = state.doc
   const primaryBlockId = blockIdAtPos(doc, primary.from)
-  if (!primaryBlockId) return []
+  if (!primaryBlockId) {
+    console.warn('ablation arm D: primary edit has no blockId — skipping')
+    return []
+  }
 
   const cfg = effectiveConfig(config, opts.cheapModel)
   const call = opts.callStructured ?? fetchStructured

--- a/src/lib/graphrag/ablationArms.ts
+++ b/src/lib/graphrag/ablationArms.ts
@@ -1,0 +1,224 @@
+import type { EditorState } from 'prosemirror-state'
+import type { SuggestedEdit, ProposedEdit } from '@/lib/annotations/types'
+import { SEVERITY_ORDER } from '@/lib/annotations/types'
+import type { LLMConfig } from '@/stores/settingsStore'
+import { collectTextblocks, blockIdAtPos } from '@/lib/prosemirror/blockIds'
+import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
+import type { JudgeFn } from '@/lib/ai/relevanceJudge'
+import {
+  PROPOSE_EDIT_TOOL,
+  resolveProposedEdits,
+  applyRelevanceJudge,
+  proposeCascadeEdits,
+  type CascadeOptions,
+} from '@/lib/ai/orchestrator'
+import { buildDeterministicGraph, getNeighborhood, type DocGraph } from './docGraph'
+
+/**
+ * Ablation-study arms for issue #19's graph-scoped-vs-whole-doc cascade
+ * question. Scaffolding only — see #27: this module makes every arm runnable
+ * against the SCRIPTED model (no live provider key), so the harness is one
+ * `bench:live`-style run away from a verdict the moment a key is available.
+ * Arm A (whole-doc single pass, no verify) is intentionally NOT implemented
+ * here — issue #27 scopes it out; only B, D, and E (cheap-model variants of
+ * B/C/D) are built alongside the existing arm C baseline (`proposeCascadeEdits`).
+ *
+ * Design choice held constant across arms: candidate parsing, blockId
+ * anchoring, evidence verification, and numeric-conflict severity derivation
+ * all run through the SAME `resolveProposedEdits` helper the production
+ * pipeline (arm C) uses. Arms differ only in what candidates they generate
+ * from — whole document (B, D) vs 2-hop graph neighborhood (C) — and what
+ * "verify" pass runs after generation. That isolates the variable the
+ * ablation is actually testing (scoping mechanism) instead of also varying
+ * the anchoring/evidence substrate, which would confound the comparison.
+ */
+
+export type ArmId = 'B' | 'C' | 'D'
+
+export interface AblationOptions {
+  callStructured?: CallStructuredFn
+  /** Arm B's self-verify judge override (defaults like the production judge). */
+  judge?: JudgeFn
+  /** Pre-built graph — arm C only (passed through to proposeCascadeEdits). */
+  graph?: DocGraph
+  /** Route generation (and, for B, self-verify) through pickUtilityModel — arm E. */
+  cheapModel?: boolean
+  /** Deterministic-graph connectivity radius for arm D's repair step. */
+  hops?: number
+}
+
+const WHOLE_DOC_SYSTEM =
+  'You keep a document internally consistent. You are given a primary edit and the FULL document, each block listed as [blockId] text. Find blocks that become inconsistent, outdated, or contradictory because of the primary edit and call propose_edit once for each. Only edit listed blocks; reference them by their block_id. Copy target_text verbatim from the block. Never propose an edit to the primary block itself. Cite your evidence: source_block_id plus a verbatim quoted_text showing the conflict. If nothing needs to change, call nothing.'
+
+function primaryBeforeText(state: EditorState, primary: SuggestedEdit): string {
+  const doc = state.doc
+  return doc.textBetween(
+    Math.min(primary.from, doc.content.size),
+    Math.min(primary.to, doc.content.size),
+  )
+}
+
+function effectiveConfig(config: LLMConfig, cheapModel?: boolean): LLMConfig {
+  return cheapModel ? { ...config, model: pickUtilityModel(config) } : config
+}
+
+/**
+ * Generate free (unscoped) proposals over every textblock in the document —
+ * the "whole doc" half of arms B and D. Best-effort: any transport failure
+ * degrades to zero proposals, same contract as the graph-scoped pipeline.
+ */
+async function generateWholeDocProposals(
+  state: EditorState,
+  primary: SuggestedEdit,
+  primaryBlockId: string,
+  primaryBefore: string,
+  config: LLMConfig,
+  call: CallStructuredFn,
+): Promise<ProposedEdit[]> {
+  const doc = state.doc
+  const blocks = collectTextblocks(doc).filter((b) => b.blockId)
+  const allBlockIds = new Set(blocks.map((b) => b.blockId!))
+
+  const userPrompt = [
+    `PRIMARY EDIT (in block [${primaryBlockId}], just applied or about to apply):`,
+    `- Was: "${primaryBefore}"`,
+    `- Now: "${primary.newText}"`,
+    '',
+    'DOCUMENT BLOCKS (the only blocks you may edit):',
+    ...blocks.map((b) => `[${b.blockId}] ${b.node.textContent}`),
+  ].join('\n')
+
+  let toolCalls: { name: string; input: unknown }[]
+  try {
+    const res = await call(
+      {
+        messages: [
+          { role: 'system', content: WHOLE_DOC_SYSTEM },
+          { role: 'user', content: userPrompt },
+        ],
+        tools: [PROPOSE_EDIT_TOOL],
+        maxTokens: 4000,
+        temperature: 0.2,
+      },
+      config,
+    )
+    toolCalls = res.toolCalls
+  } catch {
+    return []
+  }
+
+  return resolveProposedEdits(doc, toolCalls, allBlockIds, primary, primaryBefore)
+}
+
+/**
+ * Arm B — whole-doc plan-then-patch + self-verify. The "plan" (which blocks
+ * are affected) and "patch" (what they become) collapse into one generation
+ * call — a scripted model already knows its answer, so a separate plan call
+ * would only add a second scripted round-trip without changing pipeline
+ * behavior. The self-verify pass is real: the same LLM judge arm C uses
+ * re-examines every derived 'must' and demotes unconfirmed ones.
+ */
+export async function runArmB(
+  state: EditorState,
+  primary: SuggestedEdit,
+  config: LLMConfig,
+  opts: AblationOptions = {},
+): Promise<ProposedEdit[]> {
+  const doc = state.doc
+  const primaryBlockId = blockIdAtPos(doc, primary.from)
+  if (!primaryBlockId) return []
+
+  const cfg = effectiveConfig(config, opts.cheapModel)
+  const call = opts.callStructured ?? fetchStructured
+  const primaryBefore = primaryBeforeText(state, primary)
+
+  const edits = await generateWholeDocProposals(state, primary, primaryBlockId, primaryBefore, cfg, call)
+  if (edits.length === 0) return edits
+
+  const demoted = await applyRelevanceJudge(
+    edits,
+    { before: primaryBefore, newText: primary.newText },
+    doc,
+    cfg,
+    { callStructured: call, judge: opts.judge } as CascadeOptions,
+  )
+  if (demoted) {
+    edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+  }
+  return edits
+}
+
+/**
+ * Arm D — whole-doc free edits + a deterministic verify/repair loop. No LLM
+ * judge call: numeric/figure conflicts are already deterministic-verified by
+ * `deriveSeverity` inside `resolveProposedEdits` (a 'must' stays a 'must').
+ * The repair step adds the OTHER deterministic signal — docGraph's own
+ * refs/terms/duplicate-sentence extractors — as a check on 'probably'
+ * proposals: a cited-but-not-numerically-provable claim the deterministic
+ * graph does not connect to the primary block loses its confidence and caps
+ * to 'optional'. This is `docGraph`'s existing deterministic extractors doing
+ * double duty as the ablation's precursor to the Document Invariant Ledger.
+ */
+export async function runArmD(
+  state: EditorState,
+  primary: SuggestedEdit,
+  config: LLMConfig,
+  opts: AblationOptions = {},
+): Promise<ProposedEdit[]> {
+  const doc = state.doc
+  const primaryBlockId = blockIdAtPos(doc, primary.from)
+  if (!primaryBlockId) return []
+
+  const cfg = effectiveConfig(config, opts.cheapModel)
+  const call = opts.callStructured ?? fetchStructured
+  const primaryBefore = primaryBeforeText(state, primary)
+
+  const edits = await generateWholeDocProposals(state, primary, primaryBlockId, primaryBefore, cfg, call)
+  if (edits.length === 0) return edits
+
+  const detGraph = buildDeterministicGraph(doc)
+  const hops = opts.hops ?? 2
+  const neighborhood = getNeighborhood(detGraph, primaryBlockId, hops)
+  for (const edit of edits) {
+    if (edit.severity !== 'probably') continue // 'must' is numeric-verified; 'optional' is already the floor
+    const confirmed = edit.blockId ? neighborhood.has(edit.blockId) : false
+    if (!confirmed) {
+      edit.severity = 'optional'
+      edit.reason = `${edit.reason} (auto-review: no deterministic refs/terms link to the primary block)`
+    }
+  }
+  edits.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || a.from - b.from)
+  return edits
+}
+
+/**
+ * Dispatch to one ablation arm by id. Arm C delegates unchanged to the
+ * production `proposeCascadeEdits` (graph-scoped baseline) — `cheapModel`
+ * swaps its model before the call rather than adding a new code path.
+ */
+export async function runAblationArm(
+  armId: ArmId,
+  state: EditorState,
+  primary: SuggestedEdit,
+  config: LLMConfig,
+  opts: AblationOptions = {},
+): Promise<ProposedEdit[]> {
+  switch (armId) {
+    case 'B':
+      return runArmB(state, primary, config, opts)
+    case 'D':
+      return runArmD(state, primary, config, opts)
+    case 'C': {
+      const cfg = effectiveConfig(config, opts.cheapModel)
+      return proposeCascadeEdits(state, primary, cfg, {
+        callStructured: opts.callStructured,
+        judge: opts.judge,
+        graph: opts.graph,
+      })
+    }
+  }
+}
+
+/** All non-cheap arms, for iterating the full B/C/D × cheap-model grid. */
+export const ABLATION_ARMS: readonly ArmId[] = ['B', 'C', 'D']


### PR DESCRIPTION
Closes #27

## Summary

Scaffolding for the graph-scoped-vs-whole-doc cascade ablation (#19). Extends the scripted-model EditPropBench harness with three new arms, all runnable today with no live provider key:

- **Arm B — whole-doc plan-then-patch + self-verify.** Three real structured calls: PLAN (whole document, `plan_edit` tool, identifies affected blocks only) → PATCH (only the planned blocks, `propose_edit` tool, writes the actual replacement + evidence) → self-verify (the same LLM judge arm C's production pipeline uses).
- **Arm D — whole-doc free edits + deterministic verify/repair.** One free whole-doc generation pass, then a repair step: numeric/figure conflicts are already deterministic-verified by the shared severity-derivation logic (`must` stays `must`); `probably` proposals additionally get checked against `docGraph`'s own refs/terms/duplicate-sentence extractors — a citation the deterministic graph doesn't connect to the primary block loses confidence and caps to `optional`. No LLM judge call.
- **Arm E — cheap-model variants of B/C/D.** A `cheapModel` option flag swaps generation calls onto `pickUtilityModel`. (Arm A is intentionally not built — out of scope per the issue.)

Arm C (the existing graph-scoped `proposeCascadeEdits`) is unchanged and used as-is via a dispatcher.

## Design

`src/lib/ai/orchestrator.ts`'s `proposeCascadeEdits` was refactored (behavior-preserving) to expose `resolveProposedEdits` (tool-call parsing → blockId anchoring → evidence verification → severity derivation) and `applyRelevanceJudge` as reusable pieces. Every arm shares this exact substrate — arms differ only in what candidates they generate from (2-hop graph neighborhood for C; whole-doc plan-then-scoped-patch for B; whole-doc free edits for D) and what verify pass runs after. That isolates the variable the ablation is actually testing instead of also varying anchoring/evidence logic, which would confound the comparison.

New `src/lib/graphrag/ablationArms.ts` implements the arms; new `src/lib/graphrag/__tests__/ablationBench.test.ts` runs all 3 arms × cheap-model on/off × every existing `editPropBench.fixtures.ts` fixture (67 tests) with scripted calls, asserting the harness runs cleanly end-to-end and produces the metrics shape (recall vs gold, collateral-damage count, protected-span violations) — not a quality gate on B/D (their actual numbers are exactly what the live comparative run, still blocked on an operator-supplied key per #19, exists to measure).

An adversarial review flagged that the first version of arm B collapsed plan-then-patch into a single call (architecturally arm A + verify, not arm B) — fixed by making it a genuine two-stage pipeline as described above, since this scaffold is meant to be reused as-is once a live key lands, not rewritten at that point.

## Out of scope (per #27)

Running `npm run bench:live` against a real provider and drawing the arm comparison — that stays blocked on the operator-supplied key (#19). No live provider is faked anywhere in this change.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 816 passing + 10 skipped (was 749 + 10; +67 new ablation tests), including the unchanged `editPropBench.test.ts` regression gate for arm C
- [x] `npm run build` — clean
- [x] Adversarial (troublemaker) review completed; HIGH finding (arm B mislabeling) fixed before push; two lower-severity findings (arm E doc-comment accuracy, logging parity) also fixed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb7cPyK8PFgjce6asGNqDH)_