### PR TITLE
Document Invariant Ledger — Phase 2 (deterministic check runner)

### DIFF
--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -30,6 +30,7 @@ import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { createCommit } from '@/lib/history/commits'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
+import { runAndSurfaceInvariantChecks } from '@/lib/invariants/invariantCascade'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
@@ -155,6 +156,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             provenanceCommitHash: hash,
           })
         }
+        // Doc-CI (issue #32): this version just landed — re-check every
+        // previously declared fact against it. Fire-and-forget (the function
+        // never rejects — internal failures are caught and logged there).
+        void runAndSurfaceInvariantChecks(annotation.documentId, currentView.state)
       })
       .catch((err) => console.warn('[history] Failed to record version:', err))
   }

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useChangesStore } from '@/stores/changesStore'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useToastStore } from '@/stores/toastStore'
+import type { Invariant } from '../captureInvariant'
+import { runAndSurfaceInvariantChecks } from '../invariantCascade'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+const DECLARE_TEXT = 'Terminations are now 30 days per the updated policy.'
+const CONFLICT_TEXT = 'Under the new policy, terminations occur within 45 days of notice.'
+
+const DOC = schema.node('doc', null, [p('b-declare', DECLARE_TEXT), p('b-conflict', CONFLICT_TEXT)])
+
+function invariantRecord(overrides: Partial<Invariant> = {}): Invariant {
+  return {
+    id: 'inv-1',
+    documentId: 'doc-A',
+    statement: 'terminations are now 30 days',
+    blockIds: JSON.stringify(['b-declare']),
+    checkKind: 'deterministic',
+    status: 'active',
+    provenanceCommitHash: 'hash-1',
+    createdAt: '2026-08-18T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function stubListInvariants(invariants: Invariant[], onFetch?: () => void) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      onFetch?.()
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ invariants }),
+      } as Response
+    }),
+  )
+}
+
+beforeEach(() => {
+  useAnnotationStore.getState().clear()
+  useChangesStore.getState().clear()
+  useToastStore.setState({ toasts: [] })
+  useDocumentStore.setState({ activeDocumentId: 'doc-A' })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('runAndSurfaceInvariantChecks', () => {
+  it('surfaces a violation as a resolved flag annotation with a rejected no-op primary + no-op cascade', async () => {
+    stubListInvariants([invariantRecord()])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    const annotations = useAnnotationStore.getState().annotations
+    expect(annotations).toHaveLength(1)
+    const a = annotations[0]
+    expect(a.type).toBe('flag')
+    expect(a.status).toBe('resolved')
+    expect(a.documentId).toBe('doc-A')
+
+    const edits = a.resolution!.edits!
+    expect(edits).toHaveLength(2)
+    const [primary, cascade] = edits
+    expect(primary.relation).toBe('primary')
+    expect(primary.status).toBe('rejected')
+    expect(primary.newText).toBe(primary.targetText) // no-op
+    expect(primary.blockId).toBe('b-declare')
+
+    expect(cascade.relation).toBe('cascade')
+    expect(cascade.status).toBe('pending')
+    expect(cascade.newText).toBe(cascade.targetText) // no-op — a flag never auto-edits
+    expect(cascade.blockId).toBe('b-conflict')
+    // Statement text verifies verbatim against the declaring block, so this
+    // is a verified citation, not a fabricated one.
+    expect(cascade.evidence).toEqual({
+      sourceBlockId: 'b-declare',
+      quotedText: '30',
+      edgeType: 'contradicts',
+    })
+    expect(cascade.severity).toBe('must')
+
+    expect(useChangesStore.getState().getChangeSetByAnnotationId(a.id)).toBeTruthy()
+    expect(useToastStore.getState().toasts).toHaveLength(1)
+  })
+
+  it('does not re-surface the same (invariant, conflicting block) pair on a later apply', async () => {
+    stubListInvariants([invariantRecord()])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+    expect(useToastStore.getState().toasts).toHaveLength(1)
+  })
+
+  it('produces no flag and makes no network call when the active document already changed', async () => {
+    useDocumentStore.setState({ activeDocumentId: 'doc-B' })
+    const fetchSpy = vi.fn()
+    stubListInvariants([invariantRecord()], fetchSpy)
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+  })
+
+  it('aborts when the active document changes DURING the listInvariants round-trip', async () => {
+    stubListInvariants([invariantRecord()], () => {
+      useDocumentStore.setState({ activeDocumentId: 'doc-B' })
+    })
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+  })
+
+  it('produces nothing when no invariant is violated', async () => {
+    stubListInvariants([])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  it('degrades to unverified (probably, no evidence) when the declared figure is not a literal substring of the declaring block', async () => {
+    // The declaring block spells the figure as "30 dollars"; the captured
+    // statement uses "$30" — a different formatting of the same value, which
+    // the CHECK correctly treats as equal (normalized numeric comparison),
+    // but `blockTextRange`'s citation check is deliberately literal, so it
+    // must fail here rather than fabricate a verbatim quote that isn't one.
+    const declareText = 'The cancellation fee is now 30 dollars under the updated policy.'
+    const conflictText = 'Note: the cancellation fee is 50 dollars as of last quarter.'
+    const doc = schema.node('doc', null, [p('b-declare', declareText), p('b-conflict', conflictText)])
+    stubListInvariants([
+      invariantRecord({ statement: 'the cancellation fee is now $30', blockIds: JSON.stringify(['b-declare']) }),
+    ])
+    const state = EditorState.create({ schema, doc })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    const annotations = useAnnotationStore.getState().annotations
+    expect(annotations).toHaveLength(1)
+    const cascade = annotations[0].resolution!.edits![1]
+    expect(cascade.evidence).toBeNull()
+    expect(cascade.severity).toBe('probably')
+  })
+
+  it('never mutates the document even if the caller applies the cascade edit as-is (no-op by construction)', async () => {
+    stubListInvariants([invariantRecord()])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    const cascade = useAnnotationStore.getState().annotations[0].resolution!.edits![1]
+    const tr = state.tr.replaceWith(cascade.from, cascade.to, schema.text(cascade.newText))
+    const next = state.apply(tr)
+    expect(next.doc.textBetween(cascade.from, cascade.to)).toBe(cascade.targetText)
+  })
+})

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -6,6 +6,7 @@ import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
+import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import type { Invariant } from '../captureInvariant'
 import { runAndSurfaceInvariantChecks } from '../invariantCascade'
 
@@ -51,6 +52,7 @@ beforeEach(() => {
   useChangesStore.getState().clear()
   useToastStore.setState({ toasts: [] })
   useDocumentStore.setState({ activeDocumentId: 'doc-A' })
+  useInvariantFlagStore.getState().clear()
 })
 
 afterEach(() => {
@@ -140,7 +142,7 @@ describe('runAndSurfaceInvariantChecks', () => {
     expect(useToastStore.getState().toasts).toHaveLength(0)
   })
 
-  it('degrades to unverified (probably, no evidence) when the declared figure is not a literal substring of the declaring block', async () => {
+  it('degrades to unverified (optional, no evidence) when the declared figure is not a literal substring of the declaring block', async () => {
     // The declaring block spells the figure as "30 dollars"; the captured
     // statement uses "$30" — a different formatting of the same value, which
     // the CHECK correctly treats as equal (normalized numeric comparison),
@@ -160,7 +162,44 @@ describe('runAndSurfaceInvariantChecks', () => {
     expect(annotations).toHaveLength(1)
     const cascade = annotations[0].resolution!.edits![1]
     expect(cascade.evidence).toBeNull()
-    expect(cascade.severity).toBe('probably')
+    expect(cascade.severity).toBe('optional')
+  })
+
+  it('rejects a coincidental substring match ("30" inside "2030") as a verified citation', async () => {
+    const declareText = 'The renewal year is now set to 2030 under the updated policy.'
+    const conflictText = 'Under the new policy, terminations occur within 45 days of notice.'
+    const doc = schema.node('doc', null, [p('b-declare', declareText), p('b-conflict', conflictText)])
+    // "terminations ... 30 days" would word-boundary-verify against neither
+    // block's "2030" — this pins that a bare contiguity match is rejected.
+    stubListInvariants([invariantRecord({ statement: 'terminations are now 30 days' })])
+    const state = EditorState.create({ schema, doc })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    const annotations = useAnnotationStore.getState().annotations
+    expect(annotations).toHaveLength(1)
+    const cascade = annotations[0].resolution!.edits![1]
+    expect(cascade.evidence).toBeNull()
+    expect(cascade.severity).toBe('optional')
+  })
+
+  it('dedup survives an unrelated annotationStore.clear() (e.g. starting a new document elsewhere)', async () => {
+    stubListInvariants([invariantRecord()])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+
+    // Simulates DocInputModal.loadDoc()'s unscoped clear when the user
+    // starts an unrelated new document while doc-A stays open elsewhere.
+    useAnnotationStore.getState().clear()
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    // Dedup memory lives in invariantFlagStore, not annotationStore, so the
+    // still-unresolved conflict does NOT get re-injected as a duplicate.
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
   })
 
   it('never mutates the document even if the caller applies the cascade edit as-is (no-op by construction)', async () => {

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -133,6 +133,33 @@ describe('checkInvariants', () => {
     expect(violations).toEqual([])
   })
 
+  it('treats "$30" and "$30.00" as the same figure (decimal-format normalization)', () => {
+    const doc = docOf(
+      p('b-declare', 'The cancellation fee is now $30 per the updated policy.'),
+      p('b-other', 'As noted above, the cancellation fee is $30.00, unchanged.'),
+    )
+    const violations = checkInvariants(doc, [
+      invariant({ statement: 'the cancellation fee is now $30', blockIds: JSON.stringify(['b-declare']) }),
+    ])
+    expect(violations).toEqual([])
+  })
+
+  it('prefers the LAST numeric token as the declared figure for a "from X to Y" statement', () => {
+    const doc = docOf(
+      p('b-declare', 'The subscription fee increased from $20 to $30 per the updated policy.'),
+      p('b-conflict', 'Note: the subscription fee increased again to $50 last quarter.'),
+    )
+    const violations = checkInvariants(doc, [
+      invariant({
+        statement: 'the subscription fee increased from $20 to $30',
+        blockIds: JSON.stringify(['b-declare']),
+      }),
+    ])
+    expect(violations).toHaveLength(1)
+    // "$30" (the current value), not "$20" (the superseded value).
+    expect(violations[0].statementNumber).toBe('$30')
+  })
+
   it('flags a genuinely different figure even with currency-symbol formatting differences', () => {
     const doc = docOf(
       p('b-declare', 'The cancellation fee is now $30 per the updated policy.'),

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import { checkInvariants } from '../invariantCheckRunner'
+import type { Invariant } from '../captureInvariant'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, text ? [schema.text(text)] : [])
+}
+
+function docOf(...blocks: PMNode[]): PMNode {
+  return schema.node('doc', null, blocks)
+}
+
+function invariant(overrides: Partial<Invariant> = {}): Invariant {
+  return {
+    id: 'inv-1',
+    documentId: 'doc-1',
+    statement: 'terminations are now 30 days',
+    blockIds: JSON.stringify(['b-declare']),
+    checkKind: 'deterministic',
+    status: 'active',
+    provenanceCommitHash: 'hash-1',
+    createdAt: '2026-08-18T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('checkInvariants', () => {
+  it('produces no flag when nothing conflicts with the declared fact', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-other', 'Employees may appeal any decision within 10 business days.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toEqual([])
+  })
+
+  it('does not flag a block that merely corroborates the same figure', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-other', 'As noted above, terminations require 30 days notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toEqual([])
+  })
+
+  it('flags the founder fixture: a later conflicting figure for the same subject', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      invariantId: 'inv-1',
+      statement: 'terminations are now 30 days',
+      evidenceBlockIds: ['b-declare'],
+      conflictBlockId: 'b-conflict',
+    })
+    expect(violations[0].conflictText).toContain('45 days')
+  })
+
+  it('never flags the invariant\'s own evidence block', () => {
+    const doc = docOf(p('b-declare', 'Terminations are now 30 days, not 45 days, per legal review.'))
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toEqual([])
+  })
+
+  it('skips entailment-kind invariants without erroring', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant({ checkKind: 'entailment' })])
+    expect(violations).toEqual([])
+  })
+
+  it('skips inactive (already-resolved) invariants', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant({ status: 'superseded' })])
+    expect(violations).toEqual([])
+  })
+
+  it('does not flag an unrelated block that merely shares a number', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-other', 'The office holds 45 chairs in the main conference room.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toEqual([])
+  })
+
+  it('checks multiple invariants independently, one flag per violated invariant', () => {
+    const doc = docOf(
+      p('b-declare-1', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict-1', 'Under the new policy, terminations occur within 45 days of notice.'),
+      p('b-declare-2', 'Refunds are processed within 14 business days.'),
+      p('b-other-2', 'Support tickets are answered within 14 business days.'),
+    )
+    const violations = checkInvariants(doc, [
+      invariant({ id: 'inv-1', statement: 'terminations are now 30 days', blockIds: JSON.stringify(['b-declare-1']) }),
+      invariant({ id: 'inv-2', statement: 'refunds are processed within 14 business days', blockIds: JSON.stringify(['b-declare-2']) }),
+    ])
+    expect(violations).toHaveLength(1)
+    expect(violations[0].invariantId).toBe('inv-1')
+  })
+})

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -57,11 +57,13 @@ describe('checkInvariants', () => {
       statement: 'terminations are now 30 days',
       evidenceBlockIds: ['b-declare'],
       conflictBlockId: 'b-conflict',
+      statementNumber: '30',
+      conflictNumber: '45',
     })
     expect(violations[0].conflictText).toContain('45 days')
   })
 
-  it('never flags the invariant\'s own evidence block', () => {
+  it("never flags the invariant's own evidence block", () => {
     const doc = docOf(p('b-declare', 'Terminations are now 30 days, not 45 days, per legal review.'))
     const violations = checkInvariants(doc, [invariant()])
     expect(violations).toEqual([])
@@ -107,5 +109,39 @@ describe('checkInvariants', () => {
     ])
     expect(violations).toHaveLength(1)
     expect(violations[0].invariantId).toBe('inv-1')
+  })
+
+  it('does not false-positive on a two-term statement matching only its shorter, generic term', () => {
+    // "days" alone is not enough evidence of relatedness — requires BOTH
+    // "terminations" and "days" (all terms, since the statement has only 2).
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-unrelated', 'For terminations effective under state law, see form 12 for filing requirements.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations).toEqual([])
+  })
+
+  it('treats "$30" and "30" as the same figure (currency-symbol normalization)', () => {
+    const doc = docOf(
+      p('b-declare', 'The cancellation fee is now $30 per the updated policy.'),
+      p('b-other', 'As noted above, the cancellation fee is 30 dollars, unchanged.'),
+    )
+    const violations = checkInvariants(doc, [
+      invariant({ statement: 'the cancellation fee is now $30', blockIds: JSON.stringify(['b-declare']) }),
+    ])
+    expect(violations).toEqual([])
+  })
+
+  it('flags a genuinely different figure even with currency-symbol formatting differences', () => {
+    const doc = docOf(
+      p('b-declare', 'The cancellation fee is now $30 per the updated policy.'),
+      p('b-conflict', 'Note: the cancellation fee is $50 as of last quarter.'),
+    )
+    const violations = checkInvariants(doc, [
+      invariant({ statement: 'the cancellation fee is now $30', blockIds: JSON.stringify(['b-declare']) }),
+    ])
+    expect(violations).toHaveLength(1)
+    expect(violations[0].conflictBlockId).toBe('b-conflict')
   })
 })

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -1,12 +1,14 @@
 import type { EditorState } from 'prosemirror-state'
-import { findBlockById } from '@/lib/prosemirror/blockIds'
+import { findBlockById, blockTextRange } from '@/lib/prosemirror/blockIds'
 import { primaryProposedEdit } from '@/lib/ai/orchestrator'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useToastStore } from '@/stores/toastStore'
 import { generateId } from '@/lib/utils/id'
 import { listInvariants } from './captureInvariant'
 import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
-import type { Annotation, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
+import type { Annotation, CascadeSeverity, CascadeEvidence, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
 
 /**
  * Document Invariant Ledger — Phase 2 (issue #32): surfaces a failing
@@ -26,28 +28,53 @@ const FLAG_ACTIONS: ResolutionAction[] = [
   { label: 'Nevermind', kind: 'dismiss', handler: 'dismiss' },
 ]
 
+/** Deterministic key for one (invariant, conflicting block) pair — the dedup unit. */
+function violationKey(documentId: string, violation: InvariantViolation): string {
+  return `${documentId}:invariant:${violation.invariantId}:${violation.conflictBlockId}`
+}
+
+/**
+ * Evidence is only ever set when the declared figure literally verifies
+ * against the block that declared it — an unverifiable quote must not claim
+ * citation integrity (the same rule `orchestrator.ts`'s `buildEvidence`
+ * enforces for every other cascade path: "an uncited proposal can never be
+ * `must`"). When the exact statement text drifted from the source block
+ * since capture (the modal lets a user edit the captured wording), this
+ * degrades to `probably` with no evidence rather than fabricating a citation.
+ */
+function verifiedEvidence(
+  doc: EditorState['doc'],
+  sourceBlockId: string | undefined,
+  statementNumber: string,
+): { evidence: CascadeEvidence | null; severity: CascadeSeverity } {
+  if (sourceBlockId && blockTextRange(doc, sourceBlockId, statementNumber)) {
+    return {
+      evidence: { sourceBlockId, quotedText: statementNumber, edgeType: 'contradicts' },
+      severity: 'must',
+    }
+  }
+  return { evidence: null, severity: 'probably' }
+}
+
 function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
   const block = findBlockById(doc, violation.conflictBlockId)
   if (!block) return null
   const from = block.pos + 1
   const to = block.pos + block.node.nodeSize - 1
   const text = block.node.textContent
+  const { evidence, severity } = verifiedEvidence(doc, violation.evidenceBlockIds[0], violation.statementNumber)
   return {
     id: generateId(),
     from,
     to,
     newText: text,
-    reason: `Conflicts with a declared fact: "${violation.statement}"`,
+    reason: `Declared "${violation.statementNumber}", but this section says "${violation.conflictNumber}": "${violation.statement}"`,
     relation: 'cascade',
     status: 'pending',
     targetText: text,
     blockId: violation.conflictBlockId,
-    severity: 'must',
-    evidence: {
-      sourceBlockId: violation.evidenceBlockIds[0] ?? violation.conflictBlockId,
-      quotedText: violation.statement,
-      edgeType: 'contradicts',
-    },
+    severity,
+    evidence,
   }
 }
 
@@ -74,16 +101,40 @@ function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): 
  * editor state and appends one resolved 'flag' annotation per violated
  * invariant. Fire-and-forget: never throws into the caller (a DocCommit
  * write must never be blocked by a check-lane failure).
+ *
+ * Two guards keep this from becoming an unbounded nuisance:
+ * - Doc-switch race: `state` is read from a caller-captured EditorView after
+ *   an async round-trip (`listInvariants`); if the active document changed
+ *   in the meantime, `state` and `documentId` would disagree — abort rather
+ *   than tag a flag with the wrong document's id (same guard as the sibling
+ *   `directEditCascade.ts`).
+ * - Re-flag dedup: the check re-runs on every apply, so without a dedup an
+ *   unresolved conflict would re-surface as a brand-new annotation on every
+ *   future apply anywhere in the document, forever. One (invariant,
+ *   conflicting-block) pair surfaces at most once per document session;
+ *   `checkInvariants` naturally stops returning a violation once the
+ *   conflict is actually fixed, so a real fix still clears the flag's cause
+ *   even though the flag record itself isn't retracted.
  */
 export async function runAndSurfaceInvariantChecks(
   documentId: string,
   state: EditorState,
 ): Promise<void> {
   try {
+    if (useDocumentStore.getState().activeDocumentId !== documentId) return
+
     const invariants = await listInvariants(documentId)
+    if (useDocumentStore.getState().activeDocumentId !== documentId) return
+
     const violations = checkInvariants(state.doc, invariants)
+    if (violations.length === 0) return
+
+    const seen = new Set(useAnnotationStore.getState().annotations.map((a) => a.locationGroupKey))
 
     for (const violation of violations) {
+      const key = violationKey(documentId, violation)
+      if (seen.has(key)) continue
+
       const primary = primaryAnchor(state.doc, violation)
       const cascade = conflictEdit(state.doc, violation)
       // Both anchors must resolve against the live doc, or there is nothing
@@ -95,7 +146,7 @@ export async function runAndSurfaceInvariantChecks(
       const annotation: Annotation = {
         id: generateId(),
         documentId,
-        locationGroupKey: `${documentId}:invariant:${violation.invariantId}:${now}`,
+        locationGroupKey: key,
         type: 'flag',
         status: 'resolved',
         transcript: `Declared fact may no longer hold: "${violation.statement}"`,
@@ -117,6 +168,7 @@ export async function runAndSurfaceInvariantChecks(
 
       useAnnotationStore.getState().add(annotation)
       useChangesStore.getState().ensureChangeSetForAnnotation(annotation)
+      useToastStore.getState().addToast('A declared fact may no longer hold — see Annotations', 'info')
     }
   } catch (err) {
     console.warn('[invariants] Check runner failed:', err)

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -1,0 +1,124 @@
+import type { EditorState } from 'prosemirror-state'
+import { findBlockById } from '@/lib/prosemirror/blockIds'
+import { primaryProposedEdit } from '@/lib/ai/orchestrator'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useChangesStore } from '@/stores/changesStore'
+import { generateId } from '@/lib/utils/id'
+import { listInvariants } from './captureInvariant'
+import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
+import type { Annotation, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
+
+/**
+ * Document Invariant Ledger — Phase 2 (issue #32): surfaces a failing
+ * deterministic check through the existing single CascadeList surface,
+ * exactly as the Flow v1 direct-edit trigger (`directEditCascade.ts`) does.
+ * No new UI path — the "one cascade surface" rule (Wave D2) holds.
+ *
+ * HITL: doc-CI flags, it never edits. The primary anchor is pre-marked
+ * 'rejected' (nothing to apply — it just anchors "why this proposal?" at the
+ * block that declared the fact) and the cascade edit is a no-op
+ * (targetText === newText), so accepting the flag can never mutate the
+ * document; it only marks the flag reviewed.
+ */
+
+const FLAG_ACTIONS: ResolutionAction[] = [
+  { label: 'Show affected', kind: 'deepen', handler: 'show-cascade' },
+  { label: 'Nevermind', kind: 'dismiss', handler: 'dismiss' },
+]
+
+function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
+  const block = findBlockById(doc, violation.conflictBlockId)
+  if (!block) return null
+  const from = block.pos + 1
+  const to = block.pos + block.node.nodeSize - 1
+  const text = block.node.textContent
+  return {
+    id: generateId(),
+    from,
+    to,
+    newText: text,
+    reason: `Conflicts with a declared fact: "${violation.statement}"`,
+    relation: 'cascade',
+    status: 'pending',
+    targetText: text,
+    blockId: violation.conflictBlockId,
+    severity: 'must',
+    evidence: {
+      sourceBlockId: violation.evidenceBlockIds[0] ?? violation.conflictBlockId,
+      quotedText: violation.statement,
+      edgeType: 'contradicts',
+    },
+  }
+}
+
+function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
+  const blockId = violation.evidenceBlockIds[0]
+  if (!blockId) return null
+  const block = findBlockById(doc, blockId)
+  if (!block) return null
+  const from = block.pos + 1
+  const to = block.pos + block.node.nodeSize - 1
+  const text = block.node.textContent
+  return {
+    ...primaryProposedEdit(
+      { from, to, newText: text, reason: `Declared: "${violation.statement}"` },
+      text,
+      blockId,
+    ),
+    status: 'rejected',
+  }
+}
+
+/**
+ * Runs the deterministic doc-CI lane for a document against its current
+ * editor state and appends one resolved 'flag' annotation per violated
+ * invariant. Fire-and-forget: never throws into the caller (a DocCommit
+ * write must never be blocked by a check-lane failure).
+ */
+export async function runAndSurfaceInvariantChecks(
+  documentId: string,
+  state: EditorState,
+): Promise<void> {
+  try {
+    const invariants = await listInvariants(documentId)
+    const violations = checkInvariants(state.doc, invariants)
+
+    for (const violation of violations) {
+      const primary = primaryAnchor(state.doc, violation)
+      const cascade = conflictEdit(state.doc, violation)
+      // Both anchors must resolve against the live doc, or there is nothing
+      // stable to point the flag at (e.g. the declaring block was since
+      // deleted) — skip rather than surface a flag anchored to nothing.
+      if (!primary || !cascade) continue
+
+      const now = Date.now()
+      const annotation: Annotation = {
+        id: generateId(),
+        documentId,
+        locationGroupKey: `${documentId}:invariant:${violation.invariantId}:${now}`,
+        type: 'flag',
+        status: 'resolved',
+        transcript: `Declared fact may no longer hold: "${violation.statement}"`,
+        anchor: { from: cascade.from, to: cascade.to, scope: 'paragraph', text: cascade.targetText },
+        resolution: {
+          type: 'flag',
+          content: `A section conflicts with a fact you declared earlier: "${violation.statement}". Review below.`,
+          suggestedEdit: null,
+          edits: [primary, cascade],
+          actions: FLAG_ACTIONS,
+        },
+        conversation: [],
+        parentId: null,
+        childIds: [],
+        createdAt: now,
+        resolvedAt: now,
+        verbosity: 'normal',
+      }
+
+      useAnnotationStore.getState().add(annotation)
+      useChangesStore.getState().ensureChangeSetForAnnotation(annotation)
+    }
+  } catch (err) {
+    console.warn('[invariants] Check runner failed:', err)
+  }
+}

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -1,14 +1,15 @@
 import type { EditorState } from 'prosemirror-state'
-import { findBlockById, blockTextRange } from '@/lib/prosemirror/blockIds'
+import { findBlockById } from '@/lib/prosemirror/blockIds'
 import { primaryProposedEdit } from '@/lib/ai/orchestrator'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
+import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import { generateId } from '@/lib/utils/id'
 import { listInvariants } from './captureInvariant'
 import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
-import type { Annotation, CascadeSeverity, CascadeEvidence, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
+import type { Annotation, CascadeEvidence, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
 
 /**
  * Document Invariant Ledger — Phase 2 (issue #32): surfaces a failing
@@ -34,26 +35,49 @@ function violationKey(documentId: string, violation: InvariantViolation): string
 }
 
 /**
- * Evidence is only ever set when the declared figure literally verifies
- * against the block that declared it — an unverifiable quote must not claim
- * citation integrity (the same rule `orchestrator.ts`'s `buildEvidence`
- * enforces for every other cascade path: "an uncited proposal can never be
- * `must`"). When the exact statement text drifted from the source block
- * since capture (the modal lets a user edit the captured wording), this
- * degrades to `probably` with no evidence rather than fabricating a citation.
+ * Whole-word verification that `numberToken` literally appears in the given
+ * block's text — the same word-boundary discipline `containsTerm` applies to
+ * subject terms, applied here to the citation itself. A bare contiguity
+ * check (as `blockTextRange` does, by design, for arbitrary quoted phrases)
+ * would let a short token like "30" spuriously "verify" against "2030" or
+ * "$3,000" — a coincidental substring, not a real citation.
+ */
+function verifiesInBlock(blockText: string, numberToken: string): boolean {
+  const idx = blockText.indexOf(numberToken)
+  if (idx === -1) return false
+  const before = idx > 0 ? blockText[idx - 1] : ' '
+  const after = idx + numberToken.length < blockText.length ? blockText[idx + numberToken.length] : ' '
+  return /\W/.test(before) && /\W/.test(after)
+}
+
+/**
+ * Evidence is only ever set when the declared figure literally, word-
+ * boundary-verifies against one of the blocks that declared it — an
+ * unverifiable quote must not claim citation integrity (the same rule
+ * `orchestrator.ts`'s `buildEvidence` enforces for every other cascade path:
+ * "an uncited proposal can never be `must`"). Tries every evidence block, not
+ * just the first, so losing one declaring block doesn't sink an otherwise-
+ * verifiable citation. When nothing verifies (the exact wording drifted from
+ * the source block since capture — the modal lets a user edit the captured
+ * text — or the figure was reformatted), this degrades to NO evidence and
+ * `'optional'` severity, matching `deriveSeverity`'s own convention
+ * elsewhere in the codebase: no locatable citation is a lead, never a must.
  */
 function verifiedEvidence(
   doc: EditorState['doc'],
-  sourceBlockId: string | undefined,
+  evidenceBlockIds: string[],
   statementNumber: string,
-): { evidence: CascadeEvidence | null; severity: CascadeSeverity } {
-  if (sourceBlockId && blockTextRange(doc, sourceBlockId, statementNumber)) {
-    return {
-      evidence: { sourceBlockId, quotedText: statementNumber, edgeType: 'contradicts' },
-      severity: 'must',
+): { evidence: CascadeEvidence | null; severity: 'must' | 'optional' } {
+  for (const sourceBlockId of evidenceBlockIds) {
+    const block = findBlockById(doc, sourceBlockId)
+    if (block && verifiesInBlock(block.node.textContent, statementNumber)) {
+      return {
+        evidence: { sourceBlockId, quotedText: statementNumber, edgeType: 'contradicts' },
+        severity: 'must',
+      }
     }
   }
-  return { evidence: null, severity: 'probably' }
+  return { evidence: null, severity: 'optional' }
 }
 
 function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
@@ -62,7 +86,7 @@ function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): P
   const from = block.pos + 1
   const to = block.pos + block.node.nodeSize - 1
   const text = block.node.textContent
-  const { evidence, severity } = verifiedEvidence(doc, violation.evidenceBlockIds[0], violation.statementNumber)
+  const { evidence, severity } = verifiedEvidence(doc, violation.evidenceBlockIds, violation.statementNumber)
   return {
     id: generateId(),
     from,
@@ -78,22 +102,24 @@ function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): P
   }
 }
 
+/** Anchors "why this proposal?" at whichever evidence block still resolves. */
 function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
-  const blockId = violation.evidenceBlockIds[0]
-  if (!blockId) return null
-  const block = findBlockById(doc, blockId)
-  if (!block) return null
-  const from = block.pos + 1
-  const to = block.pos + block.node.nodeSize - 1
-  const text = block.node.textContent
-  return {
-    ...primaryProposedEdit(
-      { from, to, newText: text, reason: `Declared: "${violation.statement}"` },
-      text,
-      blockId,
-    ),
-    status: 'rejected',
+  for (const blockId of violation.evidenceBlockIds) {
+    const block = findBlockById(doc, blockId)
+    if (!block) continue
+    const from = block.pos + 1
+    const to = block.pos + block.node.nodeSize - 1
+    const text = block.node.textContent
+    return {
+      ...primaryProposedEdit(
+        { from, to, newText: text, reason: `Declared: "${violation.statement}"` },
+        text,
+        blockId,
+      ),
+      status: 'rejected',
+    }
   }
+  return null
 }
 
 /**
@@ -110,11 +136,16 @@ function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): 
  *   `directEditCascade.ts`).
  * - Re-flag dedup: the check re-runs on every apply, so without a dedup an
  *   unresolved conflict would re-surface as a brand-new annotation on every
- *   future apply anywhere in the document, forever. One (invariant,
- *   conflicting-block) pair surfaces at most once per document session;
- *   `checkInvariants` naturally stops returning a violation once the
- *   conflict is actually fixed, so a real fix still clears the flag's cause
- *   even though the flag record itself isn't retracted.
+ *   future apply anywhere in the document, forever. Dedup state lives in its
+ *   OWN store (`invariantFlagStore`), not derived from `annotationStore` —
+ *   `DocInputModal.loadDoc()` unconditionally clears `annotationStore` on
+ *   every new-document creation (a pre-existing, out-of-scope behavior), and
+ *   deriving dedup from it would let starting an unrelated document revive
+ *   every other document's already-seen flags. `checkInvariants` naturally
+ *   stops returning a violation once the conflict is actually fixed, so a
+ *   real fix still clears the underlying cause even though the flag record
+ *   itself isn't retracted (Phase 1's ledger has no dismiss/resolve route —
+ *   a named, disclosed follow-up, not silently assumed away).
  */
 export async function runAndSurfaceInvariantChecks(
   documentId: string,
@@ -129,16 +160,16 @@ export async function runAndSurfaceInvariantChecks(
     const violations = checkInvariants(state.doc, invariants)
     if (violations.length === 0) return
 
-    const seen = new Set(useAnnotationStore.getState().annotations.map((a) => a.locationGroupKey))
+    const flagStore = useInvariantFlagStore.getState()
 
     for (const violation of violations) {
       const key = violationKey(documentId, violation)
-      if (seen.has(key)) continue
+      if (flagStore.hasSurfaced(key)) continue
 
       const primary = primaryAnchor(state.doc, violation)
       const cascade = conflictEdit(state.doc, violation)
       // Both anchors must resolve against the live doc, or there is nothing
-      // stable to point the flag at (e.g. the declaring block was since
+      // stable to point the flag at (e.g. every declaring block was since
       // deleted) — skip rather than surface a flag anchored to nothing.
       if (!primary || !cascade) continue
 
@@ -168,6 +199,7 @@ export async function runAndSurfaceInvariantChecks(
 
       useAnnotationStore.getState().add(annotation)
       useChangesStore.getState().ensureChangeSetForAnnotation(annotation)
+      flagStore.markSurfaced(key)
       useToastStore.getState().addToast('A declared fact may no longer hold — see Annotations', 'info')
     }
   } catch (err) {

--- a/src/lib/invariants/invariantCheckRunner.ts
+++ b/src/lib/invariants/invariantCheckRunner.ts
@@ -1,0 +1,108 @@
+import type { Node as PMNode } from 'prosemirror-model'
+import { collectTextblocks } from '@/lib/prosemirror/blockIds'
+import { containsTerm } from '@/lib/graphrag/docGraph'
+import { extractChangedTokens } from '@/lib/ai/orchestrator'
+import type { Invariant } from './captureInvariant'
+
+/**
+ * Document Invariant Ledger — Phase 2 (issue #32): the deterministic check
+ * lane only. Given a document snapshot and its declared invariants, finds
+ * blocks that conflict with a previously declared fact — the founder's
+ * fixture from #20: declare "terminations are now 30 days", later a "45
+ * days" appears elsewhere without ever restating 30.
+ *
+ * Deliberately reuses the SAME deterministic relation types the cascade's
+ * severity-derivation pipeline already uses, rather than adding new
+ * extraction logic: `extractChangedTokens` (numeric/figure + substantive-term
+ * tokenizing, `orchestrator.ts`) and `containsTerm` (word-boundary matching,
+ * `docGraph.ts`). Calling `extractChangedTokens(text, '')` repurposes the
+ * before/after diff extractor as a plain tokenizer — nothing in an empty
+ * `after` can match, so every token in `text` comes back.
+ *
+ * The LLM/NLI entailment lane for semantic (non-deterministic) facts is out
+ * of scope for this slice (#20's own phasing) — entailment-kind and
+ * inactive rows are silently skipped here, never errored.
+ */
+
+export interface InvariantViolation {
+  invariantId: string
+  statement: string
+  /** The invariant's own evidence blocks — never treated as a conflict target. */
+  evidenceBlockIds: string[]
+  /** The block whose content no longer agrees with the declared statement. */
+  conflictBlockId: string
+  conflictText: string
+}
+
+const NUMERIC_TOKEN_RE = /^[$€£]?\d/
+
+function parseBlockIds(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Re-evaluate every deterministic, active invariant against the live
+ * document. Returns at most one violation per invariant (the first
+ * conflicting block found) — enough signal to flag; the cascade review flow
+ * is where the user inspects the rest of the document.
+ */
+export function checkInvariants(doc: PMNode, invariants: Invariant[]): InvariantViolation[] {
+  const blocks = collectTextblocks(doc).filter(
+    (b): b is { blockId: string; pos: number; node: (typeof b)['node'] } => Boolean(b.blockId),
+  )
+  const violations: InvariantViolation[] = []
+
+  for (const invariant of invariants) {
+    if (invariant.checkKind !== 'deterministic' || invariant.status !== 'active') continue
+
+    const statementTokens = extractChangedTokens(invariant.statement, '')
+    const statementNumbers = statementTokens.filter((t) => NUMERIC_TOKEN_RE.test(t))
+    const statementTerms = statementTokens.filter((t) => !NUMERIC_TOKEN_RE.test(t))
+    // Nothing deterministic to check: no figure means no drift to detect, and
+    // no subject term means we can't tell WHICH block is even about this fact.
+    if (statementNumbers.length === 0 || statementTerms.length === 0) continue
+
+    const evidenceBlockIds = parseBlockIds(invariant.blockIds)
+
+    // Subject match requires the LONGEST (most distinctive) half of the
+    // statement's terms, not just any one — a lone match on a short generic
+    // word like "days" would false-positive against any unrelated block that
+    // happens to mention a different count of the same unit.
+    const bySpecificity = [...statementTerms].sort((a, b) => b.length - a.length)
+    const requiredTerms = bySpecificity.slice(0, Math.max(1, Math.ceil(bySpecificity.length / 2)))
+
+    for (const block of blocks) {
+      if (evidenceBlockIds.includes(block.blockId)) continue
+      const blockText = block.node.textContent
+
+      const sharesSubject = requiredTerms.every((term) => containsTerm(blockText, term))
+      if (!sharesSubject) continue
+
+      const blockNumbers = extractChangedTokens(blockText, '').filter((t) => NUMERIC_TOKEN_RE.test(t))
+      if (blockNumbers.length === 0) continue
+
+      // A block that also cites the declared figure is corroborating, not
+      // conflicting (e.g. quoting the same "30 days" for context) — only a
+      // DIFFERENT figure with the original nowhere in sight counts as drift.
+      const hasStatementNumber = statementNumbers.some((n) => blockNumbers.includes(n))
+      const hasDifferentNumber = blockNumbers.some((n) => !statementNumbers.includes(n))
+      if (hasDifferentNumber && !hasStatementNumber) {
+        violations.push({
+          invariantId: invariant.id,
+          statement: invariant.statement,
+          evidenceBlockIds,
+          conflictBlockId: block.blockId,
+          conflictText: blockText,
+        })
+        break
+      }
+    }
+  }
+
+  return violations
+}

--- a/src/lib/invariants/invariantCheckRunner.ts
+++ b/src/lib/invariants/invariantCheckRunner.ts
@@ -28,6 +28,13 @@ import type { Invariant } from './captureInvariant'
  * numbers ("thirty days"), calendar-date fragments, and singular/plural term
  * variants (`containsTerm` is exact-word, not stemmed) are not matched. These
  * make the lane conservative — it can miss a real drift — never the reverse.
+ *
+ * Known remaining false-positive limitation: a statement whose ONLY
+ * substantive term is a single generic word ("the deadline is $500") cannot
+ * be made more specific without new NLP — there is nothing left to require
+ * "all of" once there is only one term. Two-or-more-term statements (the
+ * common case for a real declared fact) are protected; single-term ones are
+ * not, and this is a deliberate reuse-only tradeoff, not an oversight.
  */
 
 export interface InvariantViolation {
@@ -56,13 +63,20 @@ function parseBlockIds(raw: string): string[] {
 }
 
 /**
- * Value-equality for numeric tokens, not string-equality: "$30" and "30" (or
- * "1,200" and "1200") are the same figure once currency symbols and
- * thousands separators are stripped. Comparing raw regex output as strings
- * would false-positive on formatting differences alone.
+ * Value-equality for numeric tokens, not string-equality: "$30", "30", and
+ * "30.00" are the same figure once currency symbols, thousands separators,
+ * and decimal-formatting differences are normalized away via a real numeric
+ * parse. Comparing raw regex output as strings would false-positive on
+ * formatting differences alone (a non-numeric parse — shouldn't happen given
+ * the token came from a digit-anchored regex — falls back to the stripped
+ * string rather than throwing).
  */
 function normalizeNumeric(token: string): string {
-  return token.replace(/[$€£,]/g, '')
+  const isPercent = token.endsWith('%')
+  const stripped = token.replace(/[$€£,%]/g, '')
+  const value = Number(stripped)
+  if (!Number.isFinite(value)) return stripped
+  return isPercent ? `${value}%` : `${value}`
 }
 
 /**
@@ -125,7 +139,11 @@ export function checkInvariants(doc: PMNode, invariants: Invariant[]): Invariant
         evidenceBlockIds,
         conflictBlockId: block.blockId,
         conflictText: blockText,
-        statementNumber: statementNumbers[0],
+        // The LAST numeric token, not the first: a statement phrased as "the
+        // fee increased from $20 to $30" declares $30 as the current value,
+        // and English "from X to Y" / "was X, now Y" phrasing consistently
+        // puts the current figure last.
+        statementNumber: statementNumbers[statementNumbers.length - 1],
         conflictNumber: blockNumbers[differentIdx],
       })
       break

--- a/src/lib/invariants/invariantCheckRunner.ts
+++ b/src/lib/invariants/invariantCheckRunner.ts
@@ -22,6 +22,12 @@ import type { Invariant } from './captureInvariant'
  * The LLM/NLI entailment lane for semantic (non-deterministic) facts is out
  * of scope for this slice (#20's own phasing) — entailment-kind and
  * inactive rows are silently skipped here, never errored.
+ *
+ * Known false-negative limitations, disclosed rather than silently assumed
+ * away (same discipline as `hasVerbatimConflict`'s own docstring): word-form
+ * numbers ("thirty days"), calendar-date fragments, and singular/plural term
+ * variants (`containsTerm` is exact-word, not stemmed) are not matched. These
+ * make the lane conservative — it can miss a real drift — never the reverse.
  */
 
 export interface InvariantViolation {
@@ -32,6 +38,10 @@ export interface InvariantViolation {
   /** The block whose content no longer agrees with the declared statement. */
   conflictBlockId: string
   conflictText: string
+  /** The specific figure the statement declared (verbatim substring of it). */
+  statementNumber: string
+  /** The specific figure found in the conflicting block (verbatim substring of it). */
+  conflictNumber: string
 }
 
 const NUMERIC_TOKEN_RE = /^[$€£]?\d/
@@ -43,6 +53,16 @@ function parseBlockIds(raw: string): string[] {
   } catch {
     return []
   }
+}
+
+/**
+ * Value-equality for numeric tokens, not string-equality: "$30" and "30" (or
+ * "1,200" and "1200") are the same figure once currency symbols and
+ * thousands separators are stripped. Comparing raw regex output as strings
+ * would false-positive on formatting differences alone.
+ */
+function normalizeNumeric(token: string): string {
+  return token.replace(/[$€£,]/g, '')
 }
 
 /**
@@ -66,15 +86,19 @@ export function checkInvariants(doc: PMNode, invariants: Invariant[]): Invariant
     // Nothing deterministic to check: no figure means no drift to detect, and
     // no subject term means we can't tell WHICH block is even about this fact.
     if (statementNumbers.length === 0 || statementTerms.length === 0) continue
+    const normalizedStatementNumbers = statementNumbers.map(normalizeNumeric)
+
+    // Subject match: for a short (1-2 term) statement — the common case for a
+    // declarative fact like "rent is $2,000/month" — a match on a SINGLE
+    // generic term degenerates the whole check into "any block mentioning
+    // rent with any other number", so require ALL terms. Only once there are
+    // enough terms to make "all" fragile does the check relax to the
+    // longest (most distinctive) half.
+    const bySpecificity = [...statementTerms].sort((a, b) => b.length - a.length)
+    const requiredTerms =
+      bySpecificity.length <= 2 ? bySpecificity : bySpecificity.slice(0, Math.ceil(bySpecificity.length / 2))
 
     const evidenceBlockIds = parseBlockIds(invariant.blockIds)
-
-    // Subject match requires the LONGEST (most distinctive) half of the
-    // statement's terms, not just any one — a lone match on a short generic
-    // word like "days" would false-positive against any unrelated block that
-    // happens to mention a different count of the same unit.
-    const bySpecificity = [...statementTerms].sort((a, b) => b.length - a.length)
-    const requiredTerms = bySpecificity.slice(0, Math.max(1, Math.ceil(bySpecificity.length / 2)))
 
     for (const block of blocks) {
       if (evidenceBlockIds.includes(block.blockId)) continue
@@ -85,22 +109,26 @@ export function checkInvariants(doc: PMNode, invariants: Invariant[]): Invariant
 
       const blockNumbers = extractChangedTokens(blockText, '').filter((t) => NUMERIC_TOKEN_RE.test(t))
       if (blockNumbers.length === 0) continue
+      const normalizedBlockNumbers = blockNumbers.map(normalizeNumeric)
 
       // A block that also cites the declared figure is corroborating, not
       // conflicting (e.g. quoting the same "30 days" for context) — only a
       // DIFFERENT figure with the original nowhere in sight counts as drift.
-      const hasStatementNumber = statementNumbers.some((n) => blockNumbers.includes(n))
-      const hasDifferentNumber = blockNumbers.some((n) => !statementNumbers.includes(n))
-      if (hasDifferentNumber && !hasStatementNumber) {
-        violations.push({
-          invariantId: invariant.id,
-          statement: invariant.statement,
-          evidenceBlockIds,
-          conflictBlockId: block.blockId,
-          conflictText: blockText,
-        })
-        break
-      }
+      const hasStatementNumber = normalizedStatementNumbers.some((n) => normalizedBlockNumbers.includes(n))
+      if (hasStatementNumber) continue
+      const differentIdx = normalizedBlockNumbers.findIndex((n) => !normalizedStatementNumbers.includes(n))
+      if (differentIdx === -1) continue
+
+      violations.push({
+        invariantId: invariant.id,
+        statement: invariant.statement,
+        evidenceBlockIds,
+        conflictBlockId: block.blockId,
+        conflictText: blockText,
+        statementNumber: statementNumbers[0],
+        conflictNumber: blockNumbers[differentIdx],
+      })
+      break
     }
   }
 

--- a/src/stores/invariantFlagStore.ts
+++ b/src/stores/invariantFlagStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/**
+ * Dedup ledger for the Document Invariant Ledger's doc-CI lane (issue #32):
+ * tracks which (document, invariant, conflicting-block) pairs have already
+ * been surfaced as a flag, so an unresolved conflict doesn't re-inject a
+ * duplicate annotation on every future apply.
+ *
+ * Deliberately its OWN store, not a derived read of `annotationStore` — the
+ * annotation store is unscoped-cleared by `DocInputModal.loadDoc()` on every
+ * new-document creation (a pre-existing behavior, out of scope to change
+ * here), which would otherwise wipe this dedup memory for every OTHER open
+ * document too, reviving stale flags. This store is untouched by that path.
+ */
+
+const MAX_SURFACED = 1000
+
+interface InvariantFlagState {
+  surfaced: string[]
+  hasSurfaced: (key: string) => boolean
+  markSurfaced: (key: string) => void
+  clear: () => void
+}
+
+export const useInvariantFlagStore = create<InvariantFlagState>()(
+  persist(
+    (set, get) => ({
+      surfaced: [],
+      hasSurfaced: (key) => get().surfaced.includes(key),
+      markSurfaced: (key) =>
+        set((s) =>
+          s.surfaced.includes(key)
+            ? s
+            : { surfaced: [...s.surfaced, key].slice(-MAX_SURFACED) },
+        ),
+      clear: () => set({ surfaced: [] }),
+    }),
+    { name: 'intent-ide-invariant-flags' },
+  ),
+)


### PR DESCRIPTION
## Summary

Builds on the merged `DocInvariant` data model + capture path (#26, PR #29). Adds the **deterministic check lane only** — the entailment/NLI lane from #20 stays out of scope, per #20's own phasing.

- `checkInvariants()` (`src/lib/invariants/invariantCheckRunner.ts`) re-evaluates every active, `checkKind: 'deterministic'` invariant against the live document, reusing the same relation types the cascade's severity-derivation pipeline already uses — `extractChangedTokens` (numeric/figure + substantive-term tokenizing, `orchestrator.ts`) and `containsTerm` (word-boundary matching, `docGraph.ts`) — rather than adding new extraction logic. `entailment`-kind and inactive rows are silently skipped, never errored.
- `runAndSurfaceInvariantChecks()` (`src/lib/invariants/invariantCascade.ts`) wires a violation into the **existing single `CascadeList` surface** (`showAffectedMode` / the Wave D2 "one cascade surface" rule) by synthesizing a resolved `'flag'` annotation, following the same pattern as the merged `directEditCascade.ts`: a no-op, pre-rejected primary anchors "why this proposal?" at the block that declared the fact, and the cascade edit is itself a no-op (`newText === targetText`) — doc-CI flags, it never edits. Wired into `ResolutionActions.tsx` right after an AI-apply's `DocCommit` lands.
- New `src/stores/invariantFlagStore.ts` — a dedicated, persisted dedup ledger keyed on `(documentId, invariantId, conflictBlockId)`, deliberately independent of `annotationStore` (which `DocInputModal.loadDoc()` unconditionally clears on every new-document creation).

## Process record

Two full pre-push adversarial (troublemaker) review rounds — both returned **NO-MERGE**. All HIGH and MEDIUM findings fixed before this PR was opened:

**Round 1 (3 HIGH, 3 MEDIUM):**
- Unbounded re-flagging — an unresolved conflict re-injected a duplicate flag on every future apply forever → fixed with dedup.
- False-positive-prone subject match — a short statement's "longest half of terms" degenerated to single-generic-word matching; numeric tokens compared as raw strings ("$30" != "30") → fixed: statements with ≤2 terms now require ALL terms; numbers compared by normalized value.
- Doc-switch race — no guard against the active document changing during the async `listInvariants` round-trip → fixed with the same `activeDocumentId` guard `directEditCascade.ts` uses, before and after the async gap.
- (MEDIUM) Evidence citation bypassed verbatim verification, silent injection with no user signal, zero test coverage of the surfacing module → fixed: citation now verified via `blockTextRange` before being surfaced (falls back to no evidence rather than fabricating one), a toast fires on every new flag, 7 new tests added.

**Round 2 (1 HIGH, 4 MEDIUM):**
- Dedup depended on `annotationStore`, which `DocInputModal.loadDoc()` clears globally on any new-document creation — reviving stale flags → fixed with the dedicated `invariantFlagStore`.
- No-evidence severity was `'probably'`, one tier above the codebase's own `deriveSeverity` convention (no citation → `'optional'`) → fixed.
- Citation "verification" was a bare substring check ("30" could spuriously match inside "2030") → fixed with a word-boundary check mirroring `containsTerm`.
- Multi-number statements picked the first token ("the fee increased from $20 to $30" cited the superseded $20) → fixed to prefer the last token.
- Decimal-format differences ("$30" vs "$30.00") weren't normalized → fixed with a real numeric parse.
- `evidenceBlockIds[0]`-only anchoring dropped the whole flag if just the first evidence block was gone → fixed to try every evidence block in order.

## Known, disclosed scope limit (not silently assumed away)

An invariant's `status` never leaves `'active'` at the ledger level — Phase 1's `/api/invariants` has no `PATCH`/dismiss route, and this PR doesn't add one. Dedup prevents re-flagging within the persisted `invariantFlagStore`, but there is still no way to mark a conflict resolved at the `DocInvariant` row itself; "Nevermind" only dismisses the local annotation. Filing a follow-up `task:` issue for a real resolve/dismiss endpoint.

Also disclosed in-code: single-substantive-term statements ("the deadline is $500") can't be made more specific without new NLP, so they remain more false-positive-prone than 2+-term statements; word-form numbers, calendar-date fragments, and singular/plural term variants are not matched (false-negative, never false-positive).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 771 passing + 10 skipped (was 757 before this branch; +30 new/updated across `src/lib/invariants/__tests__/{invariantCheckRunner,invariantCascade}.test.ts`)
- [x] `npm run build` — clean
- [x] Two full adversarial (troublemaker) reviews completed; every HIGH and MEDIUM finding fixed with regression tests before push

Closes #32


---
_Generated by [Claude Code](https://claude.ai/code/session_013Fxd9wseDW2yGFvieEDMeK)_