### PR TITLE
Refresh multi-region primary anchor to its true post-transaction position

### DIFF
--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/lib/telemetry/modalDecisionBuffer'
 import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
-import { refreshAnchorAfterApply } from '@/lib/annotations/anchoring'
+import { refreshAnchorAfterApply, refreshedAnchorForMultiRegionApply } from '@/lib/annotations/anchoring'
 import { createCommit } from '@/lib/history/commits'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
@@ -220,20 +220,23 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
       if (changeSetId) {
         useChangesStore.getState().updateChangeSetStatus(changeSetId, 'approved')
       }
-      // NOTE: the anchor is deliberately NOT refreshed here (unlike the
-      // single-edit path below). applyProposedEdits resolves every accepted
-      // edit's from/to against the PRE-transaction doc and returns those
-      // unmapped positions in `result.applied` — correct for the ledger
-      // entry above (an explicit "resolved old range" convention), but NOT a
-      // valid live position once other edits in the same batch, positioned
-      // earlier in the doc with a different replacement length, shift
-      // everything after them. Refreshing the anchor from `appliedPrimary`
-      // here would risk writing an out-of-bounds or wrong position onto the
-      // annotation. Filed as a follow-up (task: multi-region anchor refresh)
-      // — a real fix needs the primary's true post-apply position re-derived
-      // by fingerprint match against the live doc, not trusted from
-      // `result.applied`.
-      updateAnnotation(annotation.id, { status: 'applied' })
+      // Refresh the primary edit's anchor to its TRUE post-transaction
+      // position — mirrors the single-edit path below (see
+      // refreshedAnchorForMultiRegionApply's doc comment for why
+      // result.applied's own position can't be trusted for anything but the
+      // lowest-`from` edit in the batch — #44). Returns undefined for a
+      // missing/rejected/no-op/pure-deletion primary; the anchor is then
+      // left unrefreshed, matching today's behavior rather than risking a
+      // wrong or empty-text anchor.
+      const refreshedAnchor = refreshedAnchorForMultiRegionApply(
+        annotation.anchor,
+        proposed,
+        result.applied,
+      )
+      updateAnnotation(annotation.id, {
+        status: 'applied',
+        ...(refreshedAnchor ? { anchor: refreshedAnchor } : {}),
+      })
       // Every accepted edit may have been a no-op (applied is empty): the doc
       // did not change, so record no version commit and say so — a "0 changes"
       // success toast or an empty ledger commit would fabricate history.

--- a/src/lib/annotations/__tests__/anchoring.test.ts
+++ b/src/lib/annotations/__tests__/anchoring.test.ts
@@ -5,8 +5,9 @@ import { EditorView } from 'prosemirror-view'
 import type { Node as PMNode } from 'prosemirror-model'
 import { schema } from '@/lib/prosemirror/schema'
 import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
-import { refreshAnchorAfterApply } from '../anchoring'
-import type { TextAnchor } from '../types'
+import { refreshAnchorAfterApply, refreshedAnchorForMultiRegionApply } from '../anchoring'
+import type { TextAnchor, ProposedEdit } from '../types'
+import type { AppliedEdit } from '@/lib/prosemirror/applyProposedEdits'
 
 function p(blockId: string, text: string): PMNode {
   return schema.node('paragraph', { blockId }, [schema.text(text)])
@@ -48,6 +49,81 @@ describe('refreshAnchorAfterApply', () => {
     // Simulates a fingerprint-recovered apply that landed somewhere else.
     const next = refreshAnchorAfterApply(anchor, { from: 30, to: 35, newText: 'OMEGA' })
     expect(next).toEqual({ from: 30, to: 35, scope: 'sentence', text: 'OMEGA' })
+  })
+})
+
+function proposedEdit(overrides: Partial<ProposedEdit> & { id: string }): ProposedEdit {
+  return {
+    from: 0,
+    to: 0,
+    newText: '',
+    reason: 'test',
+    relation: 'cascade',
+    status: 'pending',
+    targetText: '',
+    severity: 'probably',
+    evidence: null,
+    ...overrides,
+  }
+}
+
+function appliedEdit(overrides: Partial<AppliedEdit> & { id: string }): AppliedEdit {
+  return { from: 0, to: 0, newText: '', targetText: '', ...overrides }
+}
+
+/**
+ * #44 (review round 2): the multi-region apply's anchor refresh, extracted
+ * to one pure function so the actual apply-time WIRING (finding the applied
+ * primary among a mixed proposed/applied batch, and only refreshing for a
+ * real, applicable primary) has direct regression coverage — not just the
+ * underlying position arithmetic (`findAppliedEditFinalPosition`, covered
+ * separately in applyProposedEdits.test.ts).
+ */
+describe('refreshedAnchorForMultiRegionApply', () => {
+  const anchor: TextAnchor = { from: 5, to: 9, scope: 'phrase', text: 'beta' }
+
+  it('refreshes the anchor to the primary edit true final position, shifted by an earlier cascade', () => {
+    const proposed = [
+      proposedEdit({ id: 'primary_1', relation: 'primary', newText: 'B' }),
+      proposedEdit({ id: 'cascade_1', relation: 'cascade', newText: 'X' }),
+    ]
+    // primary at from=22 (pre-transaction); an earlier cascade (from=1..14,
+    // newText 'X') shrinks the doc by 12 before it — true position is 10.
+    const appliedEdits = [
+      appliedEdit({ id: 'primary_1', from: 22, to: 26, newText: 'B' }),
+      appliedEdit({ id: 'cascade_1', from: 1, to: 14, newText: 'X' }),
+    ]
+    const next = refreshedAnchorForMultiRegionApply(anchor, proposed, appliedEdits)
+    expect(next).toEqual({ from: 10, to: 11, scope: 'phrase', text: 'B' })
+  })
+
+  it('returns undefined when no proposed edit is tagged relation: primary', () => {
+    const proposed = [proposedEdit({ id: 'cascade_1', relation: 'cascade', newText: 'X' })]
+    const appliedEdits = [appliedEdit({ id: 'cascade_1', from: 1, to: 14, newText: 'X' })]
+    expect(refreshedAnchorForMultiRegionApply(anchor, proposed, appliedEdits)).toBeUndefined()
+  })
+
+  it('returns undefined when the primary was rejected (not in appliedEdits)', () => {
+    const proposed = [
+      proposedEdit({ id: 'primary_1', relation: 'primary', newText: 'B' }),
+      proposedEdit({ id: 'cascade_1', relation: 'cascade', newText: 'X' }),
+    ]
+    // Only the cascade was accepted/applied — the primary is absent.
+    const appliedEdits = [appliedEdit({ id: 'cascade_1', from: 1, to: 14, newText: 'X' })]
+    expect(refreshedAnchorForMultiRegionApply(anchor, proposed, appliedEdits)).toBeUndefined()
+  })
+
+  it('returns undefined when the primary was a no-op (excluded from appliedEdits by applyProposedEdits)', () => {
+    const proposed = [proposedEdit({ id: 'primary_1', relation: 'primary', newText: 'beta' })]
+    // applyProposedEdits already excludes no-ops (targetText === newText)
+    // from `applied` — simulated here by an empty appliedEdits array.
+    expect(refreshedAnchorForMultiRegionApply(anchor, proposed, [])).toBeUndefined()
+  })
+
+  it('returns undefined for a pure-deletion primary — no text to validate a future re-apply against', () => {
+    const proposed = [proposedEdit({ id: 'primary_1', relation: 'primary', newText: '' })]
+    const appliedEdits = [appliedEdit({ id: 'primary_1', from: 5, to: 9, newText: '' })]
+    expect(refreshedAnchorForMultiRegionApply(anchor, proposed, appliedEdits)).toBeUndefined()
   })
 })
 

--- a/src/lib/annotations/anchoring.ts
+++ b/src/lib/annotations/anchoring.ts
@@ -1,6 +1,7 @@
 import { EditorState } from 'prosemirror-state'
 import { inferScope } from '@/lib/prosemirror/helpers'
-import type { TextAnchor, Scope } from './types'
+import { findAppliedEditFinalPosition, type AppliedEdit } from '@/lib/prosemirror/applyProposedEdits'
+import type { TextAnchor, Scope, ProposedEdit } from './types'
 
 export function createAnchor(
   state: EditorState,
@@ -30,6 +31,37 @@ export function refreshAnchorAfterApply(
   applied: { from: number; to: number; newText: string },
 ): TextAnchor {
   return { ...anchor, from: applied.from, to: applied.from + applied.newText.length, text: applied.newText }
+}
+
+/**
+ * Refreshes `anchor` after a multi-region (`applyProposedEdits`) batch apply,
+ * to the PRIMARY edit's true post-transaction position — mirrors the
+ * single-edit `refreshAnchorAfterApply` call sites, extracted into one pure,
+ * directly-testable function (no view/doc dependency — see
+ * `findAppliedEditFinalPosition`'s doc comment for why arithmetic over the
+ * batch's own deltas, not a doc fingerprint search, derives that position)
+ * so the actual apply-time wiring in ResolutionActions.tsx has real
+ * regression coverage, not just the underlying position math (#44 review).
+ *
+ * Returns undefined (anchor left untouched) when: no edit in `proposed` is
+ * tagged `relation: 'primary'`; the primary wasn't in `appliedEdits` (it was
+ * rejected, or excluded as a no-op — `targetText === newText` — by
+ * `applyProposedEdits`); or the primary was a pure deletion (`newText===''`
+ * — no text for a future re-apply's fingerprint check to validate against,
+ * so refreshing here would let that check trivially pass on stale content,
+ * same reasoning as why insertions can't be fingerprint-validated).
+ */
+export function refreshedAnchorForMultiRegionApply(
+  anchor: TextAnchor,
+  proposed: ProposedEdit[],
+  appliedEdits: AppliedEdit[],
+): TextAnchor | undefined {
+  const appliedPrimary = appliedEdits.find(
+    (ap) => proposed.find((e) => e.id === ap.id)?.relation === 'primary',
+  )
+  if (!appliedPrimary || !appliedPrimary.newText) return undefined
+  const { from, to } = findAppliedEditFinalPosition(appliedPrimary, appliedEdits)
+  return refreshAnchorAfterApply(anchor, { from, to, newText: appliedPrimary.newText })
 }
 
 // Expand a selection to its full scope

--- a/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
+++ b/src/lib/prosemirror/__tests__/applyProposedEdits.test.ts
@@ -8,7 +8,12 @@ import {
   createProposedChangePlugin,
   setProposedEdits,
 } from '../plugins/proposedChangePlugin'
-import { applyProposedEdits, applySingleEdit } from '../applyProposedEdits'
+import {
+  applyProposedEdits,
+  applySingleEdit,
+  findAppliedEditFinalPosition,
+  findTextInDoc,
+} from '../applyProposedEdits'
 import type { ProposedEdit } from '@/lib/annotations/types'
 
 /**
@@ -127,6 +132,139 @@ describe('applyProposedEdits — no-op exclusion (M5)', () => {
     if (!result.ok) return
     expect(result.applied.map((a) => a.id)).toEqual(['pe_real'])
     expect(view.state.doc.textContent).toBe('ALTERED beta gammadelta beta OMEGA')
+  })
+})
+
+/**
+ * #44: `AppliedEdit.from/to` (as returned in `result.applied`) are the
+ * positions passed to `tr.replaceWith` at DISPATCH time — valid post-
+ * transaction only for the lowest-`from` edit in the batch, since edits
+ * dispatch descending by `from` and that one lands last. Any other edit's
+ * `AppliedEdit` position can be shifted by a different-length edit at a
+ * lower position applied after it. `findAppliedEditFinalPosition` re-derives
+ * the TRUE final position by ARITHMETIC over the batch's own deltas — a
+ * fingerprint-search-based first attempt was rejected on review because a
+ * short/common `newText` (a single corrected word or character) can
+ * coincidentally match pre-existing text elsewhere in the same block,
+ * silently returning the WRONG occurrence.
+ */
+describe('findAppliedEditFinalPosition — true post-transaction position, by arithmetic not text search (#44)', () => {
+  // b1 'one two three' (13 chars) at 1..14; b2 'alpha beta gamma' (16 chars)
+  // at 16..32.
+  function makeShrinkDoc(): PMNode {
+    return schema.node('doc', null, [
+      p('b1', 'one two three'),
+      p('b2', 'alpha beta gamma'),
+    ])
+  }
+
+  it('a lower-position, different-length cascade shifts the primary — result.applied is stale, arithmetic gives the true position', () => {
+    const view = mount(makeShrinkDoc())
+    const betaRange = findTextInDoc(view.state.doc, 'beta')!
+    const cascadeRange = findTextInDoc(view.state.doc, 'one two three')!
+    const primary = edit({
+      id: 'primary_1',
+      from: betaRange.from,
+      to: betaRange.to,
+      targetText: 'beta',
+      newText: 'B',
+      relation: 'primary',
+      blockId: 'b2',
+      severity: 'must',
+    })
+    const cascade = edit({
+      id: 'cascade_1',
+      from: cascadeRange.from,
+      to: cascadeRange.to,
+      targetText: 'one two three',
+      newText: 'X',
+      blockId: 'b1',
+    })
+    setProposedEdits(view, [primary, cascade])
+
+    const result = applyProposedEdits(view, ['primary_1', 'cascade_1'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(view.state.doc.textContent).toBe('Xalpha B gamma')
+
+    // result.applied still reports the stale, pre-transaction dispatch
+    // position — correct for the ledger entries, not a valid live position
+    // once the earlier cascade shrinks the doc by 12 chars.
+    const appliedPrimary = result.applied.find((ap) => ap.id === 'primary_1')!
+    expect(appliedPrimary).toMatchObject(betaRange)
+
+    const truePos = findAppliedEditFinalPosition(appliedPrimary, result.applied)
+    expect(truePos).toEqual({ from: betaRange.from - 12, to: betaRange.from - 12 + 1 })
+    expect(view.state.doc.textBetween(truePos.from, truePos.to)).toBe('B')
+    // Trusting the stale result.applied position would read past the end of
+    // the now-shrunk document entirely.
+    expect(view.state.doc.content.size).toBeLessThan(appliedPrimary.to)
+  })
+
+  it('a false-positive-prone collision (newText also occurs earlier in the same block) does not fool it — no text search happens at all (#44 review finding)', () => {
+    // b2 deliberately contains a decoy 'B' BEFORE the real edit target — the
+    // exact shape that broke a fingerprint-search-based first attempt: a
+    // block-scoped search for 'B' on the post-dispatch doc returns this
+    // decoy's position, not the real edit's.
+    const doc = schema.node('doc', null, [
+      p('b1', 'one two three'),
+      p('b2', 'B is a letter. alpha beta gamma'),
+    ])
+    const view = mount(doc)
+    const betaRange = findTextInDoc(view.state.doc, 'beta')!
+    const cascadeRange = findTextInDoc(view.state.doc, 'one two three')!
+    const decoyB = findTextInDoc(view.state.doc, 'B')!
+    expect(decoyB.from).toBeLessThan(betaRange.from) // confirms the decoy sorts first
+
+    const primary = edit({
+      id: 'primary_1',
+      from: betaRange.from,
+      to: betaRange.to,
+      targetText: 'beta',
+      newText: 'B',
+      relation: 'primary',
+      blockId: 'b2',
+      severity: 'must',
+    })
+    const cascade = edit({
+      id: 'cascade_1',
+      from: cascadeRange.from,
+      to: cascadeRange.to,
+      targetText: 'one two three',
+      newText: 'X',
+      blockId: 'b1',
+    })
+    setProposedEdits(view, [primary, cascade])
+
+    const result = applyProposedEdits(view, ['primary_1', 'cascade_1'])
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    const appliedPrimary = result.applied.find((ap) => ap.id === 'primary_1')!
+    const truePos = findAppliedEditFinalPosition(appliedPrimary, result.applied)
+    // The arithmetic-derived position is the REAL edited 'B' (immediately
+    // after 'alpha '), not the decoy at the start of the block.
+    expect(view.state.doc.textBetween(Math.max(0, truePos.from - 6), truePos.from)).toBe('alpha ')
+    expect(view.state.doc.textBetween(truePos.from, truePos.to)).toBe('B')
+  })
+
+  it('an edit at a HIGHER position (dispatched before target, per descending order) does not shift it', () => {
+    const target = { id: 't', from: 10, to: 10, newText: 'X', targetText: '', blockId: null }
+    const higherCascade = { id: 'h', from: 50, to: 55, newText: 'YY', targetText: 'ZZZZZ', blockId: null }
+    expect(findAppliedEditFinalPosition(target, [target, higherCascade])).toEqual({ from: 10, to: 11 })
+  })
+
+  it('sums deltas from multiple lower-position edits, both shrinking and growing', () => {
+    const target = { id: 't', from: 50, to: 54, newText: 'Q', targetText: 'wxyz', blockId: null }
+    const shrink = { id: 's', from: 0, to: 5, newText: 'AB', targetText: 'ABCDE', blockId: null } // delta -3
+    const grow = { id: 'g', from: 10, to: 10, newText: 'ABCD', targetText: '', blockId: null } // delta +4
+    // net shift = -3 + 4 = +1
+    expect(findAppliedEditFinalPosition(target, [target, shrink, grow])).toEqual({ from: 51, to: 52 })
+  })
+
+  it('a pure deletion (newText === "") resolves to a zero-length range at its shifted position', () => {
+    const target = { id: 't', from: 20, to: 24, newText: '', targetText: 'abcd', blockId: null }
+    const shrink = { id: 's', from: 0, to: 10, newText: '', targetText: 'ZZZZZZZZZZ', blockId: null } // delta -10
+    expect(findAppliedEditFinalPosition(target, [target, shrink])).toEqual({ from: 10, to: 10 })
   })
 })
 

--- a/src/lib/prosemirror/applyProposedEdits.ts
+++ b/src/lib/prosemirror/applyProposedEdits.ts
@@ -84,6 +84,50 @@ function resolveEditRange(
   return { ok: true, from: found.from, to: found.to }
 }
 
+/**
+ * Re-derives an applied edit's TRUE post-transaction position by ARITHMETIC
+ * over the batch's own known deltas, rather than trusting `target.from/to`
+ * as-is or fingerprint-searching the post-dispatch doc for `target.newText`.
+ *
+ * `AppliedEdit.from/to` are the positions passed to `tr.replaceWith` at
+ * dispatch time (pre-transaction, per `applyProposedEdits`'s doc comment)
+ * and stay valid post-transaction only for the LOWEST-`from` edit in the
+ * batch: since edits dispatch descending by `from`, that one is applied
+ * LAST, so nothing dispatched after it can shift it. Any edit that isn't
+ * the lowest can be shifted by a different-length edit at a lower position
+ * applied after it in the same transaction (#44).
+ *
+ * A fingerprint search for `target.newText` was tried and rejected: the
+ * replacement text is often short/common (a single corrected word or
+ * character), and can coincidentally match pre-existing text elsewhere in
+ * the same block or another edit's own landing text, silently returning the
+ * WRONG occurrence. Arithmetic has no such false-positive risk: every OTHER
+ * applied edit positioned before `target` (dispatched after it, since
+ * dispatch order is descending by `from`) shifts everything from its own
+ * `to` onward — including `target`'s already-landed text — by exactly its
+ * own length delta (`newText.length - (to - from)`). Summing those deltas
+ * gives `target`'s exact final position with no text search at all.
+ */
+export function findAppliedEditFinalPosition(
+  target: AppliedEdit,
+  allApplied: AppliedEdit[],
+): { from: number; to: number } {
+  // `ap.from === target.from` (a tie) is currently unreachable: primary and
+  // cascade edits are always non-zero-width (orchestrator.ts rejects an
+  // empty targetText/anchor), and the overlap/dedup gates that select which
+  // proposed edits survive into a batch treat any two non-zero-width ranges
+  // sharing a `from` as overlapping, so at most one of them is ever in
+  // `allApplied`. If either invariant ever loosens (e.g. a zero-width
+  // primary), this `>=` excludes a tied edit from the shift sum — revisit
+  // this boundary then, since it isn't exercised by any test today.
+  const shift = allApplied.reduce((sum, ap) => {
+    if (ap.id === target.id || ap.from >= target.from) return sum
+    return sum + (ap.newText.length - (ap.to - ap.from))
+  }, 0)
+  const from = target.from + shift
+  return { from, to: from + target.newText.length }
+}
+
 export function applyProposedEdits(view: EditorView, acceptedIds: string[]): ApplyProposedResult {
   const anchors = getProposedAnchors(view.state)
   const doc = view.state.doc


### PR DESCRIPTION
## What

Stacked on #45 (unmerged) — this closes #44, which #45's round-2 review discovered and deliberately descoped rather than ship a wrong fix.

`ResolutionActions.tsx`'s multi-region cascade-batch branch of `applyConfirmedEdit` (using `applyProposedEdits`) never refreshed `annotation.anchor` after a successful apply, unlike the single-edit path #45 fixed. Reason: `applyProposedEdits` resolves every accepted edit's `from`/`to` against the **pre-transaction** doc and returns those positions in `result.applied[]` — correct for the ledger entry (an established "resolved old range" convention), but **not** a valid live position for any edit that isn't the lowest-`from` one in the batch, once a different-length edit at a lower position (dispatched after it, since `applyProposedEdits` dispatches descending by `from`) shifts everything after it.

Concretely (the repro from #44): doc = `paragraph('one two three')` + `paragraph('alpha beta gamma')`. Accept a cascade shrinking `'one two three'` (13 chars) → `'X'` (1 char) in the earlier block, plus the primary edit `'beta'`→`'B'` in the later block. `applyProposedEdits` reports the primary's position as the pre-transaction `{from: 22, to: 26}`, but the real post-transaction doc is far shorter than 26 characters.

## Two rounds of pre-push adversarial (troublemaker) review — both real findings fixed

**Round 1 (NO-MERGE, HIGH):** the first implementation re-derived the primary's true position by fingerprint-**searching** the post-dispatch doc for the primary's `newText`. Proven unsafe: `newText` is often short/common (a single corrected word or character, e.g. `'B'`), and can coincidentally match pre-existing text elsewhere in the same block — `blockTextRange(doc, 'b2', 'B')` on `"B is a letter. alpha beta gamma"` returns the decoy `'B'` at the start of the block, not the actually-edited one. That's a real, silent document-integrity risk: a wrong anchor drives click-to-scroll and, worse, a later "Tweak it" re-apply's drift validation, which trusts `annotation.anchor.text` rather than re-reading the doc.

**Fix:** replaced the fingerprint search with **arithmetic**. `findAppliedEditFinalPosition(target, allApplied)` (`applyProposedEdits.ts`) sums `newText.length - (to - from)` over every other applied edit positioned before the target (those are the ones dispatched *after* it, per descending-`from` order, and each shifts everything from its own `to` onward — including the target's already-landed text — by exactly its own length delta). No document, no text search, no false-positive risk at all — the failure mode is eliminated, not worked around.

Round 1 also flagged that the apply-time *wiring* in `ResolutionActions.tsx` (finding the applied primary, guarding no-op/rejected/deletion cases) had zero test coverage. Fixed by extracting it into a pure function, `refreshedAnchorForMultiRegionApply(anchor, proposed, appliedEdits)` (`anchoring.ts`) — `ResolutionActions.tsx` now just calls it and merges the result, and the wiring itself is directly unit-tested.

**Round 2 (MERGE):** independently re-derived the arithmetic against real sequential string splicing (not just the tests), traced the `ap.from >= target.from` tie-boundary against the orchestrator's overlap/dedup gates (currently unreachable — non-zero-width edits + overlap gates structurally prevent two applied edits sharing a `from`), checked all call sites, and confirmed the guard-comments' claims against `applyProposedEdits`'s real behavior. One LOW, non-blocking note: the tie-boundary invariant wasn't documented at the point that relies on it — fixed with a comment before push.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 767 passing + 10 skipped (was 757 on #45's branch baseline; +10 net: 5 in `applyProposedEdits.test.ts` covering the arithmetic — including the round-1 collision repro proving the new approach isn't fooled by it — and 5 in `anchoring.test.ts` covering `refreshedAnchorForMultiRegionApply`'s wiring: normal refresh, no primary tagged, primary rejected, primary excluded as a no-op, pure-deletion primary)
- [x] `npm run build` — clean
- [x] Two rounds of pre-push adversarial (troublemaker) review completed; round 1's HIGH finding fixed by eliminating the failure mode (arithmetic, not fingerprint search); round 2 verdict MERGE

Closes #44

---
_Generated by [Claude Code](https://claude.ai/code/session_01EggPjh15smExzT5zaKsyX1)_