### PR TITLE
Validate insertion-only proposed edits against captured context

### DIFF
--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -1,4 +1,5 @@
 import type { EditorState } from 'prosemirror-state'
+import type { Node as PMNode } from 'prosemirror-model'
 import type {
   CascadeEdgeType,
   CascadeEvidence,
@@ -9,7 +10,12 @@ import type {
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
 import type { LLMConfig } from '@/stores/settingsStore'
 import { findTextInDoc } from '@/lib/prosemirror/applyProposedEdits'
-import { blockIdAtPos, blockTextRange, findBlockById } from '@/lib/prosemirror/blockIds'
+import {
+  blockIdAtPos,
+  blockTextRange,
+  findBlockById,
+  INSERTION_CONTEXT_RADIUS,
+} from '@/lib/prosemirror/blockIds'
 import { containsTerm, getDocGraph, getNeighborhood, type DocGraph } from '@/lib/graphrag/docGraph'
 import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
 import { judgeMustCandidates, type JudgeFn } from '@/lib/ai/relevanceJudge'
@@ -83,12 +89,30 @@ function newId(): string {
   }
 }
 
-/** Build the primary ProposedEdit from the resolving agent's suggested edit. */
+/**
+ * Verbatim before/after snippet around a pure-insertion point, for apply-time
+ * drift validation (see applyProposedEdits.ts) — insertions have no target
+ * text to fingerprint, so this is the only signal that the surrounding
+ * document still looks like it did when the insertion was proposed.
+ */
+function captureInsertionContext(doc: PMNode, pos: number): { before: string; after: string } {
+  const from = Math.max(0, pos - INSERTION_CONTEXT_RADIUS)
+  const to = Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)
+  return { before: doc.textBetween(from, pos), after: doc.textBetween(pos, to) }
+}
+
+/**
+ * Build the primary ProposedEdit from the resolving agent's suggested edit.
+ * `doc` is only needed for pure insertions (from === to, targetText === '')
+ * to capture apply-time drift-validation context; omit it for replacements.
+ */
 export function primaryProposedEdit(
   edit: SuggestedEdit,
   targetText: string,
   blockId?: string,
+  doc?: PMNode,
 ): ProposedEdit {
+  const isInsertion = edit.from === edit.to && targetText === ''
   return {
     id: newId(),
     from: edit.from,
@@ -99,6 +123,7 @@ export function primaryProposedEdit(
     status: 'pending',
     targetText,
     ...(blockId ? { blockId } : {}),
+    ...(isInsertion && doc ? { insertionContext: captureInsertionContext(doc, edit.from) } : {}),
     // The primary edit is the user's own intent — always 'must', self-evidencing.
     severity: 'must',
     evidence: null,

--- a/src/lib/ai/orchestrator.ts
+++ b/src/lib/ai/orchestrator.ts
@@ -94,11 +94,27 @@ function newId(): string {
  * drift validation (see applyProposedEdits.ts) — insertions have no target
  * text to fingerprint, so this is the only signal that the surrounding
  * document still looks like it did when the insertion was proposed.
+ *
+ * `beforeSpan`/`afterSpan` record the actual POSITION distance each snippet
+ * was captured over (== INSERTION_CONTEXT_RADIUS, unless clamped by a nearby
+ * doc boundary at capture time). Apply-time validation re-derives its window
+ * from these recorded spans, not from a fresh `doc.content.size` clamp —
+ * otherwise an edit anywhere else in the document that changes the doc's
+ * total size (even far from `pos`) would grow or shrink the live window
+ * relative to what was captured and produce a spurious mismatch.
  */
-function captureInsertionContext(doc: PMNode, pos: number): { before: string; after: string } {
+export function captureInsertionContext(
+  doc: PMNode,
+  pos: number,
+): { before: string; after: string; beforeSpan: number; afterSpan: number } {
   const from = Math.max(0, pos - INSERTION_CONTEXT_RADIUS)
   const to = Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)
-  return { before: doc.textBetween(from, pos), after: doc.textBetween(pos, to) }
+  return {
+    before: doc.textBetween(from, pos),
+    after: doc.textBetween(pos, to),
+    beforeSpan: pos - from,
+    afterSpan: to - pos,
+  }
 }
 
 /**

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -124,7 +124,7 @@ async function attachCascadeEdits(
   if (!resolution.suggestedEdit) return
   const primaryBlockId =
     blockIdAtPos(editorState.doc, resolution.suggestedEdit.from) ?? undefined
-  const primary = primaryProposedEdit(resolution.suggestedEdit, anchorText, primaryBlockId)
+  const primary = primaryProposedEdit(resolution.suggestedEdit, anchorText, primaryBlockId, editorState.doc)
   // Graph-scoped: the dependency graph bounds what the model sees, so the old
   // whole-doc-truncated-to-6000-chars payload (which silently hid everything
   // past ~page 4) is gone. Long documents now cascade end to end.

--- a/src/lib/annotations/directEditCascade.ts
+++ b/src/lib/annotations/directEditCascade.ts
@@ -94,7 +94,7 @@ export async function runDirectEditCascade(
   // modal and can never re-apply the user's own edit — only the cascades are
   // live review subjects.
   const primary = {
-    ...primaryProposedEdit(primarySuggested, offer.blockText, offer.blockId),
+    ...primaryProposedEdit(primarySuggested, offer.blockText, offer.blockId, view.state.doc),
     status: 'rejected' as const,
   }
 

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -175,8 +175,13 @@ export interface ProposedEdit {
    * fingerprint-validate. This captures the verbatim text immediately
    * before/after the insertion point at proposal time, so apply-time code can
    * still detect drift instead of trivially accepting a stale position.
+   * `beforeSpan`/`afterSpan` are the position distance each snippet was
+   * captured over — apply-time validation re-derives its window from these,
+   * not from the live document size, so an edit elsewhere in the document
+   * that merely changes its total length can't spuriously invalidate an
+   * untouched insertion. See orchestrator.ts `captureInsertionContext`.
    */
-  insertionContext?: { before: string; after: string }
+  insertionContext?: { before: string; after: string; beforeSpan: number; afterSpan: number }
 }
 
 /**

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -170,6 +170,13 @@ export interface ProposedEdit {
   severity: CascadeSeverity
   /** null ⇒ the proposal has no locatable citation and can never be `must`. */
   evidence: CascadeEvidence | null
+  /**
+   * Pure insertions (targetText === '', from === to) have no target text to
+   * fingerprint-validate. This captures the verbatim text immediately
+   * before/after the insertion point at proposal time, so apply-time code can
+   * still detect drift instead of trivially accepting a stale position.
+   */
+  insertionContext?: { before: string; after: string }
 }
 
 /**

--- a/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
+++ b/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
@@ -9,7 +9,8 @@ import {
   setProposedEdits,
 } from '../plugins/proposedChangePlugin'
 import { applyProposedEdits } from '../applyProposedEdits'
-import { blockTextRange, INSERTION_CONTEXT_RADIUS } from '../blockIds'
+import { blockTextRange } from '../blockIds'
+import { captureInsertionContext } from '@/lib/ai/orchestrator'
 import type { ProposedEdit } from '@/lib/annotations/types'
 
 /**
@@ -137,19 +138,16 @@ describe('applyProposedEdits — no-op exclusion (M5)', () => {
  * alone always trivially passes. `insertionContext` (a verbatim before/after
  * snippet captured at proposal time) is the only apply-time drift signal for
  * them; a mismatch must abort the whole transaction like any other edit kind.
+ *
+ * Uses the real `captureInsertionContext` from orchestrator.ts (not a
+ * hand-rolled copy) so these tests exercise the actual capture logic, not a
+ * parallel implementation that could silently drift from it.
  */
-function captureCtx(doc: PMNode, pos: number): { before: string; after: string } {
-  return {
-    before: doc.textBetween(Math.max(0, pos - INSERTION_CONTEXT_RADIUS), pos),
-    after: doc.textBetween(pos, Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)),
-  }
-}
-
 describe('applyProposedEdits — insertion context drift (issue #40)', () => {
   it('a valid, unchanged insertion applies normally', () => {
     const view = mount(makeDoc())
     const insertPos = blockTextRange(view.state.doc, 'b1', 'beta')!.to // right after "beta", before " gamma"
-    const ctx = captureCtx(view.state.doc, insertPos)
+    const ctx = captureInsertionContext(view.state.doc, insertPos)
     const ins = edit({
       id: 'pe_insert',
       from: insertPos,
@@ -173,7 +171,7 @@ describe('applyProposedEdits — insertion context drift (issue #40)', () => {
   it('an insertion whose captured context no longer matches the live document is rejected', () => {
     const view = mount(makeDoc())
     const insertPos = blockTextRange(view.state.doc, 'b1', 'beta')!.to
-    const ctx = captureCtx(view.state.doc, insertPos)
+    const ctx = captureInsertionContext(view.state.doc, insertPos)
     const ins = edit({
       id: 'pe_insert',
       from: insertPos,
@@ -217,6 +215,39 @@ describe('applyProposedEdits — insertion context drift (issue #40)', () => {
       // No insertionContext — mirrors edits created before this field existed.
     })
     setProposedEdits(view, [ins])
+
+    const result = applyProposedEdits(view, ['pe_insert'])
+    expect(result.ok).toBe(true)
+  })
+
+  it('growing the document far from the insertion point does not invalidate an untouched insertion', () => {
+    // Regression for a window-clamping bug: re-deriving the validation window
+    // from a fresh `min(doc.content.size, pos + RADIUS)` clamp (instead of the
+    // captured beforeSpan/afterSpan) made it grow whenever the document's total
+    // size changed anywhere — even far from the insertion point — pulling in
+    // content that didn't exist at capture time and producing a false mismatch.
+    const view = mount(makeDoc())
+    const insertPos = blockTextRange(view.state.doc, 'b2', 'omega')!.to // end of the document's text
+    const ctx = captureInsertionContext(view.state.doc, insertPos)
+    // Clamped by the doc boundary at capture time: far less than the full radius.
+    expect(ctx.afterSpan).toBeLessThan(5)
+    const ins = edit({
+      id: 'pe_insert',
+      from: insertPos,
+      to: insertPos,
+      targetText: '',
+      newText: ' NEW',
+      relation: 'primary',
+      blockId: 'b2',
+      severity: 'must',
+      insertionContext: ctx,
+    })
+    setProposedEdits(view, [ins])
+
+    // Append a large new block AFTER the insertion point — grows the document's
+    // total size without touching anything the insertion's context captured.
+    const filler = p('b3', 'Z'.repeat(80))
+    view.dispatch(view.state.tr.insert(view.state.doc.content.size, filler))
 
     const result = applyProposedEdits(view, ['pe_insert'])
     expect(result.ok).toBe(true)

--- a/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
+++ b/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
@@ -9,6 +9,7 @@ import {
   setProposedEdits,
 } from '../plugins/proposedChangePlugin'
 import { applyProposedEdits } from '../applyProposedEdits'
+import { blockTextRange, INSERTION_CONTEXT_RADIUS } from '../blockIds'
 import type { ProposedEdit } from '@/lib/annotations/types'
 
 /**
@@ -127,5 +128,97 @@ describe('applyProposedEdits — no-op exclusion (M5)', () => {
     if (!result.ok) return
     expect(result.applied.map((a) => a.id)).toEqual(['pe_real'])
     expect(view.state.doc.textContent).toBe('ALTERED beta gammadelta beta OMEGA')
+  })
+})
+
+/**
+ * Regression suite for issue #40: pure insertions (targetText === '',
+ * from === to) have no target text to fingerprint, so the textBetween check
+ * alone always trivially passes. `insertionContext` (a verbatim before/after
+ * snippet captured at proposal time) is the only apply-time drift signal for
+ * them; a mismatch must abort the whole transaction like any other edit kind.
+ */
+function captureCtx(doc: PMNode, pos: number): { before: string; after: string } {
+  return {
+    before: doc.textBetween(Math.max(0, pos - INSERTION_CONTEXT_RADIUS), pos),
+    after: doc.textBetween(pos, Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)),
+  }
+}
+
+describe('applyProposedEdits — insertion context drift (issue #40)', () => {
+  it('a valid, unchanged insertion applies normally', () => {
+    const view = mount(makeDoc())
+    const insertPos = blockTextRange(view.state.doc, 'b1', 'beta')!.to // right after "beta", before " gamma"
+    const ctx = captureCtx(view.state.doc, insertPos)
+    const ins = edit({
+      id: 'pe_insert',
+      from: insertPos,
+      to: insertPos,
+      targetText: '',
+      newText: ' INSERTED',
+      relation: 'primary',
+      blockId: 'b1',
+      severity: 'must',
+      insertionContext: ctx,
+    })
+    setProposedEdits(view, [ins])
+
+    const result = applyProposedEdits(view, ['pe_insert'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.applied).toHaveLength(1)
+    expect(view.state.doc.textContent).toContain('beta INSERTED gamma')
+  })
+
+  it('an insertion whose captured context no longer matches the live document is rejected', () => {
+    const view = mount(makeDoc())
+    const insertPos = blockTextRange(view.state.doc, 'b1', 'beta')!.to
+    const ctx = captureCtx(view.state.doc, insertPos)
+    const ins = edit({
+      id: 'pe_insert',
+      from: insertPos,
+      to: insertPos,
+      targetText: '',
+      newText: ' INSERTED',
+      relation: 'primary',
+      blockId: 'b1',
+      severity: 'must',
+      insertionContext: ctx,
+    })
+    setProposedEdits(view, [ins])
+
+    // Mutate text elsewhere within the captured context window (but not at the
+    // insertion point itself) — the plugin still maps the anchor's position
+    // through the transaction, but the surrounding text it once matched changed.
+    const range = blockTextRange(view.state.doc, 'b1', 'alpha')!
+    view.dispatch(view.state.tr.replaceWith(range.from, range.to, view.state.schema.text('ALPHA')))
+    const before = view.state.doc
+
+    const result = applyProposedEdits(view, ['pe_insert'])
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toMatch(/surrounding text/i)
+    // Whole transaction aborted — nothing was dispatched to the document.
+    expect(view.state.doc.eq(before)).toBe(true)
+  })
+
+  it('an insertion with no captured context (legacy data) still applies unvalidated', () => {
+    const view = mount(makeDoc())
+    const insertPos = blockTextRange(view.state.doc, 'b1', 'beta')!.to
+    const ins = edit({
+      id: 'pe_insert',
+      from: insertPos,
+      to: insertPos,
+      targetText: '',
+      newText: ' INSERTED',
+      relation: 'primary',
+      blockId: 'b1',
+      severity: 'must',
+      // No insertionContext — mirrors edits created before this field existed.
+    })
+    setProposedEdits(view, [ins])
+
+    const result = applyProposedEdits(view, ['pe_insert'])
+    expect(result.ok).toBe(true)
   })
 })

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -1,6 +1,7 @@
 import type { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
 import { getProposedAnchors } from './plugins/proposedChangePlugin'
-import { blockTextRange, findTextInDoc } from './blockIds'
+import { blockTextRange, findTextInDoc, INSERTION_CONTEXT_RADIUS } from './blockIds'
 
 // Compat re-export: findTextInDoc moved to blockIds.ts (the proposedChange
 // plugin needs it for re-anchoring, and importing it from here would cycle).
@@ -40,6 +41,29 @@ export type ApplyProposedResult =
   | { ok: true; applied: AppliedEdit[] }
   | { ok: false; reason: string }
 
+/**
+ * True if the live text immediately before/after `pos` still matches the
+ * verbatim snippet captured when the insertion was proposed. Insertions have
+ * no target text to fingerprint-search for, so this is the only apply-time
+ * drift check available for them.
+ *
+ * The comparison window is derived from the same fixed INSERTION_CONTEXT_RADIUS
+ * position offset used at capture time (orchestrator.ts) — never from the
+ * captured string's length. Doc positions include non-character boundary slots
+ * at block edges, so a window crossing a block boundary yields a string shorter
+ * than the position delta that produced it; inverting length back into a
+ * position offset would silently misalign the window on every such crossing.
+ */
+function insertionContextMatches(
+  doc: PMNode,
+  pos: number,
+  ctx: { before: string; after: string },
+): boolean {
+  const from = Math.max(0, pos - INSERTION_CONTEXT_RADIUS)
+  const to = Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)
+  return doc.textBetween(from, pos) === ctx.before && doc.textBetween(pos, to) === ctx.after
+}
+
 export function applyProposedEdits(view: EditorView, acceptedIds: string[]): ApplyProposedResult {
   const anchors = getProposedAnchors(view.state)
   const doc = view.state.doc
@@ -62,11 +86,26 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
 
     const safeFrom = Math.min(a.from, doc.content.size)
     const safeTo = Math.min(a.to, doc.content.size)
-    const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
 
-    // Insertions (targetText:'' ⇒ from === to) trivially pass this check —
-    // they bypass fingerprint validation entirely (and render no decoration).
-    // Known limitation; do not rely on validation for insertion placement.
+    // Insertions (targetText:'' ⇒ from === to) have no target text to fingerprint,
+    // so the textBetween check below would trivially pass regardless of drift.
+    // Validate against the before/after context captured at proposal time instead;
+    // there is no fingerprint recovery for an insertion (nothing to search for), so
+    // a mismatch aborts the whole transaction — same fail-closed contract as every
+    // other edit kind. Edits from before this check existed carry no context and
+    // fall through unvalidated (unchanged legacy behavior).
+    if (safeFrom === safeTo && a.targetText === '') {
+      if (a.insertionContext && !insertionContextMatches(doc, safeFrom, a.insertionContext)) {
+        return {
+          ok: false,
+          reason: 'Could not safely place an insertion — the surrounding text has changed. Re-run the annotation.',
+        }
+      }
+      resolved.push({ id, from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
+      continue
+    }
+
+    const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
     if (current === a.targetText) {
       resolved.push({ id, from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
       continue

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -1,7 +1,7 @@
 import type { EditorView } from 'prosemirror-view'
 import type { Node as PMNode } from 'prosemirror-model'
 import { getProposedAnchors } from './plugins/proposedChangePlugin'
-import { blockTextRange, findTextInDoc, INSERTION_CONTEXT_RADIUS } from './blockIds'
+import { blockTextRange, findTextInDoc } from './blockIds'
 
 // Compat re-export: findTextInDoc moved to blockIds.ts (the proposedChange
 // plugin needs it for re-anchoring, and importing it from here would cycle).
@@ -47,20 +47,27 @@ export type ApplyProposedResult =
  * no target text to fingerprint-search for, so this is the only apply-time
  * drift check available for them.
  *
- * The comparison window is derived from the same fixed INSERTION_CONTEXT_RADIUS
- * position offset used at capture time (orchestrator.ts) — never from the
- * captured string's length. Doc positions include non-character boundary slots
- * at block edges, so a window crossing a block boundary yields a string shorter
- * than the position delta that produced it; inverting length back into a
- * position offset would silently misalign the window on every such crossing.
+ * The comparison window is re-derived from the RECORDED `beforeSpan`/`afterSpan`
+ * position distances (never from the captured strings' length, and never from
+ * a fresh doc-size-based radius clamp):
+ * - Length-based reconstruction breaks across block boundaries, where doc
+ *   positions include non-character slots that don't correspond to characters.
+ * - A fresh `min(doc.content.size, pos + RADIUS)` clamp breaks whenever the
+ *   document's total size changes between proposal and apply for ANY reason
+ *   (e.g. text typed far away, near the end of the doc) — the window would
+ *   silently grow or shrink to include content that didn't exist at capture
+ *   time, producing a spurious mismatch even though nothing near `pos` moved.
+ * Reusing the exact spans captured at proposal time keeps the window's SIZE
+ * stable; only its clamp to the live `doc.content.size` can shrink it, which
+ * is itself a correct drift signal (the document got shorter near `pos`).
  */
 function insertionContextMatches(
   doc: PMNode,
   pos: number,
-  ctx: { before: string; after: string },
+  ctx: { before: string; after: string; beforeSpan: number; afterSpan: number },
 ): boolean {
-  const from = Math.max(0, pos - INSERTION_CONTEXT_RADIUS)
-  const to = Math.min(doc.content.size, pos + INSERTION_CONTEXT_RADIUS)
+  const from = Math.max(0, pos - ctx.beforeSpan)
+  const to = Math.min(doc.content.size, pos + ctx.afterSpan)
   return doc.textBetween(from, pos) === ctx.before && doc.textBetween(pos, to) === ctx.after
 }
 

--- a/src/lib/prosemirror/blockIds.ts
+++ b/src/lib/prosemirror/blockIds.ts
@@ -5,6 +5,19 @@ import { BLOCK_ID_NODE_NAMES } from './schema'
 /** Node type names that carry a `blockId` attr. */
 export const BLOCK_ID_TYPES: ReadonlySet<string> = new Set(BLOCK_ID_NODE_NAMES)
 
+/**
+ * Position radius (not character count) used on both sides of a pure
+ * insertion's before/after drift-validation context — see
+ * ProposedEdit.insertionContext. Shared by the capture site (orchestrator.ts)
+ * and the apply-time check (applyProposedEdits.ts) so both derive their
+ * comparison window from the same fixed position offset rather than from the
+ * captured string's length: doc positions include non-character boundary
+ * slots at block edges, so a window that crosses a block boundary yields a
+ * string shorter than the position delta that produced it — inverting length
+ * back into a position offset would drift the window on every such crossing.
+ */
+export const INSERTION_CONTEXT_RADIUS = 40
+
 export interface BlockRef {
   blockId: string | null
   pos: number

--- a/src/lib/prosemirror/plugins/proposedChangePlugin.ts
+++ b/src/lib/prosemirror/plugins/proposedChangePlugin.ts
@@ -35,7 +35,7 @@ export interface ProposedAnchor {
   evidence: CascadeEvidence | null
   blockId?: string
   /** See ProposedEdit.insertionContext — apply-time drift check for insertions. */
-  insertionContext?: { before: string; after: string }
+  insertionContext?: { before: string; after: string; beforeSpan: number; afterSpan: number }
   /**
    * Flow-state hold flag (reveal-flag design): `false` means the anchor is
    * tracked, mapped, status-carrying, and APPLYABLE like any other — it just

--- a/src/lib/prosemirror/plugins/proposedChangePlugin.ts
+++ b/src/lib/prosemirror/plugins/proposedChangePlugin.ts
@@ -34,6 +34,8 @@ export interface ProposedAnchor {
   severity: CascadeSeverity
   evidence: CascadeEvidence | null
   blockId?: string
+  /** See ProposedEdit.insertionContext — apply-time drift check for insertions. */
+  insertionContext?: { before: string; after: string }
   /**
    * Flow-state hold flag (reveal-flag design): `false` means the anchor is
    * tracked, mapped, status-carrying, and APPLYABLE like any other — it just
@@ -159,6 +161,7 @@ export function createProposedChangePlugin(): Plugin {
                 severity: e.severity ?? (e.relation === 'primary' ? 'must' : 'probably'),
                 evidence: e.evidence ?? null,
                 blockId: e.blockId,
+                insertionContext: e.insertionContext,
                 revealed: !held.has(e.id),
               })
             }


### PR DESCRIPTION
## What

Pure-insertion proposed edits (`targetText === ''`, `from === to`) had no drift protection in `applyProposedEdits.ts`: the existing fingerprint check (`doc.textBetween(from, to) === targetText`) trivially passes for an empty target string regardless of whether the surrounding document has actually changed since the edit was proposed. Every other edit kind either validates cleanly or aborts the whole apply transaction on drift; insertions silently bypassed that entirely.

- `ProposedEdit` gains an optional `insertionContext: { before, after, beforeSpan, afterSpan }` — a verbatim text snippet captured immediately before/after the insertion point at proposal time (`orchestrator.ts`'s `primaryProposedEdit`, when `doc` is passed and the edit is a pure insertion).
- `applyProposedEdits.ts` re-derives the same window at apply time and requires both snippets to still match verbatim before applying; a mismatch aborts the **whole transaction**, matching the existing fail-closed contract for every other edit kind (no fingerprint recovery is possible for an insertion — there's no target text to search for).
- Edits created before this field existed (`insertionContext` absent) fall through unvalidated — unchanged legacy behavior, not a new failure mode.

## Why `beforeSpan`/`afterSpan` instead of a fixed radius or string length

Two bugs surfaced and got fixed during an adversarial review pass before this was pushed:

1. **Length-based reconstruction breaks across block boundaries.** ProseMirror doc positions include non-character boundary slots at block open/close, so a captured string's `.length` doesn't equal the position delta that produced it once the window crosses a block boundary. Fixed by using a fixed position-space radius (`INSERTION_CONTEXT_RADIUS`, `blockIds.ts`) shared between capture and validation — never inverting string length back into a position offset.
2. **A fresh `min(doc.content.size, pos ± RADIUS)` clamp at validate time is itself unstable.** If the document's total size changes for any reason between proposal and apply — even from an edit far away, unrelated to the insertion point — the live clamp silently grows or shrinks the comparison window relative to what was captured, producing a false-positive abort on an otherwise untouched insertion. Fixed by recording the actual `beforeSpan`/`afterSpan` position distance at capture time and reusing those exact spans at validate time, so the window's size can only shrink (a real drift signal) rather than grow from unrelated changes.

Both are covered by regression tests (see below); the second was caught by a spawned adversarial reviewer, not by the original test suite, before push.

## Also in this diff

- `directEditCascade.ts`'s `primaryProposedEdit` call site now passes `doc` through (it's currently always a guaranteed no-op there, so this was inert, but the reviewer flagged it as a silent regression trap if that invariant ever changes).
- Test suite now calls the real `captureInsertionContext` (exported from `orchestrator.ts`) instead of a hand-rolled copy, so tests exercise actual capture logic rather than a parallel implementation that could drift from it.

## Descoped (filed separately)

The same review found that the single-edit apply path (`ResolutionActions.tsx`'s `applyConfirmedEdit` when `resolution.edits.length <= 1`, and `ConversationThread.tsx`'s `handleApplyEdit`) never calls `applyProposedEdits` at all — it dispatches a raw `replaceWith` with **no** drift validation of any kind, not just no insertion-context check. This is a real, broader, pre-existing gap (affects every edit kind, not just insertions), but it's out of scope for this issue's done-means (narrowly scoped to `applyProposedEdits.ts`) and would substantially widen this diff. Filed as #42.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 753 passing + 10 skipped (was 752 baseline on `main`; +1 net after the review-fix commit added a 4th insertion test)
- `npm run build` — clean

Closes #40


---
_Generated by [Claude Code](https://claude.ai/code/session_01SeZ2L6X6Wqe3LjvVpV4x38)_