### PR TITLE
Retention/collapse policy for 'direct' DocCommit history versions

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -12,10 +12,28 @@ those guarantees. Precision over promotion.
 
 **Append-only, enforced at the application layer.** The only write path is
 `POST /api/history` (`src/app/api/history/route.ts`); the API exposes no update or delete
-operations, and restores are recorded as *new* versions — history is never rewritten through the
-application. This is an application-level guarantee, not a physical one: an actor with direct
-access to the local SQLite file could remove or alter rows. Hash verification (below) makes such
-partial modification *detectable* (tamper-evident), not impossible.
+operations on compliance-relevant versions (`kind: 'import' | 'apply' | 'restore'`), and restores
+are recorded as *new* versions — history is never rewritten through the application for these
+kinds. This is an application-level guarantee, not a physical one: an actor with direct access to
+the local SQLite file could remove or alter rows. Hash verification (below) makes such partial
+modification *detectable* (tamper-evident), not impossible.
+
+**One disclosed, narrowly-scoped exception: `kind: 'direct'` retention.** `'direct'` versions
+capture autosave/doc-switch/unmount flushes of raw human typing — they carry no AI provenance and
+(by construction — see capture points below) no audit linkage. Left unbounded, an actively-edited
+document would gain a full-document-snapshot row roughly every autosave cycle, forever, in the
+shared hosted database. To bound that growth, `POST /api/history` (`action: 'amend'`) lets a new
+`'direct'` write replace the CURRENT HEAD in place *if and only if* that head is itself a
+`'direct'` commit with no child yet — i.e. one continuous, still-open editing session collapses to
+exactly one row, refreshed on every flush, until a compliance-relevant commit lands and starts a
+new session. `'import'`, `'apply'`, and `'restore'` commits are never eligible as an amend target
+(the server rejects `kind !== 'direct'` outright) and are never replaced — this exception touches
+only the retention-only, provenance-free snapshot kind. The amend path re-verifies the same
+two-level hash scheme and the same linearity invariant (the target must still be the head, checked
+again inside the delete-and-recreate transaction) as a normal append, and a target that has already
+gained a child is rejected as a stale head exactly like a forked write — the client's existing
+single-retry-on-409 logic recovers by refetching and deciding fresh whether to amend again or
+append (`src/lib/history/commits.ts`).
 
 **Two-level content addressing (git's design).** Every version stores a `contentHash` — sha256
 over the canonical document content only — and is keyed by a commit `hash` — sha256 over the
@@ -48,12 +66,15 @@ audit ledger (`AuditLog`, written via the append-only `src/app/api/audit/route.t
 flagged in the UI (`auditFailed`) and the linked version records **zero** audit ids — the gap is
 surfaced, not papered over.
 
-**Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years); document
-versions are retained indefinitely alongside them in the same SQLite database. Version capture
-happens contemporaneously with the action that produced it (document creation, approved AI apply,
-autosaved or flushed edit session, restore) — see `src/lib/history/commits.ts` and the capture
-points in `src/stores/documentStore.ts`, `src/components/Annotations/ResolutionActions.tsx`, and
-`src/components/Editor/EditorShell.tsx`.
+**Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years);
+compliance-relevant document versions (`'import' | 'apply' | 'restore'`) are retained indefinitely
+alongside them in the same SQLite database. `'direct'` versions are retained for the life of the
+editing session that produced them and then collapse to their final state under the amend-in-place
+exception above — see "One disclosed, narrowly-scoped exception" for what that does and does not
+touch. Version capture happens contemporaneously with the action that produced it (document
+creation, approved AI apply, autosaved or flushed edit session, restore) — see
+`src/lib/history/commits.ts` and the capture points in `src/stores/documentStore.ts`,
+`src/components/Annotations/ResolutionActions.tsx`, and `src/components/Editor/EditorShell.tsx`.
 
 ## Article 14 — Human oversight
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -33,7 +33,19 @@ two-level hash scheme and the same linearity invariant (the target must still be
 again inside the delete-and-recreate transaction) as a normal append, and a target that has already
 gained a child is rejected as a stale head exactly like a forked write — the client's existing
 single-retry-on-409 logic recovers by refetching and deciding fresh whether to amend again or
-append (`src/lib/history/commits.ts`).
+append (`src/lib/history/commits.ts`). The whole read-target / validate / check-for-a-child /
+delete / create sequence runs inside one `$transaction`, so a second concurrent amend of the same
+target is either serialized cleanly after the first (and correctly told to retry) or never observes
+a half-applied state — never a corrupted or orphaned chain link.
+
+Disclosed limitation: "the head is a `'direct'` commit" is used as a proxy for "this write
+continues the same editing session," but it isn't proof of that — it only proves no
+compliance-relevant commit has landed since. Two genuinely different writers (e.g. two browser tabs
+open on the same document) both autosaving `'direct'` commits will amend over each other with no
+merge; whichever flush lands last wins, and the other's snapshot is discarded with no signal to
+either tab. This is judged acceptable because `'direct'` commits carry no compliance weight by
+design (no AI provenance, no audit linkage) — but it is a real, disclosed weakening of the ledger's
+usefulness for reconstructing concurrent-editing history, not merely a hypothetical.
 
 **Two-level content addressing (git's design).** Every version stores a `contentHash` — sha256
 over the canonical document content only — and is keyed by a commit `hash` — sha256 over the

--- a/src/app/api/history/__tests__/route.test.ts
+++ b/src/app/api/history/__tests__/route.test.ts
@@ -6,9 +6,9 @@ import {
 } from '@/lib/history/canonical'
 
 // ---------------------------------------------------------------------------
-// In-memory Prisma double for the DocCommit table. The route only uses
-// findUnique / findFirst / findMany / create, so the double implements the
-// exact query shapes route.ts issues.
+// In-memory Prisma double for the DocCommit table. The route uses
+// findUnique / findFirst / findMany / create / delete / $transaction, so the
+// double implements the exact query shapes route.ts issues.
 // ---------------------------------------------------------------------------
 
 interface Row {
@@ -43,39 +43,64 @@ function matches(row: Row, where: any): boolean {
   return true
 }
 
+/** Shared by the top-level client and the `$transaction` tx client below. */
+function performCreate({ data }: any): Row {
+  const insert = (): Row => {
+    const row: Row = {
+      ...data,
+      annotationId: data.annotationId ?? null,
+      createdAt: new Date(1700000000000 + clock++ * 1000),
+    }
+    rows.push(row)
+    return row
+  }
+  if (loseCreateRaceOnce) {
+    loseCreateRaceOnce = false
+    insert() // the concurrent identical request wins first…
+    throw new Error('Unique constraint failed on the fields: (`hash`)')
+  }
+  if (rows.some((r) => r.hash === data.hash)) {
+    throw new Error('Unique constraint failed on the fields: (`hash`)')
+  }
+  return insert()
+}
+
+function performDelete({ where }: any): Row {
+  const idx = rows.findIndex((r) => r.hash === where.hash)
+  if (idx === -1) throw new Error('Record to delete does not exist.')
+  const [removed] = rows.splice(idx, 1)
+  return removed
+}
+
+/**
+ * Function declaration (not `const`) so it is safe to reference from inside
+ * the `vi.mock` factory below regardless of Vitest's hoisting of that call —
+ * function declarations are fully hoisted with their body, unlike `const`.
+ */
+function makeDocCommitClient() {
+  return {
+    findUnique: async ({ where }: any) => rows.find((r) => r.hash === where.hash) ?? null,
+    findFirst: async ({ where }: any) => rows.find((r) => matches(r, where)) ?? null,
+    findMany: async (args: any) => {
+      lastFindManyArgs = args
+      return rows
+        .filter((r) => matches(r, args.where))
+        .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+        .slice(0, args.take)
+    },
+    create: async (args: any) => performCreate(args),
+    delete: async (args: any) => performDelete(args),
+  }
+}
+
 vi.mock('@/lib/db', () => ({
   prisma: {
-    docCommit: {
-      findUnique: async ({ where }: any) => rows.find((r) => r.hash === where.hash) ?? null,
-      findFirst: async ({ where }: any) => rows.find((r) => matches(r, where)) ?? null,
-      findMany: async (args: any) => {
-        lastFindManyArgs = args
-        return rows
-          .filter((r) => matches(r, args.where))
-          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-          .slice(0, args.take)
-      },
-      create: async ({ data }: any) => {
-        const insert = (): Row => {
-          const row: Row = {
-            ...data,
-            annotationId: data.annotationId ?? null,
-            createdAt: new Date(1700000000000 + clock++ * 1000),
-          }
-          rows.push(row)
-          return row
-        }
-        if (loseCreateRaceOnce) {
-          loseCreateRaceOnce = false
-          insert() // the concurrent identical request wins first…
-          throw new Error('Unique constraint failed on the fields: (`hash`)')
-        }
-        if (rows.some((r) => r.hash === data.hash)) {
-          throw new Error('Unique constraint failed on the fields: (`hash`)')
-        }
-        return insert()
-      },
-    },
+    docCommit: makeDocCommitClient(),
+    // Interactive-transaction double: the fake store is single-threaded and
+    // every op below resolves synchronously-in-effect, so running the
+    // callback against the SAME client is sufficient to test the route's
+    // "re-check inside the transaction" logic without a real DB.
+    $transaction: async (fn: any) => fn({ docCommit: makeDocCommitClient() }),
   },
 }))
 
@@ -135,6 +160,59 @@ async function validBody(docJson: string, over: BodyOverrides = {}) {
   })
   return {
     action: 'commit',
+    hash,
+    contentHash,
+    documentId,
+    parentHash: parentHash ?? undefined,
+    kind,
+    message,
+    docJson,
+    blockIdsTouched: '[]',
+    annotationId: annotationId ?? undefined,
+    auditIds: JSON.stringify(auditIds),
+    actor,
+    modelVersion,
+  }
+}
+
+interface AmendOverrides {
+  documentId?: string
+  message?: string
+  actor?: string
+  annotationId?: string | null
+  auditIds?: string[]
+  modelVersion?: string
+}
+
+/**
+ * A fully valid, correctly hashed amend body targeting `target` (a stored
+ * row's metadata) — the new commit's parentHash is the TARGET's own parent,
+ * not the target's hash, matching the "step into the target's slot" contract.
+ */
+async function validAmendBody(target: Row, docJson: string, over: AmendOverrides = {}) {
+  const documentId = over.documentId ?? target.documentId
+  const parentHash = target.parentHash
+  const kind = 'direct'
+  const message = over.message ?? 'Edited document'
+  const actor = over.actor ?? 'human'
+  const annotationId = over.annotationId ?? null
+  const auditIds = over.auditIds ?? []
+  const modelVersion = over.modelVersion ?? ''
+  const contentHash = await computeContentHash(docJson)
+  const hash = await computeCommitHash({
+    documentId,
+    parentHash,
+    contentHash,
+    kind,
+    message,
+    actor,
+    annotationId,
+    auditIds,
+    modelVersion,
+  })
+  return {
+    action: 'amend',
+    targetHash: target.hash,
     hash,
     contentHash,
     documentId,
@@ -254,6 +332,183 @@ describe('POST /api/history', () => {
     const res = await POST(postRequest(body))
     expect(res.status).toBe(400)
     expect((await res.json()).error).toMatch(/parentHash/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/history — action: 'amend' (retention-only 'direct' collapse)
+// ---------------------------------------------------------------------------
+
+describe("POST /api/history — action: 'amend'", () => {
+  it("replaces a 'direct' head in place: same row count, new content, parent unchanged", async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    expect(rows).toHaveLength(2)
+
+    const target = rows[1]
+    const amendBody = await validAmendBody(target, docJsonWithText('v2'))
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ hash: amendBody.hash })
+
+    expect(rows).toHaveLength(2) // no growth — the direct row was replaced
+    expect(rows.find((r) => r.hash === target.hash)).toBeUndefined()
+    const survivor = rows.find((r) => r.hash === amendBody.hash)!
+    expect(survivor.parentHash).toBe(root) // steps into the target's slot
+    expect(survivor.kind).toBe('direct')
+    expect(JSON.parse(survivor.docJson)).toMatchObject({
+      content: [{ content: [{ text: 'v2' }] }],
+    })
+  })
+
+  it('collapses a long run of amends into a single row', async () => {
+    const root = await seedRoot()
+    const firstDirect = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(firstDirect))).status).toBe(200)
+
+    let target = rows.find((r) => r.hash === firstDirect.hash)!
+    for (let i = 2; i <= 5; i++) {
+      const amendBody = await validAmendBody(target, docJsonWithText(`v${i}`))
+      const res = await POST(postRequest(amendBody))
+      expect(res.status).toBe(200)
+      target = rows.find((r) => r.hash === amendBody.hash)!
+    }
+    expect(rows).toHaveLength(2) // root + one surviving direct row, no matter how many amends
+    expect(rows[1].parentHash).toBe(root)
+  })
+
+  it('400s when kind is not direct — apply/import/restore can never be amend targets', async () => {
+    const root = await seedRoot()
+    const applyBody = await validBody(docJsonWithText('applied'), {
+      parentHash: root,
+      kind: 'apply',
+      actor: 'ai+human',
+    })
+    expect((await POST(postRequest(applyBody))).status).toBe(200)
+
+    const target = rows[1]
+    const amendBody = await validAmendBody(target, docJsonWithText('tampered'))
+    ;(amendBody as any).kind = 'apply' // attempt to smuggle a compliance-relevant kind through amend
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/direct/)
+    expect(rows).toHaveLength(2) // untouched
+  })
+
+  it('400s when the amend target itself is not a direct commit', async () => {
+    const root = await seedRoot()
+    const applyBody = await validBody(docJsonWithText('applied'), {
+      parentHash: root,
+      kind: 'apply',
+      actor: 'ai+human',
+    })
+    expect((await POST(postRequest(applyBody))).status).toBe(200)
+
+    const target = rows[1] // the 'apply' row
+    const amendBody = await validAmendBody(target, docJsonWithText('tampered'))
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/not a direct commit/)
+    expect(rows).toHaveLength(2) // the 'apply' row survives untouched
+    expect(rows.find((r) => r.hash === target.hash)).toBeDefined()
+  })
+
+  it('409 stale-head when the amend target already has a child', async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    const target = rows[1]
+
+    // A second writer already chained a new 'apply' onto this direct row.
+    const applyBody = await validBody(docJsonWithText('v2'), {
+      parentHash: target.hash,
+      kind: 'apply',
+      actor: 'ai+human',
+    })
+    expect((await POST(postRequest(applyBody))).status).toBe(200)
+
+    // Our amend, computed against the now-stale target, must be rejected —
+    // deleting `target` here would orphan the 'apply' row's parentHash.
+    const amendBody = await validAmendBody(target, docJsonWithText('mine'))
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ reason: 'stale-head' })
+    expect(rows).toHaveLength(3) // nothing deleted
+    expect(rows.find((r) => r.hash === target.hash)).toBeDefined()
+  })
+
+  it('409 stale-head when the amend target no longer exists', async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    const target = rows[1]
+
+    const amendBody = await validAmendBody(target, docJsonWithText('mine'))
+    ;(amendBody as any).targetHash = 'nonexistent'.repeat(8)
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ reason: 'stale-head' })
+  })
+
+  it('200s an identical duplicate amend (idempotent re-send)', async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    const target = rows[1]
+
+    const amendBody = await validAmendBody(target, docJsonWithText('v2'))
+    expect((await POST(postRequest(amendBody))).status).toBe(200)
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ hash: amendBody.hash, existing: true })
+    expect(rows).toHaveLength(2)
+  })
+
+  it("400s when a self-consistent payload's parentHash does not match the target's own parent", async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    const target = rows[1]
+
+    // Self-consistent but wrong: the hash is computed against `target.hash`
+    // as the parent (an append-style parent) even though this is an amend,
+    // whose parent must be the TARGET's OWN parent. Hash verification alone
+    // cannot catch this — it only proves the payload is internally
+    // consistent — so this exercises the dedicated target-consistency check.
+    const docJson = docJsonWithText('v2')
+    const contentHash = await computeContentHash(docJson)
+    const wrongParentHash = target.hash
+    const hash = await computeCommitHash({
+      documentId: target.documentId,
+      parentHash: wrongParentHash,
+      contentHash,
+      kind: 'direct',
+      message: 'Edited document',
+      actor: 'human',
+      annotationId: null,
+      auditIds: [],
+      modelVersion: '',
+    })
+    const amendBody = {
+      action: 'amend',
+      targetHash: target.hash,
+      hash,
+      contentHash,
+      documentId: target.documentId,
+      parentHash: wrongParentHash,
+      kind: 'direct',
+      message: 'Edited document',
+      docJson,
+      blockIdsTouched: '[]',
+      auditIds: '[]',
+      actor: 'human',
+      modelVersion: '',
+    }
+    const res = await POST(postRequest(amendBody))
+    expect(res.status).toBe(400)
+    expect((await res.json()).error).toMatch(/parent/)
+    expect(rows).toHaveLength(2) // untouched
   })
 })
 

--- a/src/app/api/history/__tests__/route.test.ts
+++ b/src/app/api/history/__tests__/route.test.ts
@@ -73,34 +73,68 @@ function performDelete({ where }: any): Row {
 }
 
 /**
+ * A real (macrotask) tick, not just a microtask — wide enough that two
+ * concurrent requests' DB calls reliably interleave regardless of how fast
+ * an unrelated real async op (e.g. WebCrypto hashing) happens to resolve in
+ * this environment. Without this, a race test can pass "by accident": both
+ * requests' non-transactional reads might happen to run back-to-back before
+ * either write lands, hiding a real TOCTOU gap instead of exercising it.
+ */
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+/**
  * Function declaration (not `const`) so it is safe to reference from inside
  * the `vi.mock` factory below regardless of Vitest's hoisting of that call —
  * function declarations are fully hoisted with their body, unlike `const`.
  */
 function makeDocCommitClient() {
   return {
-    findUnique: async ({ where }: any) => rows.find((r) => r.hash === where.hash) ?? null,
-    findFirst: async ({ where }: any) => rows.find((r) => matches(r, where)) ?? null,
+    findUnique: async ({ where }: any) => {
+      await tick()
+      return rows.find((r) => r.hash === where.hash) ?? null
+    },
+    findFirst: async ({ where }: any) => {
+      await tick()
+      return rows.find((r) => matches(r, where)) ?? null
+    },
     findMany: async (args: any) => {
+      await tick()
       lastFindManyArgs = args
       return rows
         .filter((r) => matches(r, args.where))
         .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
         .slice(0, args.take)
     },
-    create: async (args: any) => performCreate(args),
-    delete: async (args: any) => performDelete(args),
+    create: async (args: any) => {
+      await tick()
+      return performCreate(args)
+    },
+    delete: async (args: any) => {
+      await tick()
+      return performDelete(args)
+    },
   }
+}
+
+/**
+ * Serializes concurrent `$transaction` callbacks so at most one runs at a
+ * time, start to finish — the same atomicity guarantee real Prisma gets from
+ * SQLite. Without this, two callbacks invoked via `Promise.all` could
+ * interleave their internal `await`s (e.g. both read the target row before
+ * either deletes it), which a real DB transaction would never allow and
+ * which would make a concurrency test non-representative of production.
+ */
+let txQueue: Promise<unknown> = Promise.resolve()
+function runTransaction(fn: (tx: unknown) => Promise<unknown>) {
+  const run = txQueue.then(() => fn({ docCommit: makeDocCommitClient() }))
+  txQueue = run.catch(() => undefined)
+  return run
 }
 
 vi.mock('@/lib/db', () => ({
   prisma: {
     docCommit: makeDocCommitClient(),
-    // Interactive-transaction double: the fake store is single-threaded and
-    // every op below resolves synchronously-in-effect, so running the
-    // callback against the SAME client is sufficient to test the route's
-    // "re-check inside the transaction" logic without a real DB.
-    $transaction: async (fn: any) => fn({ docCommit: makeDocCommitClient() }),
+    $transaction: (fn: any) => runTransaction(fn),
   },
 }))
 
@@ -112,6 +146,7 @@ beforeEach(() => {
   clock = 0
   loseCreateRaceOnce = false
   lastFindManyArgs = null
+  txQueue = Promise.resolve()
 })
 
 // ---------------------------------------------------------------------------
@@ -463,6 +498,37 @@ describe("POST /api/history — action: 'amend'", () => {
     expect(res.status).toBe(200)
     expect(await res.json()).toMatchObject({ hash: amendBody.hash, existing: true })
     expect(rows).toHaveLength(2)
+  })
+
+  it('two concurrent amends of the SAME target: one wins 200, the other gets 409 stale-head (never a 500)', async () => {
+    const root = await seedRoot()
+    const directBody = await validBody(docJsonWithText('v1'), { parentHash: root })
+    expect((await POST(postRequest(directBody))).status).toBe(200)
+    const target = rows[1]
+
+    // Two independent writers (e.g. two tabs) both amending the same head at
+    // once. Before the fix, the second request's transaction would find the
+    // target already deleted by the first and throw an uncaught "record to
+    // delete does not exist" — an unhandled 500 instead of the documented
+    // 409 the client's retry logic knows how to recover from.
+    const amendA = await validAmendBody(target, docJsonWithText('from tab A'))
+    const amendB = await validAmendBody(target, docJsonWithText('from tab B'))
+    const [resA, resB] = await Promise.all([
+      POST(postRequest(amendA)),
+      POST(postRequest(amendB)),
+    ])
+
+    const statuses = [resA.status, resB.status].sort()
+    expect(statuses).toEqual([200, 409])
+    const [winner, loser] = resA.status === 200 ? [resA, resB] : [resB, resA]
+    expect(await loser.json()).toMatchObject({ reason: 'stale-head' })
+    const winnerBody = await winner.json()
+
+    // Exactly one row replaced the target — no orphan, no duplicate, no
+    // partially-applied delete-without-create (or vice versa).
+    expect(rows).toHaveLength(2)
+    expect(rows.find((r) => r.hash === target.hash)).toBeUndefined()
+    expect(rows.find((r) => r.hash === winnerBody.hash)).toBeDefined()
   })
 
   it("400s when a self-consistent payload's parentHash does not match the target's own parent", async () => {

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -333,6 +333,8 @@ export async function POST(request: NextRequest) {
 
 /** Internal signal: the amend target stopped being the head inside the transaction. */
 class AmendStaleHeadError extends Error {}
+/** Internal signal: the amend target exists but fails a structural precondition (400, not 409). */
+class AmendInvalidTargetError extends Error {}
 
 /**
  * action: 'amend' — retention-only in-place replacement of a 'direct' commit.
@@ -348,6 +350,20 @@ class AmendStaleHeadError extends Error {}
  * existing single-retry-on-409 logic recovers by refetching the head and
  * deciding fresh whether to amend again or append. 'import' | 'apply' |
  * 'restore' commits are never touched by this path.
+ *
+ * The target lookup and every check that depends on it (kind, parentHash
+ * consistency, "does it already have a child") run INSIDE the `$transaction`
+ * callback below, not before it — an earlier version read the target once
+ * outside the transaction and only re-checked for a child inside it, which
+ * left a real gap: a second concurrent amend of the SAME target could delete
+ * it out from under the first request between that outer read and the
+ * transaction's delete, turning a normal, recoverable stale-head race into
+ * an unhandled 500 ("record to delete does not exist") instead of the
+ * documented 409 the client's retry logic expects. Doing the whole
+ * read-decide-write sequence atomically closes that gap: whichever
+ * concurrent amend's transaction commits first wins, and the other's target
+ * lookup — now inside its own transaction — correctly finds the row already
+ * gone and reports 409 stale-head like any other race.
  */
 async function handleAmend(params: Record<string, unknown>) {
   const documentId = typeof params.documentId === 'string' ? params.documentId : ''
@@ -434,30 +450,20 @@ async function handleAmend(params: Record<string, unknown>) {
     return NextResponse.json({ hash: existing.hash, existing: true })
   }
 
-  const target = await prisma.docCommit.findFirst({ where: { hash: targetHash, documentId } })
-  if (!target) {
-    // Most likely cause: another writer already amended or superseded this
-    // row. Same recovery as a normal fork race — refetch head and retry.
-    return NextResponse.json(
-      { error: 'Amend target not found', reason: 'stale-head' },
-      { status: 409 },
-    )
-  }
-  if (target.kind !== 'direct') {
-    return NextResponse.json({ error: 'Amend target is not a direct commit' }, { status: 400 })
-  }
-  if (parentHash !== target.parentHash) {
-    return NextResponse.json(
-      { error: "parentHash must match the amend target's own parent" },
-      { status: 400 },
-    )
-  }
-
   try {
     const record = await prisma.$transaction(async (tx) => {
-      // Re-verify inside the transaction: the target could have gained a
-      // child (an 'apply'/'import'/'restore' or a racing amend) in the gap
-      // between the read above and this write.
+      // The target lookup and every check derived from it run HERE, inside
+      // the transaction — see the function doc comment for why an earlier
+      // outer-then-inner split left a real TOCTOU gap.
+      const target = await tx.docCommit.findFirst({ where: { hash: targetHash, documentId } })
+      if (!target) throw new AmendStaleHeadError() // superseded before we could even read it
+      if (target.kind !== 'direct') throw new AmendInvalidTargetError('not-direct')
+      if (parentHash !== target.parentHash) throw new AmendInvalidTargetError('parent-mismatch')
+
+      // A concurrent writer could still have appended a child (an
+      // 'apply'/'import'/'restore' or a racing amend's new row) onto this
+      // exact target between two callers both finding it present above —
+      // that's a distinct interleaving from "target already deleted".
       const child = await tx.docCommit.findFirst({
         where: { documentId, parentHash: target.hash },
         select: { hash: true },
@@ -492,6 +498,17 @@ async function handleAmend(params: Record<string, unknown>) {
           reason: 'stale-head',
         },
         { status: 409 },
+      )
+    }
+    if (amendErr instanceof AmendInvalidTargetError) {
+      return NextResponse.json(
+        {
+          error:
+            amendErr.message === 'parent-mismatch'
+              ? "parentHash must match the amend target's own parent"
+              : 'Amend target is not a direct commit',
+        },
+        { status: 400 },
       )
     }
     // A concurrent identical amend can race past the checks above and

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -5,12 +5,18 @@ import { computeCommitHash, computeContentHash } from '@/lib/history/canonical'
 /**
  * /api/history — append-only, content-addressed document version history.
  *
- * EU AI Act Article 12 record-keeping: every version of a document is kept as
- * a snapshot in a linear parent-pointer chain. This endpoint ONLY creates and
- * reads records — no update or delete operations exist, and restores are
- * recorded as NEW versions (history is never rewritten). Append-only is
- * enforced at the application layer; hash verification makes stored records
- * tamper-evident against partial modification.
+ * EU AI Act Article 12 record-keeping: every compliance-relevant version of a
+ * document ('import' | 'apply' | 'restore') is kept as a snapshot in a linear
+ * parent-pointer chain and is NEVER updated or deleted; restores are recorded
+ * as NEW versions (history is never rewritten). Append-only is enforced at
+ * the application layer; hash verification makes stored records tamper-
+ * evident against partial modification.
+ *
+ * The one disclosed exception, scoped narrowly: 'direct' autosave-flush
+ * commits (no AI provenance, no audit linkage) may be amended in place via
+ * `action: 'amend'` below — a retention measure so an active editing session
+ * doesn't grow one full-snapshot row per autosave forever. 'import' | 'apply'
+ * | 'restore' are never amend targets. See docs/compliance.md.
  *
  * Integrity (two-level, git's design):
  *   - contentHash = sha256(canonical docJson)               — the "tree"
@@ -145,6 +151,10 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json()
     const { action, ...params } = body
+
+    if (action === 'amend') {
+      return await handleAmend(params)
+    }
 
     if (action !== 'commit') {
       return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
@@ -316,6 +326,186 @@ export async function POST(request: NextRequest) {
     console.error('[/api/history] Error:', err)
     return NextResponse.json(
       { error: err instanceof Error ? err.message : 'History write failed' },
+      { status: 500 },
+    )
+  }
+}
+
+/** Internal signal: the amend target stopped being the head inside the transaction. */
+class AmendStaleHeadError extends Error {}
+
+/**
+ * action: 'amend' — retention-only in-place replacement of a 'direct' commit.
+ *
+ * Body adds `targetHash`: the hash of the 'direct' row being replaced. The
+ * new row takes the TARGET's own parentHash (it steps into the target's slot
+ * in the chain), not the target's hash — this is not an append.
+ *
+ * Scoped narrowly and defended at every layer: only `kind: 'direct'` may be
+ * submitted, only a `kind: 'direct'` target may be replaced, and the target
+ * must currently be the head (no commit anywhere has it as a parent) or the
+ * write is rejected exactly like a normal stale-head race — the client's
+ * existing single-retry-on-409 logic recovers by refetching the head and
+ * deciding fresh whether to amend again or append. 'import' | 'apply' |
+ * 'restore' commits are never touched by this path.
+ */
+async function handleAmend(params: Record<string, unknown>) {
+  const documentId = typeof params.documentId === 'string' ? params.documentId : ''
+  const docJson = typeof params.docJson === 'string' ? params.docJson : ''
+  const kind = typeof params.kind === 'string' ? params.kind : ''
+  const message = typeof params.message === 'string' ? params.message : ''
+  const hash = typeof params.hash === 'string' ? params.hash : ''
+  const contentHash = typeof params.contentHash === 'string' ? params.contentHash : ''
+  const actor = typeof params.actor === 'string' ? params.actor : 'human'
+  const modelVersion = typeof params.modelVersion === 'string' ? params.modelVersion : ''
+  const annotationId = typeof params.annotationId === 'string' ? params.annotationId : null
+  const targetHash = typeof params.targetHash === 'string' ? params.targetHash : ''
+  const parentHash =
+    typeof params.parentHash === 'string' && params.parentHash.length > 0
+      ? params.parentHash
+      : null
+
+  if (kind !== 'direct') {
+    return NextResponse.json({ error: 'Only direct commits may be amended' }, { status: 400 })
+  }
+  if (!documentId || !docJson || !hash || !contentHash || !message || !targetHash) {
+    return NextResponse.json(
+      { error: 'hash, contentHash, documentId, docJson, message, and targetHash are required' },
+      { status: 400 },
+    )
+  }
+
+  let auditIds: string[]
+  try {
+    const parsed: unknown = JSON.parse(
+      typeof params.auditIds === 'string' ? params.auditIds : '[]',
+    )
+    if (!Array.isArray(parsed) || parsed.some((id) => typeof id !== 'string')) {
+      throw new Error('not a string array')
+    }
+    auditIds = parsed
+  } catch {
+    return NextResponse.json(
+      { error: 'auditIds must be a JSON array of strings' },
+      { status: 400 },
+    )
+  }
+
+  // Integrity checks run against the PAYLOAD alone (they don't need the
+  // target row) so a sequential idempotent re-send — whose target the first,
+  // already-successful call already consumed — is recognized as a duplicate
+  // before it can be misread as "amend target not found". Same ordering as
+  // the 'commit' path above: verify, then check for a duplicate, then act.
+  let expectedContentHash: string
+  try {
+    expectedContentHash = await computeContentHash(docJson)
+  } catch {
+    return NextResponse.json({ error: 'docJson is not valid JSON' }, { status: 400 })
+  }
+  if (expectedContentHash !== contentHash) {
+    return NextResponse.json(
+      { error: 'Content hash mismatch: docJson does not match its content address' },
+      { status: 400 },
+    )
+  }
+
+  const expectedHash = await computeCommitHash({
+    documentId,
+    parentHash,
+    contentHash,
+    kind,
+    message,
+    actor,
+    annotationId,
+    auditIds,
+    modelVersion,
+  })
+  if (expectedHash !== hash) {
+    return NextResponse.json(
+      { error: 'Hash mismatch: payload does not match its commit address' },
+      { status: 400 },
+    )
+  }
+
+  // Idempotency: identical amend re-send (the hash covers content AND
+  // attribution, so a duplicate hash is a true full duplicate).
+  const existing = await prisma.docCommit.findUnique({ where: { hash }, select: { hash: true } })
+  if (existing) {
+    return NextResponse.json({ hash: existing.hash, existing: true })
+  }
+
+  const target = await prisma.docCommit.findFirst({ where: { hash: targetHash, documentId } })
+  if (!target) {
+    // Most likely cause: another writer already amended or superseded this
+    // row. Same recovery as a normal fork race — refetch head and retry.
+    return NextResponse.json(
+      { error: 'Amend target not found', reason: 'stale-head' },
+      { status: 409 },
+    )
+  }
+  if (target.kind !== 'direct') {
+    return NextResponse.json({ error: 'Amend target is not a direct commit' }, { status: 400 })
+  }
+  if (parentHash !== target.parentHash) {
+    return NextResponse.json(
+      { error: "parentHash must match the amend target's own parent" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const record = await prisma.$transaction(async (tx) => {
+      // Re-verify inside the transaction: the target could have gained a
+      // child (an 'apply'/'import'/'restore' or a racing amend) in the gap
+      // between the read above and this write.
+      const child = await tx.docCommit.findFirst({
+        where: { documentId, parentHash: target.hash },
+        select: { hash: true },
+      })
+      if (child) throw new AmendStaleHeadError()
+
+      await tx.docCommit.delete({ where: { hash: target.hash } })
+      return tx.docCommit.create({
+        data: {
+          hash,
+          contentHash,
+          documentId,
+          parentHash,
+          kind,
+          message,
+          docJson,
+          blockIdsTouched:
+            typeof params.blockIdsTouched === 'string' ? params.blockIdsTouched : '[]',
+          annotationId: annotationId ?? undefined,
+          auditIds: JSON.stringify(auditIds),
+          actor,
+          modelVersion,
+        },
+      })
+    })
+    return NextResponse.json({ hash: record.hash })
+  } catch (amendErr) {
+    if (amendErr instanceof AmendStaleHeadError) {
+      return NextResponse.json(
+        {
+          error: 'Stale head: the amend target already has a newer version',
+          reason: 'stale-head',
+        },
+        { status: 409 },
+      )
+    }
+    // A concurrent identical amend can race past the checks above and
+    // collide on the primary key — that is still an idempotent success.
+    const racedExisting = await prisma.docCommit.findUnique({
+      where: { hash },
+      select: { hash: true },
+    })
+    if (racedExisting) {
+      return NextResponse.json({ hash: racedExisting.hash, existing: true })
+    }
+    console.error('[/api/history amend] Error:', amendErr)
+    return NextResponse.json(
+      { error: amendErr instanceof Error ? amendErr.message : 'Amend failed' },
       { status: 500 },
     )
   }

--- a/src/components/History/HistoryPanel.tsx
+++ b/src/components/History/HistoryPanel.tsx
@@ -435,9 +435,10 @@ export function HistoryPanel() {
 
       {commits.length > 0 && (
         <p className="text-[10px] text-muted-foreground/70 pt-1">
-          Version history is append-only at the application level (no edit or delete operations;
-          server-verified hashes make records tamper-evident) and is linked to the audit trail in
-          support of EU AI Act Art. 12 &amp; 14.
+          Applied and imported versions are append-only at the application level (no edit or
+          delete operations; server-verified hashes make records tamper-evident) and are linked to
+          the audit trail in support of EU AI Act Art. 12 &amp; 14. In-progress typing snapshots are
+          refreshed in place until an applied change or restore closes the session.
         </p>
       )}
 

--- a/src/lib/history/__tests__/commits.test.ts
+++ b/src/lib/history/__tests__/commits.test.ts
@@ -154,6 +154,55 @@ async function fakeFetch(input: string, init?: { method?: string; body?: string 
       const existing = commits.find((c) => c.hash === body.hash)
       if (existing) return jsonResponse({ hash: existing.hash, existing: true })
 
+      // action: 'amend' — retention-only in-place replacement of a 'direct'
+      // commit, mirroring route.ts's handleAmend semantics for this fake.
+      if (body.action === 'amend') {
+        if (body.kind !== 'direct') {
+          return jsonResponse({ error: 'Only direct commits may be amended' }, 400)
+        }
+        const target = commits.find(
+          (c) => c.hash === body.targetHash && c.documentId === body.documentId,
+        )
+        if (!target) {
+          return jsonResponse(
+            { error: 'Amend target not found', reason: 'stale-head' },
+            409,
+          )
+        }
+        if (target.kind !== 'direct') {
+          return jsonResponse({ error: 'Amend target is not a direct commit' }, 400)
+        }
+        if (parentHash !== target.parentHash) {
+          return jsonResponse({ error: "parentHash must match the amend target's own parent" }, 400)
+        }
+        const hasChild = commits.some(
+          (c) => c.documentId === body.documentId && c.parentHash === target.hash,
+        )
+        if (hasChild) {
+          return jsonResponse(
+            { error: 'Stale head: the amend target already has a newer version', reason: 'stale-head' },
+            409,
+          )
+        }
+        commits = commits.filter((c) => c.hash !== target.hash)
+        commits.push({
+          hash: body.hash,
+          contentHash: body.contentHash,
+          documentId: body.documentId,
+          parentHash,
+          kind: body.kind,
+          message: body.message,
+          docJson: body.docJson,
+          blockIdsTouched: body.blockIdsTouched ?? '[]',
+          annotationId,
+          auditIds: body.auditIds ?? '[]',
+          actor: body.actor ?? 'human',
+          modelVersion: body.modelVersion ?? '',
+          createdAt: new Date(1700000000000 + clock++ * 1000).toISOString(),
+        })
+        return jsonResponse({ hash: body.hash })
+      }
+
       if (parentHash) {
         if (!commits.some((c) => c.hash === parentHash && c.documentId === body.documentId)) {
           return jsonResponse({ error: 'Unknown parent' }, 400)
@@ -379,7 +428,7 @@ describe('createCommit', () => {
   })
 
   it('retries ONCE against the new head on a 409 stale-head, then succeeds', async () => {
-    await createCommit({
+    const root = await createCommit({
       docJson: docJsonWithText('v1'),
       documentId: 'doc-1',
       kind: 'import',
@@ -388,6 +437,10 @@ describe('createCommit', () => {
 
     // The next POST is beaten by a concurrent writer → server 409s the first
     // attempt; the client must refetch the head, rehash, and land on top.
+    // The racer is itself a 'direct' commit, so the retry's own 'direct'
+    // write finds a 'direct' head and amends it in place rather than
+    // appending — collapsing the racer away, which is the retention feature
+    // working as intended (both are ordinary autosave snapshots).
     raceInjectionsRemaining = 1
     const postsBefore = historyPosts().length
     const result = await createCommit({
@@ -399,10 +452,10 @@ describe('createCommit', () => {
 
     expect(result.noop).toBe(false)
     expect(historyPosts().length).toBe(postsBefore + 2) // 409 attempt + retry
-    expect(commits).toHaveLength(3) // v1, racer, mine
+    expect(commits).toHaveLength(2) // v1, mine (the racer was amended away)
+    expect(commits.some((c) => c.message.startsWith('concurrent writer'))).toBe(false)
     const mine = commits.find((c) => c.hash === result.hash)!
-    const racer = commits.find((c) => c.message.startsWith('concurrent writer'))!
-    expect(mine.parentHash).toBe(racer.hash) // rebased onto the interloper
+    expect(mine.parentHash).toBe(root.hash) // stepped into the racer's slot
   })
 
   it('gives up (throws) when the head keeps moving after one retry', async () => {
@@ -482,22 +535,26 @@ describe('restoreCommit', () => {
   })
 
   it('flushes pending unsaved edits as a direct version BEFORE restoring (no typed tail lost)', async () => {
-    const { v2 , v1 } = await seedTwoVersions()
+    const { v2, v1 } = await seedTwoVersions()
 
     // The user typed after the last autosave: the editor is ahead of history.
+    // v2 is itself a 'direct' commit, so the flush amends it in place rather
+    // than appending a third row — the retention feature collapsing the
+    // pre-restore session into its final state before the restore lands.
     const typedJson = pmDocJson('version two plus unsaved typing')
     const view = makeView(typedJson)
     const target = await getCommit(v1)
 
     const result = await restoreCommit(view, target!, 'doc-1')
 
-    // v1, v2, flush, restore — the typed tail is preserved in the chain.
-    expect(commits).toHaveLength(4)
-    const flush = commits[2]
+    // v1, flush (replacing v2), restore — the typed tail is preserved.
+    expect(commits).toHaveLength(3)
+    expect(commits.some((c) => c.hash === v2)).toBe(false)
+    const flush = commits[1]
     expect(flush.kind).toBe('direct')
-    expect(flush.parentHash).toBe(v2)
+    expect(flush.parentHash).toBe(v1)
     expect(JSON.parse(flush.docJson)).toEqual(typedJson)
-    const restore = commits[3]
+    const restore = commits[2]
     expect(restore.hash).toBe(result.hash)
     expect(restore.parentHash).toBe(flush.hash)
     expect((view as any).state.doc.textContent).toBe('version one')
@@ -530,6 +587,82 @@ describe('restoreCommit', () => {
     // "Restore failed" toast is now TRUE.
     expect((view as any).state.doc.textContent).toBe('version two')
     expect(commits).toHaveLength(2)
+  })
+})
+
+describe("direct-commit retention (amend-in-place collapse)", () => {
+  it("collapses a run of 'direct' commits into one row, refreshed in place", async () => {
+    const root = await createCommit({
+      docJson: docJsonWithText('v0'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+    await createCommit({ docJson: docJsonWithText('v1'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    await createCommit({ docJson: docJsonWithText('v2'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    const last = await createCommit({ docJson: docJsonWithText('v3'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+
+    // Exactly one 'direct' row survives the whole run, no matter how many
+    // autosave flushes happened — this is the retention policy in action.
+    expect(commits).toHaveLength(2) // root + one collapsed direct row
+    const survivor = commits.find((c) => c.kind === 'direct')!
+    expect(survivor.hash).toBe(last.hash)
+    expect(survivor.parentHash).toBe(root.hash)
+    expect(JSON.parse(survivor.docJson)).toEqual(docJsonWithText('v3'))
+  })
+
+  it("never amends across a compliance-relevant boundary — 'apply' survives untouched", async () => {
+    const root = await createCommit({
+      docJson: docJsonWithText('v0'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+    await createCommit({ docJson: docJsonWithText('v1'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    const applied = await createCommit({
+      docJson: docJsonWithText('v2'),
+      documentId: 'doc-1',
+      kind: 'apply',
+      message: 'AI change applied',
+      annotationId: 'ann-1',
+      auditIds: ['audit-9'],
+      actor: 'ai+human',
+    })
+    await createCommit({ docJson: docJsonWithText('v3'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    const last = await createCommit({ docJson: docJsonWithText('v4'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+
+    // root, the pre-apply direct row (never amended — 'apply' is never an
+    // amend target, so it stays a permanent row once superseded), apply
+    // itself, and one collapsed post-apply direct row.
+    expect(commits).toHaveLength(4)
+    expect(commits.find((c) => c.hash === applied.hash)).toBeTruthy()
+    expect(commits.find((c) => c.hash === applied.hash)).toMatchObject({ kind: 'apply', actor: 'ai+human' })
+    const survivor = commits.find((c) => c.hash === last.hash)!
+    expect(survivor.parentHash).toBe(applied.hash) // new session starts on top of apply
+  })
+
+  it('blameBlock still resolves the compliance-relevant commit after later direct commits collapse', async () => {
+    await createCommit({
+      docJson: docJsonWithText('v0'),
+      documentId: 'doc-1',
+      kind: 'import',
+      message: 'Created "Test"',
+    })
+    const applied = await createCommit({
+      docJson: docJsonWithText('v1'),
+      documentId: 'doc-1',
+      kind: 'apply',
+      message: 'AI change applied',
+      blockIdsTouched: ['b1'],
+      annotationId: 'ann-1',
+      auditIds: ['audit-9'],
+      actor: 'ai+human',
+    })
+    await createCommit({ docJson: docJsonWithText('v2'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+    await createCommit({ docJson: docJsonWithText('v3'), documentId: 'doc-1', kind: 'direct', message: 'Edited document' })
+
+    const history = await listCommits('doc-1')
+    expect(blameBlock(history, 'b1')?.hash).toBe(applied.hash)
   })
 })
 

--- a/src/lib/history/commits.ts
+++ b/src/lib/history/commits.ts
@@ -20,6 +20,13 @@
  *
  * UI capture points go through `recordCommit`, a fire-and-forget wrapper
  * that can never block or throw into UI paths.
+ *
+ * Retention: consecutive 'direct' autosave flushes with no compliance-
+ * relevant commit ('import' | 'apply' | 'restore') between them are
+ * amended in place server-side rather than appended — an active editing
+ * session keeps exactly one 'direct' row in the chain, refreshed on every
+ * flush. 'import' | 'apply' | 'restore' commits are never amend targets and
+ * are never replaced. See docs/compliance.md.
  */
 
 import type { EditorView } from 'prosemirror-view'
@@ -143,7 +150,15 @@ async function attemptCommit(
     return { hash: head.hash, noop: true }
   }
 
-  const parentHash = head?.hash ?? null
+  // Retention (amend-in-place): a 'direct' write whose current head is ALSO
+  // an unamended 'direct' write steps into that row's place instead of
+  // appending a new one — one active-editing session keeps exactly one row
+  // in the chain, refreshed on every autosave flush, until a compliance-
+  // relevant commit ('import' | 'apply' | 'restore') lands and starts a new
+  // session. Those kinds are NEVER amend targets. See docs/compliance.md.
+  const amendTarget = params.kind === 'direct' && head?.kind === 'direct' ? head : null
+
+  const parentHash = amendTarget ? amendTarget.parentHash : (head?.hash ?? null)
   const annotationId = params.annotationId ?? null
   const auditIds = params.auditIds ?? []
   const actor = params.actor ?? 'human'
@@ -165,7 +180,8 @@ async function attemptCommit(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      action: 'commit',
+      action: amendTarget ? 'amend' : 'commit',
+      targetHash: amendTarget?.hash,
       hash,
       contentHash,
       documentId: params.documentId,


### PR DESCRIPTION
## What

`DocCommit` had no retention, pruning, or collapse mechanism. `'direct'` commits (autosave-flush snapshots of raw human typing — no AI provenance, no audit linkage) fire on every 5s autosave debounce, doc-switch, and unmount, so an actively-edited document accumulated one full-document-snapshot row roughly every 5 seconds of typing, forever, on the live public demo's shared Turso free-tier database.

## Changes

- **New `action: 'amend'` request to `POST /api/history`** (`src/app/api/history/route.ts`, `handleAmend()`): lets a new `'direct'` write replace the CURRENT HEAD in place — delete old row, insert new row with a new hash — *if and only if* that head is ALSO a `'direct'` commit with no child yet. One continuous active-editing session collapses to exactly one row, refreshed on every autosave flush, until a compliance-relevant commit (`'import' | 'apply' | 'restore'`) lands and starts a new session. Those three kinds are **never** amend targets and are never deleted — this is a narrowly-scoped, structurally-enforced exception (`kind !== 'direct'` and `target.kind !== 'direct'` are both hard-rejected with 400) to the append-only rule, applied only to the retention-only, provenance-free snapshot kind.
- **`src/lib/history/commits.ts`**: `attemptCommit()` now decides append vs. amend — amend computes the new row's `parentHash` as the amend TARGET's own parent (it steps into the target's slot), not the target's hash.
- **`docs/compliance.md`**: two new disclosed paragraphs under Article 12 — what the exception does and doesn't touch, and a disclosed limitation that two genuinely concurrent writers (e.g. two browser tabs) of `'direct'` commits can amend over each other with no merge (judged acceptable since `'direct'` carries no compliance weight, but stated plainly rather than left implicit).
- **`src/components/History/HistoryPanel.tsx`**: footer copy updated so it no longer overstates the guarantee (applied/imported versions are append-only; in-progress typing snapshots are refreshed in place until an applied change or restore closes the session).

## Process record

Pre-push adversarial (troublemaker) review returned **NO-MERGE** with one real, *reproduced* HIGH finding: the amend target was read once outside the `$transaction`, and the transaction's re-check only detected a newly-appended child — not the target having been fully deleted-and-replaced by a second concurrent amend. Two concurrent amends of the same target could turn a normal, recoverable stale-head race into an unhandled 500 (`"Record to delete does not exist"`) instead of the documented 409 the client's existing single-retry logic knows how to recover from. `restoreCommit()`'s pre-restore flush has no try/catch around this, so the failure mode was a misleading "Restore failed" toast on what was actually a benign concurrent-autosave collision.

Fixed by moving the entire read-target → validate (kind, parentHash consistency) → check-for-a-child → delete → create sequence **inside** the `$transaction` callback, so the whole thing is atomic — whichever concurrent amend's transaction commits first wins, and the other's target lookup, now itself inside a transaction, correctly finds the row already gone and reports 409 stale-head like any other race.

The review also flagged that the existing test doubles (fully synchronous, no real interleaving) could never have caught this. Verified concretely: reverted the fix locally, added a real (macrotask-tick-widened) interleaving point to the in-memory Prisma double's transaction-serializing mock, and confirmed the new concurrency test **fails** against the old code (`[200, 500]`) before confirming it **passes** against the fix (`[200, 409]`) — so the regression test is a genuine guard, not a vacuous one.

A second, lower-severity design nuance was flagged (no "session identity" — the collapse only proves no compliance-relevant commit has landed since, not that the same writer is doing the amending) and judged acceptable per the design intent, but is now explicitly disclosed in `docs/compliance.md` rather than left implicit.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 761 passing + 10 skipped (was 760 pre-fix-commit; +1 net new concurrency regression test on top of the ~15 amend/collapse tests added by this PR)
- [x] `npm run build` — clean
- [x] Pre-push adversarial (troublemaker) review completed; the one HIGH finding (TOCTOU race) fixed and independently verified to reproduce against the pre-fix code and pass against the fix

New coverage: `src/app/api/history/__tests__/route.test.ts` gains a full `action: 'amend'` describe block (happy path, long-run collapse, 400s for non-direct kind/target, 409s for stale/missing target, idempotent duplicate re-send, parentHash-consistency mismatch, and the concurrency race). `src/lib/history/__tests__/commits.test.ts` gains a `direct-commit retention` describe block (collapses a run of direct commits, never amends across a compliance-relevant boundary, `blameBlock` still resolves correctly after collapse) plus updates to two pre-existing tests whose expected outcomes legitimately change under the new collapse behavior (both traced by hand against the client/server logic to confirm the new expectations are correct, not laundered).

Closes #39

---
_Generated by [Claude Code](https://claude.ai/code/session_017BFYT7XAdgDx8qpU2rdA3X)_