### PR TITLE
ci: run verify on every PR, not only those based on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter here on purpose. That filter matches the pull
+  # request's BASE branch, so a PR stacked on another PR's branch was skipped
+  # entirely — intent-ide#46 reached a merge with no `verify` run ever having
+  # happened, and once `verify` became a required check a never-reported check
+  # blocked the merge permanently. GitHub also fires no run when it retargets
+  # a stacked PR's base after the parent merges, so the gap did not self-heal.
   pull_request:
-    branches: [main]
 
 jobs:
   verify:


### PR DESCRIPTION
## What

Removes `branches: [main]` from `ci.yml`'s `pull_request` trigger.

That filter matches the pull request's **base** branch. A PR opened stacked on another PR's branch therefore ran **no CI at all** — not on open, not on any subsequent push.

## Why now

It was harmless-looking until `verify` became a required status check (ruleset updated 2026-08-19). Then it became a hard block:

1. PR #46 was opened 00:42:26 stacked on #45's branch → base ≠ `main` → CI skipped on every event. `gate-integrity` ran, because it carries no branch filter — which is exactly why the gap looked like "one check is broken" rather than "CI never ran".
2. #45 merged; GitHub retargeted #46's base to `main` at 00:49:26. **A base change fires no workflow run**, so the head commit still carried no `verify` check.
3. A required check that has never reported leaves the PR `BLOCKED` forever. It took an empty commit to force a `synchronize` event and produce the first run — which then passed on the first try.

The gap predates the required-check change; stacked PRs in this repo have simply been merging without CI.

## Scope

- `push` keeps its `branches: [main]` filter — branch pushes are already covered by the `pull_request` run, and this avoids double runs on main.
- `pull_request` with no filter uses GitHub's default activity types (`opened`, `synchronize`, `reopened`), unchanged from before.

## Test plan

- [x] `ci.yml` parses (`js-yaml`): `on = {"push":{"branches":["main"]},"pull_request":null}`, `jobs = ["verify"]`
- [x] This PR is itself the proof — it is based on `main`, so `verify` must run and pass here
- [x] Labelled `machinery-change`, which `gate-integrity` requires for any `.github/workflows/**` edit

Discovered while unblocking #46.
