### PR TITLE
Validate single-suggestion edits against drift before applying them

### DIFF
--- a/src/components/Annotations/ConversationThread.tsx
+++ b/src/components/Annotations/ConversationThread.tsx
@@ -7,6 +7,7 @@ import { useChangesStore } from '@/stores/changesStore'
 import { generateId } from '@/lib/utils/id'
 import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
+import { refreshAnchorAfterApply } from '@/lib/annotations/anchoring'
 import { captureAndResolveInBackground } from '@/lib/voice/pipeline'
 import type { ConversationMessage, SuggestedEdit } from '@/lib/annotations/types'
 import { AgentMarkdown } from '@/components/ui/AgentMarkdown'
@@ -71,6 +72,12 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
       pmStep: null,
       undone: false,
     })
+
+    if (annotation) {
+      useAnnotationStore.getState().update(annotation.id, {
+        anchor: refreshAnchorAfterApply(annotation.anchor, applied),
+      })
+    }
   }
 
   return (

--- a/src/components/Annotations/ConversationThread.tsx
+++ b/src/components/Annotations/ConversationThread.tsx
@@ -5,7 +5,8 @@ import { useEditorStore } from '@/stores/editorStore'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
 import { generateId } from '@/lib/utils/id'
-import { AI_APPLY_META } from '@/lib/prosemirror/applyProposedEdits'
+import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
+import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { captureAndResolveInBackground } from '@/lib/voice/pipeline'
 import type { ConversationMessage, SuggestedEdit } from '@/lib/annotations/types'
 import { AgentMarkdown } from '@/components/ui/AgentMarkdown'
@@ -31,27 +32,42 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
   const handleApplyEdit = (edit: SuggestedEdit) => {
     if (!view) return
 
-    // AI_APPLY_META keeps the direct-edit cascade trigger from re-offering a
-    // cascade on this AI-driven per-message apply.
-    const tr = view.state.tr.replaceWith(
-      edit.from,
-      edit.to,
-      view.state.schema.text(edit.newText)
-    )
-    tr.setMeta(AI_APPLY_META, true)
-    view.dispatch(tr)
+    const annotation = useAnnotationStore.getState().getById(annotationId || '')
+
+    // Same fail-closed fingerprint/block-scoped-recovery validation the
+    // multi-region cascade path gets from applyProposedEdits — this
+    // per-message apply previously dispatched a raw, unvalidated replaceWith,
+    // so a document that changed since the edit was proposed (e.g. an earlier
+    // message in the same thread already applied) could silently misapply.
+    const result = applySingleEdit(view, {
+      id: annotationId || generateId(),
+      from: edit.from,
+      to: edit.to,
+      newText: edit.newText,
+      targetText: annotation?.anchor.text ?? '',
+      blockId: blockIdAtPos(view.state.doc, edit.from) ?? undefined,
+    })
+    if (!result.ok) {
+      useToastStore.getState().addToast(result.reason, 'error')
+      return
+    }
+    if (result.applied.length === 0) {
+      useToastStore.getState().addToast('No changes were needed — the text already matches', 'info')
+      return
+    }
+    const applied = result.applied[0]
 
     useChangesStore.getState().addEntry({
       id: generateId(),
-      documentId: useAnnotationStore.getState().getById(annotationId || '')?.documentId ?? 'unknown',
+      documentId: annotation?.documentId ?? 'unknown',
       rootAnnotationId: annotationId ?? null,
       annotationId: annotationId || '',
       timestamp: Date.now(),
       description: `Applied suggested edit from conversation`,
-      beforeSlice: '',
-      afterSlice: edit.newText,
-      from: edit.from,
-      to: edit.to,
+      beforeSlice: applied.targetText,
+      afterSlice: applied.newText,
+      from: applied.from,
+      to: applied.to,
       pmStep: null,
       undone: false,
     })

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -28,6 +28,7 @@ import {
 } from '@/lib/telemetry/modalDecisionBuffer'
 import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
+import { refreshAnchorAfterApply } from '@/lib/annotations/anchoring'
 import { createCommit } from '@/lib/history/commits'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
@@ -219,7 +220,19 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       if (changeSetId) {
         useChangesStore.getState().updateChangeSetStatus(changeSetId, 'approved')
       }
-      updateAnnotation(annotation.id, { status: 'applied' })
+      // Refresh the anchor to where the PRIMARY edit landed (if it was applied
+      // — a rejected/no-op primary leaves the original text untouched, so the
+      // anchor is still valid). Without this, a later per-message "Tweak it"
+      // apply (ConversationThread.handleApplyEdit) would validate its
+      // targetText against the now-stale pre-apply anchor.text and fail-closed
+      // on every legitimate reapply.
+      const appliedPrimary = result.applied.find((ap) =>
+        proposed.some((e) => e.id === ap.id && e.relation === 'primary'),
+      )
+      updateAnnotation(annotation.id, {
+        status: 'applied',
+        ...(appliedPrimary ? { anchor: refreshAnchorAfterApply(annotation.anchor, appliedPrimary) } : {}),
+      })
       // Every accepted edit may have been a no-op (applied is empty): the doc
       // did not change, so record no version commit and say so — a "0 changes"
       // success toast or an empty ledger commit would fabricate history.
@@ -313,7 +326,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       useChangesStore.getState().updateChangeSetStatus(changeSetId, 'approved')
     }
 
-    updateAnnotation(annotation.id, { status: 'applied' })
+    updateAnnotation(annotation.id, {
+      status: 'applied',
+      anchor: refreshAnchorAfterApply(annotation.anchor, applied),
+    })
     recordApplyCommit(applied.blockId ? [applied.blockId] : [])
 
     // Apply uncertainty highlights to the newly inserted text

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -19,7 +19,7 @@ import {
   restoreCommitReview,
   type CommitStatusSnapshot,
 } from '@/lib/annotations/commitStatusSnapshot'
-import { AI_APPLY_META, applyProposedEdits } from '@/lib/prosemirror/applyProposedEdits'
+import { AI_APPLY_META, applyProposedEdits, applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
 import { recordCascadeDecision } from '@/lib/telemetry/cascadeCalibration'
 import {
   createModalDecisionBuffer,
@@ -259,18 +259,39 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     const edit = annotation.resolution?.suggestedEdit
     if (!edit || !view) return
 
-    // Resolve the touched block before the positions shift under the apply.
-    const editedBlockId = blockIdAtPos(view.state.doc, edit.from)
-
-    // Apply the edit to the document. AI_APPLY_META keeps the direct-edit
-    // cascade trigger from re-offering a cascade on this AI-driven write.
-    const tr = view.state.tr.replaceWith(
-      edit.from,
-      edit.to,
-      view.state.schema.text(edit.newText)
-    )
-    tr.setMeta(AI_APPLY_META, true)
-    view.dispatch(tr)
+    // Same fail-closed fingerprint/block-scoped-recovery validation the
+    // multi-region path gets from applyProposedEdits — this single-suggestion
+    // path previously dispatched a raw, unvalidated replaceWith, so a document
+    // that changed since the edit was proposed could silently misapply.
+    const result = applySingleEdit(view, {
+      id: annotation.id,
+      from: edit.from,
+      to: edit.to,
+      newText: edit.newText,
+      targetText: annotation.anchor.text,
+      blockId: blockIdAtPos(view.state.doc, edit.from) ?? undefined,
+    })
+    if (!result.ok) {
+      pendingInvariantRef.current = null
+      useToastStore.getState().addToast(result.reason, 'error')
+      setShowDiffModal(false)
+      setPendingHandler(null)
+      return
+    }
+    if (result.applied.length === 0) {
+      // No-op: the target already matches newText — nothing was dispatched,
+      // so recording a version/change entry would fabricate history.
+      pendingInvariantRef.current = null
+      updateAnnotation(annotation.id, { status: 'applied' })
+      useToastStore.getState().addToast(
+        'No changes were needed — the text already matches',
+        'info',
+      )
+      setShowDiffModal(false)
+      setPendingHandler(null)
+      return
+    }
+    const applied = result.applied[0]
 
     // Record the change
     useChangesStore.getState().addEntry({
@@ -280,10 +301,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       annotationId: annotation.id,
       timestamp: Date.now(),
       description: `${annotation.type}: ${annotation.transcript.slice(0, 50)}`,
-      beforeSlice: annotation.anchor.text,
-      afterSlice: edit.newText,
-      from: edit.from,
-      to: edit.to,
+      beforeSlice: applied.targetText,
+      afterSlice: applied.newText,
+      from: applied.from,
+      to: applied.to,
       pmStep: null,
       undone: false,
     })
@@ -293,26 +314,26 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     }
 
     updateAnnotation(annotation.id, { status: 'applied' })
-    recordApplyCommit(editedBlockId ? [editedBlockId] : [])
+    recordApplyCommit(applied.blockId ? [applied.blockId] : [])
 
     // Apply uncertainty highlights to the newly inserted text
-    const newTo = edit.from + edit.newText.length
+    const newTo = applied.from + applied.newText.length
     if (annotation.resolution?.logprobs?.content) {
-      applyUncertaintyFromLogprobs(view, annotation.resolution.logprobs, edit.from, newTo)
+      applyUncertaintyFromLogprobs(view, annotation.resolution.logprobs, applied.from, newTo)
     } else if (annotation.resolution?.uncertaintyFlags?.length) {
-      applyUncertaintyFromFlags(view, annotation.resolution.uncertaintyFlags, edit.from, newTo)
+      applyUncertaintyFromFlags(view, annotation.resolution.uncertaintyFlags, applied.from, newTo)
     }
 
     // Ingest the edit into GraphRAG (non-blocking)
     ingestEditEpisode(
       annotation.id,
-      annotation.anchor.text,
-      edit.newText,
+      applied.targetText,
+      applied.newText,
       `${annotation.type}: ${annotation.transcript.slice(0, 50)}`,
     )
 
     // GraphRAG-powered cascade check (falls back to keyword if MCP unavailable)
-    runCascadeCheck(view, annotation.anchor.text, edit.newText, edit.from).then(
+    runCascadeCheck(view, applied.targetText, applied.newText, applied.from).then(
       (result) => {
         if (result.count > 0) {
           const source = result.usedGraphRAG ? 'knowledge graph' : 'keyword analysis'

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -220,19 +220,20 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       if (changeSetId) {
         useChangesStore.getState().updateChangeSetStatus(changeSetId, 'approved')
       }
-      // Refresh the anchor to where the PRIMARY edit landed (if it was applied
-      // — a rejected/no-op primary leaves the original text untouched, so the
-      // anchor is still valid). Without this, a later per-message "Tweak it"
-      // apply (ConversationThread.handleApplyEdit) would validate its
-      // targetText against the now-stale pre-apply anchor.text and fail-closed
-      // on every legitimate reapply.
-      const appliedPrimary = result.applied.find((ap) =>
-        proposed.some((e) => e.id === ap.id && e.relation === 'primary'),
-      )
-      updateAnnotation(annotation.id, {
-        status: 'applied',
-        ...(appliedPrimary ? { anchor: refreshAnchorAfterApply(annotation.anchor, appliedPrimary) } : {}),
-      })
+      // NOTE: the anchor is deliberately NOT refreshed here (unlike the
+      // single-edit path below). applyProposedEdits resolves every accepted
+      // edit's from/to against the PRE-transaction doc and returns those
+      // unmapped positions in `result.applied` — correct for the ledger
+      // entry above (an explicit "resolved old range" convention), but NOT a
+      // valid live position once other edits in the same batch, positioned
+      // earlier in the doc with a different replacement length, shift
+      // everything after them. Refreshing the anchor from `appliedPrimary`
+      // here would risk writing an out-of-bounds or wrong position onto the
+      // annotation. Filed as a follow-up (task: multi-region anchor refresh)
+      // — a real fix needs the primary's true post-apply position re-derived
+      // by fingerprint match against the live doc, not trusted from
+      // `result.applied`.
+      updateAnnotation(annotation.id, { status: 'applied' })
       // Every accepted edit may have been a no-op (applied is empty): the doc
       // did not change, so record no version commit and say so — a "0 changes"
       // success toast or an empty ledger commit would fabricate history.

--- a/src/lib/annotations/__tests__/anchoring.test.ts
+++ b/src/lib/annotations/__tests__/anchoring.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
+import { refreshAnchorAfterApply } from '../anchoring'
+import type { TextAnchor } from '../types'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+function makeDoc(): PMNode {
+  return schema.node('doc', null, [p('b1', 'alpha beta gamma')])
+}
+
+const views: EditorView[] = []
+
+function mount(doc: PMNode): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const state = EditorState.create({ schema, doc })
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      view.updateState(view.state.apply(transaction))
+    },
+  })
+  views.push(view)
+  return view
+}
+
+afterEach(() => {
+  while (views.length) views.pop()!.destroy()
+})
+
+describe('refreshAnchorAfterApply', () => {
+  it('re-anchors from/to/text to the applied edit, preserving scope', () => {
+    const anchor: TextAnchor = { from: 1, to: 17, scope: 'sentence', text: 'alpha beta gamma' }
+    const next = refreshAnchorAfterApply(anchor, { from: 1, to: 17, newText: 'ALPHA' })
+    expect(next).toEqual({ from: 1, to: 6, scope: 'sentence', text: 'ALPHA' })
+  })
+
+  it('re-anchors to a RECOVERED position, not the original from/to', () => {
+    const anchor: TextAnchor = { from: 1, to: 17, scope: 'sentence', text: 'alpha beta gamma' }
+    // Simulates a fingerprint-recovered apply that landed somewhere else.
+    const next = refreshAnchorAfterApply(anchor, { from: 30, to: 35, newText: 'OMEGA' })
+    expect(next).toEqual({ from: 30, to: 35, scope: 'sentence', text: 'OMEGA' })
+  })
+})
+
+/**
+ * #42 review finding: without refreshing `annotation.anchor` after a
+ * successful apply, a second apply on the same annotation (the "Tweak it"
+ * flow — ResolutionActions/ConversationThread both validate a re-apply's
+ * targetText against `annotation.anchor.text`) would fail-closed forever,
+ * because parseSuggestedEdit always derives a fresh suggestion's from/to from
+ * the annotation's anchor, and the SECOND apply's targetText would still be
+ * the FIRST apply's pre-apply text — already replaced in the live doc.
+ * This reproduces that two-apply sequence end to end through applySingleEdit
+ * + refreshAnchorAfterApply (the exact mechanism the two call sites use) to
+ * prove a tweak-and-reapply now succeeds instead of aborting.
+ */
+describe('applySingleEdit + refreshAnchorAfterApply — tweak-and-reapply sequence (#42)', () => {
+  it('a second apply succeeds when the anchor was refreshed after the first', () => {
+    const view = mount(makeDoc())
+    let anchor: TextAnchor = { from: 1, to: 17, scope: 'sentence', text: 'alpha beta gamma' }
+
+    const first = applySingleEdit(view, {
+      id: 'a',
+      from: anchor.from,
+      to: anchor.to,
+      newText: 'ALPHA BETA GAMMA',
+      targetText: anchor.text,
+      blockId: 'b1',
+    })
+    expect(first.ok).toBe(true)
+    if (!first.ok) return
+    anchor = refreshAnchorAfterApply(anchor, first.applied[0])
+    expect(view.state.doc.textContent).toBe('ALPHA BETA GAMMA')
+
+    // "Tweak it": parseSuggestedEdit derives the new suggestion's from/to from
+    // the (now-refreshed) anchor, and targetText is the (now-refreshed) anchor.text.
+    const second = applySingleEdit(view, {
+      id: 'a',
+      from: anchor.from,
+      to: anchor.to,
+      newText: 'ALPHA GAMMA',
+      targetText: anchor.text,
+      blockId: 'b1',
+    })
+    expect(second.ok).toBe(true)
+    if (!second.ok) return
+    expect(view.state.doc.textContent).toBe('ALPHA GAMMA')
+  })
+
+  it('WITHOUT the anchor refresh, the same second apply would fail-closed (regression guard)', () => {
+    const view = mount(makeDoc())
+    const staleAnchor: TextAnchor = { from: 1, to: 17, scope: 'sentence', text: 'alpha beta gamma' }
+
+    const first = applySingleEdit(view, {
+      id: 'a',
+      from: staleAnchor.from,
+      to: staleAnchor.to,
+      newText: 'ALPHA BETA GAMMA',
+      targetText: staleAnchor.text,
+      blockId: 'b1',
+    })
+    expect(first.ok).toBe(true)
+
+    // Deliberately reuse the STALE (pre-apply) anchor, as the code did before
+    // this fix — the live doc no longer contains 'alpha beta gamma'.
+    const second = applySingleEdit(view, {
+      id: 'a',
+      from: staleAnchor.from,
+      to: staleAnchor.to,
+      newText: 'ALPHA GAMMA',
+      targetText: staleAnchor.text,
+      blockId: 'b1',
+    })
+    expect(second.ok).toBe(false)
+  })
+})

--- a/src/lib/annotations/anchoring.ts
+++ b/src/lib/annotations/anchoring.ts
@@ -13,6 +13,25 @@ export function createAnchor(
   return { from, to, scope, text }
 }
 
+/**
+ * Re-anchors a TextAnchor to where an applied edit actually landed.
+ *
+ * `parseSuggestedEdit` always derives a fresh SUGGESTED EDIT's from/to from
+ * `annotation.anchor`, and every apply path validates that suggestion's
+ * targetText against `annotation.anchor.text` (applyProposedEdits.ts's
+ * fingerprint check) before dispatching. An annotation whose anchor never
+ * moves past its FIRST successful apply would have every later re-apply on
+ * the same thread ("Tweak it", a further per-message edit) validate against
+ * stale pre-apply text and fail-closed. `scope` is preserved — an apply never
+ * changes what range-expansion mode the annotation was created with.
+ */
+export function refreshAnchorAfterApply(
+  anchor: TextAnchor,
+  applied: { from: number; to: number; newText: string },
+): TextAnchor {
+  return { ...anchor, from: applied.from, to: applied.from + applied.newText.length, text: applied.newText }
+}
+
 // Expand a selection to its full scope
 export function expandToScope(
   state: EditorState,

--- a/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
+++ b/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
@@ -8,7 +8,7 @@ import {
   createProposedChangePlugin,
   setProposedEdits,
 } from '../plugins/proposedChangePlugin'
-import { applyProposedEdits } from '../applyProposedEdits'
+import { applyProposedEdits, applySingleEdit } from '../applyProposedEdits'
 import type { ProposedEdit } from '@/lib/annotations/types'
 
 /**
@@ -127,5 +127,98 @@ describe('applyProposedEdits — no-op exclusion (M5)', () => {
     if (!result.ok) return
     expect(result.applied.map((a) => a.id)).toEqual(['pe_real'])
     expect(view.state.doc.textContent).toBe('ALTERED beta gammadelta beta OMEGA')
+  })
+})
+
+/**
+ * #42: the single-suggestion apply paths (ResolutionActions.applyConfirmedEdit's
+ * fallback, ConversationThread.handleApplyEdit) never went through
+ * applyProposedEdits at all — a raw, unvalidated replaceWith with no re-check
+ * that the live doc still matched what was proposed. applySingleEdit gives
+ * those call sites the identical fail-closed fingerprint/block-scoped-recovery
+ * contract, for one ad-hoc edit that isn't registered in the plugin's anchors.
+ */
+describe('applySingleEdit — drift validation for the single-suggestion apply path (#42)', () => {
+  it('applies cleanly when the live range still matches targetText', () => {
+    const view = mount(makeDoc())
+    const before = view.state.doc
+
+    const result = applySingleEdit(view, {
+      id: 'single_1',
+      from: 1,
+      to: 17,
+      newText: 'ALPHA BETA GAMMA',
+      targetText: 'alpha beta gamma',
+      blockId: 'b1',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.applied).toHaveLength(1)
+    expect(result.applied[0]).toMatchObject({ id: 'single_1', from: 1, to: 17, newText: 'ALPHA BETA GAMMA' })
+    expect(view.state.doc.textContent).toBe('ALPHA BETA GAMMAdelta beta omega')
+    expect(view.state.doc.eq(before)).toBe(false)
+  })
+
+  it('recovers by block-scoped fingerprint when the stored range has drifted', () => {
+    const view = mount(makeDoc())
+    // "omega" really lives at 30..35 in b2, but the caller's stored range is
+    // stale (e.g. an earlier apply in the same session shifted positions) —
+    // this mirrors the applyProposedEdits recovery path, now exercised for a
+    // single ad-hoc edit with no plugin anchor to remap it.
+    const result = applySingleEdit(view, {
+      id: 'single_2',
+      from: 0,
+      to: 0,
+      newText: 'OMEGA',
+      targetText: 'omega',
+      blockId: 'b2',
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.applied[0]).toMatchObject({ from: 30, to: 35, newText: 'OMEGA' })
+    expect(view.state.doc.textContent).toBe('alpha beta gammadelta beta OMEGA')
+  })
+
+  it('aborts — never misapplies — when targetText can no longer be found anywhere', () => {
+    const view = mount(makeDoc())
+    const before = view.state.doc
+    const dispatchesBefore = dispatchCount
+
+    const result = applySingleEdit(view, {
+      id: 'single_3',
+      from: 1,
+      to: 17,
+      newText: 'REPLACEMENT',
+      targetText: 'this text was never in the document',
+      blockId: 'b1',
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toMatch(/could not safely place/i)
+    // Fail-closed: no partial/wrong-range mutation, no dispatch at all.
+    expect(view.state.doc.eq(before)).toBe(true)
+    expect(dispatchCount).toBe(dispatchesBefore)
+  })
+
+  it('a no-op (targetText === newText) applies nothing and dispatches nothing', () => {
+    const view = mount(makeDoc())
+    const before = view.state.doc
+    const dispatchesBefore = dispatchCount
+
+    const result = applySingleEdit(view, {
+      id: 'single_4',
+      from: 1,
+      to: 17,
+      newText: 'alpha beta gamma',
+      targetText: 'alpha beta gamma',
+      blockId: 'b1',
+    })
+
+    expect(result).toEqual({ ok: true, applied: [] })
+    expect(view.state.doc.eq(before)).toBe(true)
+    expect(dispatchCount).toBe(dispatchesBefore)
   })
 })

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -1,4 +1,5 @@
 import type { EditorView } from 'prosemirror-view'
+import type { Node as PMNode } from 'prosemirror-model'
 import { getProposedAnchors } from './plugins/proposedChangePlugin'
 import { blockTextRange, findTextInDoc } from './blockIds'
 
@@ -40,6 +41,49 @@ export type ApplyProposedResult =
   | { ok: true; applied: AppliedEdit[] }
   | { ok: false; reason: string }
 
+interface PendingRange {
+  from: number
+  to: number
+  targetText: string
+  blockId?: string | null
+}
+
+/**
+ * Validates one edit's range against the live doc: unchanged → use it as-is;
+ * drifted → recover by fingerprint match (block-scoped first, when known).
+ * Shared by the batched (plugin-anchored) and single ad-hoc apply paths so
+ * both get the identical fail-closed contract.
+ */
+function resolveEditRange(
+  doc: PMNode,
+  edit: PendingRange,
+): { ok: true; from: number; to: number } | { ok: false; reason: string } {
+  const safeFrom = Math.min(edit.from, doc.content.size)
+  const safeTo = Math.min(edit.to, doc.content.size)
+  const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
+
+  // Insertions (targetText:'' ⇒ from === to) trivially pass this check —
+  // they bypass fingerprint validation entirely (and render no decoration).
+  // Known limitation; do not rely on validation for insertion placement.
+  if (current === edit.targetText) {
+    return { ok: true, from: safeFrom, to: safeTo }
+  }
+
+  // Range drifted — recover by fingerprint match on the expected text,
+  // scoped to the edit's block when we know it (a phrase repeated in two
+  // blocks must not silently recover into the wrong one).
+  const found =
+    (edit.blockId ? blockTextRange(doc, edit.blockId, edit.targetText) : null) ??
+    findTextInDoc(doc, edit.targetText)
+  if (!found) {
+    return {
+      ok: false,
+      reason: `Could not safely place an edit — the text "${edit.targetText.slice(0, 40)}…" has changed. Re-run the annotation.`,
+    }
+  }
+  return { ok: true, from: found.from, to: found.to }
+}
+
 export function applyProposedEdits(view: EditorView, acceptedIds: string[]): ApplyProposedResult {
   const anchors = getProposedAnchors(view.state)
   const doc = view.state.doc
@@ -60,31 +104,9 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
     // failure — accepting one is harmless.
     if (a.targetText === a.newText) continue
 
-    const safeFrom = Math.min(a.from, doc.content.size)
-    const safeTo = Math.min(a.to, doc.content.size)
-    const current = safeFrom <= safeTo ? doc.textBetween(safeFrom, safeTo) : ''
-
-    // Insertions (targetText:'' ⇒ from === to) trivially pass this check —
-    // they bypass fingerprint validation entirely (and render no decoration).
-    // Known limitation; do not rely on validation for insertion placement.
-    if (current === a.targetText) {
-      resolved.push({ id, from: safeFrom, to: safeTo, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
-      continue
-    }
-
-    // Range drifted — recover by fingerprint match on the expected text,
-    // scoped to the edit's block when we know it (a phrase repeated in two
-    // blocks must not silently recover into the wrong one).
-    const found =
-      (a.blockId ? blockTextRange(doc, a.blockId, a.targetText) : null) ??
-      findTextInDoc(doc, a.targetText)
-    if (!found) {
-      return {
-        ok: false,
-        reason: `Could not safely place an edit — the text "${a.targetText.slice(0, 40)}…" has changed. Re-run the annotation.`,
-      }
-    }
-    resolved.push({ id, from: found.from, to: found.to, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
+    const range = resolveEditRange(doc, a)
+    if (!range.ok) return range
+    resolved.push({ id, from: range.from, to: range.to, newText: a.newText, targetText: a.targetText, blockId: a.blockId ?? null })
   }
 
   // All accepted ids were no-ops → nothing to dispatch, nothing applied.
@@ -102,4 +124,53 @@ export function applyProposedEdits(view: EditorView, acceptedIds: string[]): App
   view.dispatch(tr)
 
   return { ok: true, applied: resolved }
+}
+
+export interface AdHocEdit {
+  /** Caller-supplied id — lets callers attribute change entries/ledger rows. */
+  id: string
+  from: number
+  to: number
+  newText: string
+  /** Verbatim text this edit expects to replace, captured at proposal time. */
+  targetText: string
+  blockId?: string | null
+}
+
+/**
+ * Validates and applies a SINGLE edit that is not registered in the
+ * proposedChange plugin — the common single-suggestion resolution path
+ * (`ResolutionActions.applyConfirmedEdit`) and per-message conversation-thread
+ * edits (`ConversationThread.handleApplyEdit`), neither of which run a
+ * cascade batch through `applyProposedEdits`. Same fail-closed fingerprint /
+ * block-scoped-recovery contract as the batched path, scoped to one edit, so
+ * a document that changed since the edit was proposed aborts instead of
+ * silently misapplying.
+ */
+export function applySingleEdit(view: EditorView, edit: AdHocEdit): ApplyProposedResult {
+  // No-op (targetText === newText): nothing to validate or apply — matches
+  // the batched path's convention that a non-change is never dispatched or
+  // recorded.
+  if (edit.targetText === edit.newText) return { ok: true, applied: [] }
+
+  const range = resolveEditRange(view.state.doc, edit)
+  if (!range.ok) return range
+
+  const applied: AppliedEdit = {
+    id: edit.id,
+    from: range.from,
+    to: range.to,
+    newText: edit.newText,
+    targetText: edit.targetText,
+    blockId: edit.blockId ?? null,
+  }
+
+  let tr = view.state.tr
+  tr.setMeta(AI_APPLY_META, true)
+  tr = edit.newText
+    ? tr.replaceWith(applied.from, applied.to, view.state.schema.text(edit.newText))
+    : tr.delete(applied.from, applied.to)
+  view.dispatch(tr)
+
+  return { ok: true, applied: [applied] }
 }

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -1,7 +1,7 @@
 import type { EditorView } from 'prosemirror-view'
 import type { Node as PMNode } from 'prosemirror-model'
 import { getProposedAnchors } from './plugins/proposedChangePlugin'
-import { blockTextRange, findTextInDoc } from './blockIds'
+import { blockIdAtPos, blockTextRange, findTextInDoc } from './blockIds'
 
 // Compat re-export: findTextInDoc moved to blockIds.ts (the proposedChange
 // plugin needs it for re-anchoring, and importing it from here would cycle).
@@ -153,8 +153,17 @@ export function applySingleEdit(view: EditorView, edit: AdHocEdit): ApplyPropose
   // recorded.
   if (edit.targetText === edit.newText) return { ok: true, applied: [] }
 
-  const range = resolveEditRange(view.state.doc, edit)
+  const doc = view.state.doc
+  const range = resolveEditRange(doc, edit)
   if (!range.ok) return range
+
+  // Recompute blockId from where the edit actually landed rather than
+  // trusting the caller's pre-resolution guess: unlike the plugin-anchored
+  // batched path (whose blockId was captured at proposal time), this ad-hoc
+  // caller's blockId is a live guess at the ORIGINAL (possibly stale) `from`
+  // — wrong or null if that guess missed, which would otherwise misattribute
+  // the ledger/GraphRAG record to the wrong block.
+  const landedBlockId = blockIdAtPos(doc, range.from) ?? edit.blockId ?? null
 
   const applied: AppliedEdit = {
     id: edit.id,
@@ -162,7 +171,7 @@ export function applySingleEdit(view: EditorView, edit: AdHocEdit): ApplyPropose
     to: range.to,
     newText: edit.newText,
     targetText: edit.targetText,
-    blockId: edit.blockId ?? null,
+    blockId: landedBlockId,
   }
 
   let tr = view.state.tr


### PR DESCRIPTION
## What

`ResolutionActions.tsx`'s `applyConfirmedEdit` (the fallback taken whenever a resolution has 0 or 1 edits — the common case for a resolution with no cascades) and `ConversationThread.tsx`'s `handleApplyEdit` (per-message conversation apply) both dispatched a raw, unvalidated `view.state.tr.replaceWith(edit.from, edit.to, ...)` with zero check that the live document at `[from, to)` still matched what the model saw when it proposed the edit. This is the exact drift failure the existing multi-region path (`applyProposedEdits.ts`) already guards against via fingerprint validation + block-scoped recovery + fail-closed abort — it just was never reachable from these two single-edit call sites.

- Extracts the existing per-edit range-validation/recovery logic out of `applyProposedEdits`'s loop into a shared `resolveEditRange(doc, edit)` helper (behavior-preserving for the existing batched path — verified line-by-line against the pre-diff loop).
- Adds `applySingleEdit(view, edit)`, which both call sites now route through instead of a bare `replaceWith`. A drifted, unrecoverable edit aborts with a toast instead of silently misapplying; downstream change-entry/version-commit/uncertainty-highlight/GraphRAG/cascade-check code reads the resolved (possibly fingerprint-recovered) position instead of the stale proposal-time one.
- `applySingleEdit` attributes the applied edit's `blockId` to where it actually landed (recomputed via `blockIdAtPos` on the resolved position) rather than the caller's pre-resolution guess, so ledger/GraphRAG records aren't misattributed to the wrong block.

## Process record — two rounds of pre-push adversarial (troublemaker) review, both real findings fixed

**Round 1 (NO-MERGE):** one HIGH finding. `annotation.anchor` (the `TextAnchor` captured once when the annotation was created) was never refreshed anywhere after a successful apply. Because `parseSuggestedEdit` always derives a fresh "Tweak it" suggestion's `from`/`to` from `annotation.anchor`, and the new validation gate checks a re-apply's `targetText` against `annotation.anchor.text`, every re-apply after the first successful one on a given annotation would fail-closed against now-replaced text — a regression the new drift gate itself introduced (the old raw `replaceWith` had no such check, so it "worked" only by accident). Fixed by adding `refreshAnchorAfterApply()` (`src/lib/annotations/anchoring.ts`) and calling it from both single-edit apply paths after a successful, non-no-op apply.

**Round 2 (NO-MERGE):** verified round 1's fix closes the reported scenario for the single-edit path (traced end-to-end, not just trusted the new test), but found the round-1 fix *also* wired the same anchor refresh into the multi-region cascade-batch branch, using positions (`result.applied[].from/to`) that `applyProposedEdits` resolves against the **pre-transaction** doc — not valid live positions once other edits in the same batch, positioned earlier with a different replacement length, shift everything after them. Reproduced concretely: a batch mixing a big earlier-block shrink with a later-block primary edit reported an out-of-bounds position for the primary once the earlier edit's length delta was accounted for. **Descoped**: the multi-region anchor refresh is dropped from this PR (left as a documented no-op with an in-code explanation) and filed separately as #44 with its own done-means (re-derive the true post-transaction position by fingerprint match, don't trust `result.applied`). The single-edit fix this PR actually delivers is unaffected — its resolved position is always correct since there's nothing else in the transaction to shift it.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 757 passing + 10 skipped (was 749 baseline on `main`; +8 new: 4 in `applyProposedEdits.test.ts` covering `applySingleEdit`'s clean-apply/recovery/abort/no-op cases, 4 in new `src/lib/annotations/__tests__/anchoring.test.ts` covering `refreshAnchorAfterApply` and an end-to-end tweak-and-reapply sequence, including a regression guard proving the *pre-fix* shape would fail)
- [x] `npm run build` — clean
- [x] Two rounds of pre-push adversarial (troublemaker) review completed; the HIGH finding from round 1 fixed, the HIGH finding from round 2 resolved by descoping (not by shipping a wrong fix) and filed as #44

Closes #42

---
_Generated by [Claude Code](https://claude.ai/code/session_01KChpXpauRHByWDRmcYy9bQ)_