### PR TITLE
Document Invariant Ledger — resolve/dismiss endpoint (Phase 3)

### DIFF
--- a/prisma/migrations/20260820042527_add_doc_invariant_supersedes/migration.sql
+++ b/prisma/migrations/20260820042527_add_doc_invariant_supersedes/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable
+ALTER TABLE "DocInvariant" ADD COLUMN "supersedesId" TEXT;
+
+-- CreateIndex
+-- Unique (not just indexed): at most one row may point supersedesId at any
+-- given target, so two concurrent resolve/dismiss requests for the same
+-- invariant can never both succeed (SQLite unique indexes allow unlimited
+-- NULLs, so ordinary capture rows with supersedesId = NULL are unaffected).
+CREATE UNIQUE INDEX "DocInvariant_supersedesId_key" ON "DocInvariant"("supersedesId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,23 +81,29 @@ model DocCommit {
   @@index([documentId, parentHash])
 }
 
-/// Document Invariant Ledger — Phase 1 (data model + capture only; see #26).
-/// A user-declared fact, captured at SemanticCommitModal confirm time and
-/// linked to the block(s) that evidence it. The check runner that regression-
-/// tests these against later DocCommits, and CascadeList surfacing of a
-/// failing invariant, are out of scope until a follow-up task lands (#20
-/// steps 2-3); `status` and `checkKind` exist now so that runner has a stable
-/// schema to read, but nothing in this phase writes anything other than
-/// `active`/`deterministic`.
-/// Append-only: no update/delete operations permitted on invariant records.
+/// Document Invariant Ledger. A user-declared fact, captured at
+/// SemanticCommitModal confirm time and linked to the block(s) that evidence
+/// it (Phase 1, #26). The deterministic check runner re-evaluates active rows
+/// against later document edits and surfaces conflicts through CascadeList
+/// (Phase 2, #32).
+/// Append-only, git-model (Phase 3, #35): no update/delete operations exist on
+/// a row's evidentiary content (`statement`/`blockIds`/`provenanceCommitHash`
+/// are set once at creation and never rewritten). A status transition
+/// (active -> resolved|superseded) is recorded as a NEW row that duplicates
+/// the prior row's content forward and points `supersedesId` at it — the same
+/// parent-pointer-chain shape `DocCommit.parentHash` uses, rather than a
+/// PATCH that mutates a row in place. A row is "live" (counts toward active
+/// checks) iff no other row's `supersedesId` points at it; see
+/// `src/app/api/invariants/route.ts` GET for that computation.
 model DocInvariant {
   id                   String   @id @default(cuid())
   documentId           String
   statement            String
   blockIds             String   @default("[]") // JSON string[] — evidence links
   checkKind            String   @default("deterministic") // 'deterministic' | 'entailment'
-  status               String   @default("active") // reserved for the future check runner
+  status               String   @default("active") // 'active' | 'resolved' | 'superseded'
   provenanceCommitHash String? // DocCommit.hash of the commit that declared this fact
+  supersedesId         String?  @unique // id of the DocInvariant row this one supersedes (append-only resolve/dismiss)
   createdAt            DateTime @default(now())
 
   @@index([documentId, createdAt])

--- a/src/app/api/invariants/__tests__/route.test.ts
+++ b/src/app/api/invariants/__tests__/route.test.ts
@@ -14,6 +14,7 @@ interface Row {
   checkKind: string
   status: string
   provenanceCommitHash: string | null
+  supersedesId: string | null
   createdAt: Date
 }
 
@@ -37,8 +38,9 @@ vi.mock('@/lib/db', () => ({
           statement: data.statement,
           blockIds: data.blockIds,
           checkKind: data.checkKind,
-          status: 'active',
+          status: data.status ?? 'active',
           provenanceCommitHash: data.provenanceCommitHash ?? null,
+          supersedesId: data.supersedesId ?? null,
           createdAt: new Date(1700000000000 + clock++ * 1000),
         }
         rows.push(row)
@@ -185,5 +187,71 @@ describe('GET /api/invariants', () => {
     const res = await GET(getRequest('documentId=doc-1&limit=2'))
     const data = await res.json()
     expect(data.invariants).toHaveLength(2)
+  })
+
+  it('excludes a superseded row, keeping the row that supersedes it (#35 resolve/dismiss)', async () => {
+    const created = await POST(postRequest({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' }))
+    const original = (await created.json()).invariant
+
+    // Simulates what POST /api/invariants/resolve creates — a new row
+    // duplicating the target's content forward with supersedesId set, never
+    // mutating the original row's own columns.
+    rows.push({
+      id: `inv-${nextId++}`,
+      documentId: 'doc-1',
+      statement: original.statement,
+      blockIds: original.blockIds,
+      checkKind: original.checkKind,
+      status: 'resolved',
+      provenanceCommitHash: original.provenanceCommitHash,
+      supersedesId: original.id,
+      createdAt: new Date(1700000000000 + clock++ * 1000),
+    })
+
+    const res = await GET(getRequest('documentId=doc-1'))
+    const data = await res.json()
+    expect(data.invariants).toHaveLength(1)
+    expect(data.invariants[0].status).toBe('resolved')
+    expect(data.invariants[0].supersedesId).toBe(original.id)
+    // The original row itself is untouched (still exists, still 'active') —
+    // it just no longer appears in the LIVE set GET returns.
+    expect(rows.find((r) => r.id === original.id)?.status).toBe('active')
+  })
+
+  it('follows a two-level supersede chain, surfacing only the newest terminal row', async () => {
+    const created = await POST(postRequest({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' }))
+    const original = (await created.json()).invariant
+
+    const firstResolveId = `inv-${nextId++}`
+    rows.push({
+      id: firstResolveId,
+      documentId: 'doc-1',
+      statement: original.statement,
+      blockIds: original.blockIds,
+      checkKind: original.checkKind,
+      status: 'resolved',
+      provenanceCommitHash: original.provenanceCommitHash,
+      supersedesId: original.id,
+      createdAt: new Date(1700000000000 + clock++ * 1000),
+    })
+    // A resolve-of-a-resolve — e.g. a newly declared fact later supersedes
+    // the ledger's record of having resolved the earlier one.
+    rows.push({
+      id: `inv-${nextId++}`,
+      documentId: 'doc-1',
+      statement: original.statement,
+      blockIds: original.blockIds,
+      checkKind: original.checkKind,
+      status: 'superseded',
+      provenanceCommitHash: original.provenanceCommitHash,
+      supersedesId: firstResolveId,
+      createdAt: new Date(1700000000000 + clock++ * 1000),
+    })
+
+    const res = await GET(getRequest('documentId=doc-1'))
+    const data = await res.json()
+    expect(data.invariants).toHaveLength(1)
+    expect(data.invariants[0].status).toBe('superseded')
+    expect(data.invariants[0].supersedesId).toBe(firstResolveId)
   })
 })

--- a/src/app/api/invariants/resolve/__tests__/route.test.ts
+++ b/src/app/api/invariants/resolve/__tests__/route.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ---------------------------------------------------------------------------
+// In-memory Prisma double for the DocInvariant table. The resolve route uses
+// findUnique / findFirst / create, so the double implements exactly those.
+// ---------------------------------------------------------------------------
+
+interface Row {
+  id: string
+  documentId: string
+  statement: string
+  blockIds: string
+  checkKind: string
+  status: string
+  provenanceCommitHash: string | null
+  supersedesId: string | null
+  createdAt: Date
+}
+
+let rows: Row[] = []
+let clock = 0
+let nextId = 0
+
+function seedRow(overrides: Partial<Row> = {}): Row {
+  const row: Row = {
+    id: `inv-${nextId++}`,
+    documentId: 'doc-1',
+    statement: 'Terminations are now 30 days.',
+    blockIds: JSON.stringify(['blk-terminations']),
+    checkKind: 'deterministic',
+    status: 'active',
+    provenanceCommitHash: 'hash-1',
+    supersedesId: null,
+    createdAt: new Date(1700000000000 + clock++ * 1000),
+    ...overrides,
+  }
+  rows.push(row)
+  return row
+}
+
+// Simulates the real schema's `supersedesId String? @unique` — SQLite
+// unique indexes allow unlimited NULLs, so only a non-null collision throws.
+let forceRaceOnNextCreate = false
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    docInvariant: {
+      findUnique: async ({ where }: any) => {
+        if (where.id !== undefined) return rows.find((r) => r.id === where.id) ?? null
+        if (where.supersedesId !== undefined) {
+          return rows.find((r) => r.supersedesId === where.supersedesId) ?? null
+        }
+        return null
+      },
+      create: async ({ data }: any) => {
+        // A concurrent request's write landing between this route's own
+        // pre-check and its create — the unique-constraint race #35's review
+        // flagged. Simulated explicitly rather than via true concurrency
+        // since the double is single-threaded.
+        if (forceRaceOnNextCreate && data.supersedesId != null) {
+          forceRaceOnNextCreate = false
+          rows.push({
+            id: `inv-${nextId++}`,
+            documentId: data.documentId,
+            statement: data.statement,
+            blockIds: data.blockIds,
+            checkKind: data.checkKind,
+            status: data.status,
+            provenanceCommitHash: data.provenanceCommitHash ?? null,
+            supersedesId: data.supersedesId,
+            createdAt: new Date(1700000000000 + clock++ * 1000),
+          })
+          throw new Error('UNIQUE constraint failed: DocInvariant.supersedesId')
+        }
+        if (data.supersedesId != null && rows.some((r) => r.supersedesId === data.supersedesId)) {
+          throw new Error('UNIQUE constraint failed: DocInvariant.supersedesId')
+        }
+        const row: Row = {
+          id: `inv-${nextId++}`,
+          documentId: data.documentId,
+          statement: data.statement,
+          blockIds: data.blockIds,
+          checkKind: data.checkKind,
+          status: data.status,
+          provenanceCommitHash: data.provenanceCommitHash ?? null,
+          supersedesId: data.supersedesId ?? null,
+          createdAt: new Date(1700000000000 + clock++ * 1000),
+        }
+        rows.push(row)
+        return row
+      },
+    },
+  },
+}))
+
+// Import AFTER the mock so route.ts binds to the double.
+import { POST } from '../route'
+
+beforeEach(() => {
+  rows = []
+  clock = 0
+  nextId = 0
+  forceRaceOnNextCreate = false
+})
+
+function postRequest(body: unknown) {
+  return new NextRequest('http://localhost/api/invariants/resolve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/invariants/resolve', () => {
+  it('appends a new row pointing supersedesId at the target, duplicating its content forward', async () => {
+    const original = seedRow()
+
+    const res = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+
+    expect(data.invariant.id).not.toBe(original.id)
+    expect(data.invariant.supersedesId).toBe(original.id)
+    expect(data.invariant.status).toBe('resolved')
+    expect(data.invariant.statement).toBe(original.statement)
+    expect(data.invariant.blockIds).toBe(original.blockIds)
+    expect(data.invariant.provenanceCommitHash).toBe(original.provenanceCommitHash)
+
+    // The original row's own columns are never written to — append-only.
+    const stillOriginal = rows.find((r) => r.id === original.id)
+    expect(stillOriginal?.status).toBe('active')
+    expect(stillOriginal?.supersedesId).toBeNull()
+    expect(rows).toHaveLength(2)
+  })
+
+  it('accepts a "superseded" status transition too', async () => {
+    const original = seedRow()
+    const res = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'superseded' }))
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.invariant.status).toBe('superseded')
+  })
+
+  it('rejects a missing documentId or invariantId', async () => {
+    const res1 = await POST(postRequest({ invariantId: 'inv-0', status: 'resolved' }))
+    expect(res1.status).toBe(400)
+    const res2 = await POST(postRequest({ documentId: 'doc-1', status: 'resolved' }))
+    expect(res2.status).toBe(400)
+    expect(rows).toHaveLength(0)
+  })
+
+  it('rejects an invalid status', async () => {
+    const original = seedRow()
+    const res = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'active' }))
+    expect(res.status).toBe(400)
+    expect(rows).toHaveLength(1)
+  })
+
+  it('404s on an unknown invariantId', async () => {
+    const res = await POST(postRequest({ documentId: 'doc-1', invariantId: 'nope', status: 'resolved' }))
+    expect(res.status).toBe(404)
+  })
+
+  it("404s when documentId doesn't match the target row's own documentId", async () => {
+    const original = seedRow({ documentId: 'doc-1' })
+    const res = await POST(postRequest({ documentId: 'doc-2', invariantId: original.id, status: 'resolved' }))
+    expect(res.status).toBe(404)
+  })
+
+  it('409s when the target has already been resolved/superseded', async () => {
+    const original = seedRow()
+    const first = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }))
+    expect(first.status).toBe(200)
+
+    const second = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }))
+    expect(second.status).toBe(409)
+    expect(rows).toHaveLength(2)
+  })
+
+  it('409s (never 500, never a duplicate row) when a concurrent request wins the race past the pre-check', async () => {
+    // Regression for the #35 review's HIGH finding: two requests can both
+    // pass the findUnique pre-check before either writes. The double injects
+    // a competing write INSIDE this request's own create() call, simulating
+    // the other request landing in the gap, and the real route's unique-
+    // constraint catch-and-requery must turn that into a clean 409.
+    const original = seedRow()
+    forceRaceOnNextCreate = true
+
+    const res = await POST(postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }))
+    expect(res.status).toBe(409)
+    // Exactly the one row the "concurrent" write inserted — this request's
+    // own create() threw and produced nothing.
+    expect(rows.filter((r) => r.supersedesId === original.id)).toHaveLength(1)
+  })
+
+  it('supports a second-level resolve — resolving a resolution row itself', async () => {
+    const original = seedRow()
+    const firstResolve = await POST(
+      postRequest({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }),
+    )
+    const firstData = (await firstResolve.json()).invariant
+
+    const secondResolve = await POST(
+      postRequest({ documentId: 'doc-1', invariantId: firstData.id, status: 'superseded' }),
+    )
+    expect(secondResolve.status).toBe(200)
+    const secondData = (await secondResolve.json()).invariant
+
+    expect(secondData.supersedesId).toBe(firstData.id)
+    expect(secondData.status).toBe('superseded')
+    // The whole chain exists, untouched: original -> firstResolve -> secondResolve.
+    expect(rows).toHaveLength(3)
+    expect(rows.find((r) => r.id === original.id)?.status).toBe('active')
+    expect(rows.find((r) => r.id === firstData.id)?.status).toBe('resolved')
+  })
+
+  it('exposes no PATCH/PUT/DELETE — status transitions are append-only writes', async () => {
+    const routeModule: Record<string, unknown> = await import('../route')
+    expect(routeModule.PATCH).toBeUndefined()
+    expect(routeModule.PUT).toBeUndefined()
+    expect(routeModule.DELETE).toBeUndefined()
+  })
+})

--- a/src/app/api/invariants/resolve/route.ts
+++ b/src/app/api/invariants/resolve/route.ts
@@ -1,0 +1,107 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { INVARIANT_SELECT } from '@/lib/invariants/invariantSelect'
+
+/**
+ * /api/invariants/resolve — Document Invariant Ledger, Phase 3 (#35). Ends a
+ * DocInvariant row's currency (e.g. the user clicked "Nevermind" on a
+ * surfaced conflict, or a newly declared fact explicitly replaces an older
+ * one) WITHOUT mutating the original row.
+ *
+ * Append-only, git-model: this creates a NEW row that duplicates the target
+ * row's evidentiary content (`statement`/`blockIds`/`checkKind`/
+ * `provenanceCommitHash`) forward — the same full-snapshot-per-version shape
+ * `DocCommit` uses — with `status` set to the requested value and
+ * `supersedesId` pointing at the row it replaces, mirroring
+ * `DocCommit.parentHash`. The original row's own columns are never written
+ * to. GET /api/invariants treats a row as "live" iff nothing else's
+ * `supersedesId` points at it, so the target stops being checked without its
+ * history being rewritten — chosen over an in-place PATCH because it matches
+ * this project's "tamper-evident, not immutable, but auditable" posture
+ * (docs/compliance.md) instead of introducing the one kind of row in this
+ * ledger whose evidentiary fields CAN silently change after the fact.
+ */
+
+const VALID_STATUSES = new Set(['resolved', 'superseded'])
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+
+    const documentId = typeof body.documentId === 'string' ? body.documentId : ''
+    const invariantId = typeof body.invariantId === 'string' ? body.invariantId : ''
+    const status = typeof body.status === 'string' ? body.status : ''
+    if (!documentId || !invariantId) {
+      return NextResponse.json(
+        { error: 'documentId and invariantId are required' },
+        { status: 400 },
+      )
+    }
+    if (!VALID_STATUSES.has(status)) {
+      return NextResponse.json(
+        { error: `status must be one of: ${[...VALID_STATUSES].join(', ')}` },
+        { status: 400 },
+      )
+    }
+
+    const target = await prisma.docInvariant.findUnique({ where: { id: invariantId } })
+    if (!target || target.documentId !== documentId) {
+      return NextResponse.json({ error: 'invariant not found' }, { status: 404 })
+    }
+
+    // Fast-path pre-check (findUnique on the unique `supersedesId` column) —
+    // gives a clean 409 in the ordinary sequential case. This alone is NOT
+    // race-safe (two concurrent requests can both pass it before either
+    // writes); the schema's `@unique` constraint on `supersedesId` is the
+    // actual correctness guarantee, enforced by the catch block below.
+    const alreadySuperseded = await prisma.docInvariant.findUnique({
+      where: { supersedesId: invariantId },
+      select: { id: true },
+    })
+    if (alreadySuperseded) {
+      return NextResponse.json(
+        { error: 'invariant already resolved or superseded' },
+        { status: 409 },
+      )
+    }
+
+    try {
+      const record = await prisma.docInvariant.create({
+        data: {
+          documentId: target.documentId,
+          statement: target.statement,
+          blockIds: target.blockIds,
+          checkKind: target.checkKind,
+          provenanceCommitHash: target.provenanceCommitHash ?? undefined,
+          status,
+          supersedesId: invariantId,
+        },
+        select: INVARIANT_SELECT,
+      })
+      return NextResponse.json({ invariant: record })
+    } catch (createErr) {
+      // A concurrent request can race past the pre-check above and collide
+      // on the unique `supersedesId` constraint — same idempotent-collision
+      // pattern /api/history uses for its own unique-constraint race. Confirm
+      // it really was that constraint (a row for this target now exists)
+      // before reporting 409; anything else is a genuine 500.
+      const racedExisting = await prisma.docInvariant.findUnique({
+        where: { supersedesId: invariantId },
+        select: { id: true },
+      })
+      if (racedExisting) {
+        return NextResponse.json(
+          { error: 'invariant already resolved or superseded' },
+          { status: 409 },
+        )
+      }
+      throw createErr
+    }
+  } catch (err) {
+    console.error('[/api/invariants/resolve] Error:', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Invariant resolve failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/invariants/route.ts
+++ b/src/app/api/invariants/route.ts
@@ -1,17 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/db'
+import { INVARIANT_SELECT } from '@/lib/invariants/invariantSelect'
 
 /**
- * /api/invariants — Document Invariant Ledger, Phase 1 (data model + capture
- * only; see issue #26). A user-declared fact ("terminations are now 30
- * days"), captured at SemanticCommitModal confirm time and linked to the
- * block(s) that evidence it.
+ * /api/invariants — Document Invariant Ledger. A user-declared fact
+ * ("terminations are now 30 days"), captured at SemanticCommitModal confirm
+ * time and linked to the block(s) that evidence it (Phase 1, #26). The
+ * deterministic check runner re-evaluates active rows against later document
+ * edits (Phase 2, #32).
  *
- * This endpoint ONLY creates and reads records — no update or delete
- * operations exist. The check runner that regression-tests these against
- * later document edits, and CascadeList surfacing of a failing invariant,
- * are a separate follow-up task (#20 steps 2-3); this route only stores what
- * that runner will eventually read.
+ * This route creates and reads records — no PATCH/DELETE exist, and no row's
+ * `statement`/`blockIds`/`provenanceCommitHash` is ever rewritten in place. A
+ * status transition (e.g. dismissing a surfaced conflict) is a separate
+ * append-only write at POST /api/invariants/resolve (Phase 3, #35), which
+ * appends a NEW row pointing `supersedesId` at the one it resolves rather
+ * than mutating it — see the schema doc-comment on `DocInvariant` for the
+ * full rationale. GET computes the "live" (not-yet-superseded) set below.
  */
 
 const VALID_CHECK_KINDS = new Set(['deterministic', 'entailment'])
@@ -22,21 +26,28 @@ const MAX_BLOCK_ID_CHARS = 200
 
 const DEFAULT_LIMIT = 100
 const MAX_LIMIT = 200
-
-const INVARIANT_SELECT = {
-  id: true,
-  documentId: true,
-  statement: true,
-  blockIds: true,
-  checkKind: true,
-  status: true,
-  provenanceCommitHash: true,
-  createdAt: true,
-} as const
+// Upper bound on how many of a document's rows (across both original facts
+// and their resolve/supersede rows) GET scans to compute the live set. Rows
+// beyond this cutoff (ordered newest-first) are invisible to this endpoint —
+// a disclosed limit, not silently unbounded, matching this app's public-
+// exposure hardening posture elsewhere (e.g. /api/audit's body cap).
+// Disclosed interaction (#35 review): there is no offset/cursor param on
+// this route (pre-existing, not introduced here), so a document whose live
+// set exceeds MAX_LIMIT has no way to fetch a second page — each resolve now
+// leaves BOTH the original and its resolution row present in the DB (only
+// the original drops out of the live view), so an actively-dismissed
+// document's live-row count grows faster post-#35 than pre-#35. Acceptable
+// for now given expected per-document invariant volume; a real follow-up if
+// it becomes user-visible.
+const SUPERSEDE_SCAN_CAP = 2000
 
 /**
- * GET /api/invariants?documentId=... — list a document's invariants, newest
- * first (default page of 100, ?limit=N up to 200).
+ * GET /api/invariants?documentId=... — list a document's LIVE invariants
+ * (rows no other row supersedes), newest first (default page of 100,
+ * ?limit=N up to 200). A row that has been resolved/superseded is excluded;
+ * the row recording that resolution (status 'resolved'|'superseded') takes
+ * its place in the result if it is itself still live — which it always is
+ * unless something later supersedes it too.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -51,12 +62,16 @@ export async function GET(request: NextRequest) {
       ? Math.min(Math.max(Math.floor(rawLimit), 1), MAX_LIMIT)
       : DEFAULT_LIMIT
 
-    const invariants = await prisma.docInvariant.findMany({
+    const scanned = await prisma.docInvariant.findMany({
       where: { documentId },
       orderBy: { createdAt: 'desc' },
-      take: limit,
+      take: SUPERSEDE_SCAN_CAP,
       select: INVARIANT_SELECT,
     })
+    const supersededIds = new Set(
+      scanned.filter((r) => r.supersedesId).map((r) => r.supersedesId as string),
+    )
+    const invariants = scanned.filter((r) => !supersededIds.has(r.id)).slice(0, limit)
     return NextResponse.json({ invariants })
   } catch (err) {
     console.error('[/api/invariants GET] Error:', err)

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -31,7 +31,7 @@ import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { refreshAnchorAfterApply, refreshedAnchorForMultiRegionApply } from '@/lib/annotations/anchoring'
 import { createCommit } from '@/lib/history/commits'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
-import { runAndSurfaceInvariantChecks } from '@/lib/invariants/invariantCascade'
+import { resolveInvariantFlagOnDismiss, runAndSurfaceInvariantChecks } from '@/lib/invariants/invariantCascade'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
@@ -471,6 +471,13 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
 
       case 'dismiss':
       case 'park': {
+        // Idempotency guard: a double-click fires two synchronous onClick
+        // calls before React can re-render with the new status, but each
+        // call reads the STORE (not the closure-captured `annotation` prop)
+        // fresh — so the second call correctly sees what the first one just
+        // wrote and no-ops, rather than firing the invariant-resolve network
+        // call (below) twice for one user action.
+        if (useAnnotationStore.getState().getById(annotation.id)?.status === 'dismissed') break
         updateAnnotation(annotation.id, { status: 'dismissed' })
         if (changeSetId) {
           useChangesStore.getState().updateChangeSetStatus(changeSetId, 'rejected')
@@ -478,6 +485,12 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         if (view) {
           removeAnnotationDecoration(view, annotation.id)
         }
+        // Dismissing an invariant-check flag ("Nevermind") also resolves the
+        // underlying ledger row (#35), so the doc-CI lane stops re-flagging
+        // it. No-op for any other annotation type. Fire-and-forget from this
+        // handler's perspective — the helper itself only prunes dedup memory
+        // once the resolve genuinely succeeds.
+        resolveInvariantFlagOnDismiss(annotation)
         break
       }
 

--- a/src/lib/invariants/__tests__/captureInvariant.test.ts
+++ b/src/lib/invariants/__tests__/captureInvariant.test.ts
@@ -3,6 +3,7 @@ import {
   captureInvariant,
   listInvariants,
   recordInvariant,
+  resolveInvariant,
   shouldCaptureInvariant,
   type Invariant,
 } from '../captureInvariant'
@@ -16,6 +17,7 @@ import {
 let store: Invariant[] = []
 let nextId = 0
 let failNextPost = false
+let failNextResolve = false
 
 function jsonResponse(body: unknown, status = 200) {
   return {
@@ -26,6 +28,31 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 function fetchStub(url: string, init?: RequestInit) {
+  const path = new URL(url, 'http://localhost').pathname
+
+  if (init?.method === 'POST' && path === '/api/invariants/resolve') {
+    if (failNextResolve) {
+      failNextResolve = false
+      return Promise.resolve(jsonResponse({ error: 'boom' }, 500))
+    }
+    const body = JSON.parse(String(init.body))
+    const target = store.find((r) => r.id === body.invariantId && r.documentId === body.documentId)
+    if (!target) return Promise.resolve(jsonResponse({ error: 'invariant not found' }, 404))
+    const invariant: Invariant = {
+      id: `inv-${nextId++}`,
+      documentId: target.documentId,
+      statement: target.statement,
+      blockIds: target.blockIds,
+      checkKind: target.checkKind,
+      status: body.status,
+      provenanceCommitHash: target.provenanceCommitHash,
+      supersedesId: target.id,
+      createdAt: new Date(1700000000000 + nextId * 1000).toISOString(),
+    }
+    store.push(invariant)
+    return Promise.resolve(jsonResponse({ invariant }))
+  }
+
   if (init?.method === 'POST') {
     if (failNextPost) {
       failNextPost = false
@@ -40,15 +67,17 @@ function fetchStub(url: string, init?: RequestInit) {
       checkKind: body.checkKind ?? 'deterministic',
       status: 'active',
       provenanceCommitHash: body.provenanceCommitHash ?? null,
+      supersedesId: null,
       createdAt: new Date(1700000000000 + nextId * 1000).toISOString(),
     }
     store.push(invariant)
     return Promise.resolve(jsonResponse({ invariant }))
   }
-  // GET
+  // GET — mirrors the real route's "exclude superseded rows" computation.
   const documentId = new URL(url, 'http://localhost').searchParams.get('documentId')
+  const supersededIds = new Set(store.filter((r) => r.supersedesId).map((r) => r.supersedesId as string))
   const invariants = [...store]
-    .filter((r) => r.documentId === documentId)
+    .filter((r) => r.documentId === documentId && !supersededIds.has(r.id))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
   return Promise.resolve(jsonResponse({ invariants }))
 }
@@ -57,6 +86,7 @@ beforeEach(() => {
   store = []
   nextId = 0
   failNextPost = false
+  failNextResolve = false
   vi.stubGlobal('fetch', vi.fn(fetchStub))
 })
 
@@ -157,5 +187,43 @@ describe('listInvariants', () => {
     expect(invariants[0].statement).toBe('Termination notices go through HR.')
     expect(invariants[1].statement).toBe('Terminations are now 30 days.')
     expect(JSON.parse(invariants[1].blockIds)).toEqual(['blk-terminations'])
+  })
+
+  it('excludes a resolved invariant\'s original row, keeping the resolution row live (#35)', async () => {
+    const original = await captureInvariant({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' })
+    await resolveInvariant({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' })
+
+    const invariants = await listInvariants('doc-1')
+    expect(invariants).toHaveLength(1)
+    expect(invariants[0].status).toBe('resolved')
+    expect(invariants[0].supersedesId).toBe(original.id)
+  })
+})
+
+describe('resolveInvariant', () => {
+  it('appends a new row pointing supersedesId at the target, duplicating its content forward', async () => {
+    const original = await captureInvariant({
+      documentId: 'doc-1',
+      statement: 'Terminations are now 30 days.',
+      blockIds: ['blk-terminations'],
+    })
+    const resolved = await resolveInvariant({
+      documentId: 'doc-1',
+      invariantId: original.id,
+      status: 'resolved',
+    })
+    expect(resolved.id).not.toBe(original.id)
+    expect(resolved.supersedesId).toBe(original.id)
+    expect(resolved.status).toBe('resolved')
+    expect(resolved.statement).toBe(original.statement)
+    expect(resolved.blockIds).toBe(original.blockIds)
+  })
+
+  it('throws on a failed resolve', async () => {
+    const original = await captureInvariant({ documentId: 'doc-1', statement: 'A fact.' })
+    failNextResolve = true
+    await expect(
+      resolveInvariant({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' }),
+    ).rejects.toThrow('boom')
   })
 })

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -8,7 +8,11 @@ import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
 import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import type { Invariant } from '../captureInvariant'
-import { runAndSurfaceInvariantChecks } from '../invariantCascade'
+import {
+  invariantIdFromFlagKey,
+  resolveInvariantFlagOnDismiss,
+  runAndSurfaceInvariantChecks,
+} from '../invariantCascade'
 
 function p(blockId: string, text: string): PMNode {
   return schema.node('paragraph', { blockId }, [schema.text(text)])
@@ -28,6 +32,7 @@ function invariantRecord(overrides: Partial<Invariant> = {}): Invariant {
     checkKind: 'deterministic',
     status: 'active',
     provenanceCommitHash: 'hash-1',
+    supersedesId: null,
     createdAt: '2026-08-18T00:00:00.000Z',
     ...overrides,
   }
@@ -212,5 +217,94 @@ describe('runAndSurfaceInvariantChecks', () => {
     const tr = state.tr.replaceWith(cascade.from, cascade.to, schema.text(cascade.newText))
     const next = state.apply(tr)
     expect(next.doc.textBetween(cascade.from, cascade.to)).toBe(cascade.targetText)
+  })
+
+  it('produces no flag for an invariant already resolved (#35: dismissing a flag stops it being checked)', async () => {
+    // Simulates what GET /api/invariants returns once a "Nevermind" resolve
+    // has landed: the live row for this fact now has status 'resolved', not
+    // 'active' — checkInvariants (and therefore this runner) must skip it,
+    // exactly as it already does for entailment-kind and superseded rows.
+    stubListInvariants([invariantRecord({ status: 'resolved', supersedesId: null })])
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+})
+
+describe('invariantIdFromFlagKey', () => {
+  it('recovers the invariantId from a locationGroupKey produced for an invariant-check flag', () => {
+    expect(invariantIdFromFlagKey('doc-A:invariant:inv-1:b-conflict')).toBe('inv-1')
+  })
+
+  it('returns null for a locationGroupKey that is not an invariant-flag key', () => {
+    expect(invariantIdFromFlagKey('some-other-annotation-key')).toBeNull()
+  })
+
+  it('is unfooled by a documentId that itself contains a colon', () => {
+    expect(invariantIdFromFlagKey('doc:with:colons:invariant:inv-9:b-1')).toBe('inv-9')
+  })
+
+  it('is unfooled by a documentId that itself contains the literal ":invariant:" marker', () => {
+    // A front-anchored (indexOf-from-the-start) parse would find the FIRST
+    // ":invariant:" occurrence and misparse this as invariantId="evil" — the
+    // real invariantId is only recoverable by anchoring from the END.
+    expect(invariantIdFromFlagKey('doc:invariant:evil:invariant:inv-9:b-1')).toBe('inv-9')
+  })
+
+  it('returns null for a key one segment short of the minimum shape', () => {
+    expect(invariantIdFromFlagKey('doc-A:invariant:inv-1')).toBeNull()
+  })
+})
+
+describe('resolveInvariantFlagOnDismiss', () => {
+  const FLAG_KEY = 'doc-A:invariant:inv-1:b-conflict'
+
+  it('no-ops (and makes no network call) for a non-invariant annotation', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+
+    await resolveInvariantFlagOnDismiss({ documentId: 'doc-A', locationGroupKey: 'some-other-key' })
+
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('resolves the ledger row and prunes the dedup entry on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ invariant: { id: 'inv-2', supersedesId: 'inv-1', status: 'resolved' } }),
+      })),
+    )
+    useInvariantFlagStore.getState().markSurfaced(FLAG_KEY)
+
+    await resolveInvariantFlagOnDismiss({ documentId: 'doc-A', locationGroupKey: FLAG_KEY })
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/invariants/resolve',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    expect(useInvariantFlagStore.getState().hasSurfaced(FLAG_KEY)).toBe(false)
+  })
+
+  it('leaves the dedup entry intact (and warns) when the resolve call fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, json: async () => ({ error: 'boom' }) })),
+    )
+    useInvariantFlagStore.getState().markSurfaced(FLAG_KEY)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await resolveInvariantFlagOnDismiss({ documentId: 'doc-A', locationGroupKey: FLAG_KEY })
+
+    // Still surfaced — a network failure must not silently drop dedup memory
+    // and let the doc-CI lane re-flag this as a brand-new annotation later.
+    expect(useInvariantFlagStore.getState().hasSurfaced(FLAG_KEY)).toBe(true)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -21,6 +21,7 @@ function invariant(overrides: Partial<Invariant> = {}): Invariant {
     checkKind: 'deterministic',
     status: 'active',
     provenanceCommitHash: 'hash-1',
+    supersedesId: null,
     createdAt: '2026-08-18T00:00:00.000Z',
     ...overrides,
   }
@@ -78,12 +79,21 @@ describe('checkInvariants', () => {
     expect(violations).toEqual([])
   })
 
-  it('skips inactive (already-resolved) invariants', () => {
+  it('skips inactive (superseded) invariants', () => {
     const doc = docOf(
       p('b-declare', 'Terminations are now 30 days per the updated policy.'),
       p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
     )
     const violations = checkInvariants(doc, [invariant({ status: 'superseded' })])
+    expect(violations).toEqual([])
+  })
+
+  it('skips inactive (resolved via the #35 "Nevermind" flow) invariants', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant({ status: 'resolved' })])
     expect(violations).toEqual([])
   })
 

--- a/src/lib/invariants/captureInvariant.ts
+++ b/src/lib/invariants/captureInvariant.ts
@@ -11,6 +11,7 @@
  */
 
 export type InvariantCheckKind = 'deterministic' | 'entailment'
+export type InvariantResolveStatus = 'resolved' | 'superseded'
 
 export interface Invariant {
   id: string
@@ -20,6 +21,7 @@ export interface Invariant {
   checkKind: InvariantCheckKind
   status: string
   provenanceCommitHash: string | null
+  supersedesId: string | null
   createdAt: string
 }
 
@@ -87,4 +89,31 @@ export async function listInvariants(documentId: string): Promise<Invariant[]> {
   if (!res.ok) throw new Error(`Failed to load invariants (HTTP ${res.status})`)
   const data = await res.json()
   return data.invariants ?? []
+}
+
+export interface ResolveInvariantParams {
+  documentId: string
+  invariantId: string
+  status: InvariantResolveStatus
+}
+
+/**
+ * Append a status-transition row for a DocInvariant (Phase 3, #35) — see
+ * `/api/invariants/resolve` for why this is a new row, not a PATCH. Throws on
+ * failure — callers that must react differently to success vs. failure (e.g.
+ * `resolveInvariantFlagOnDismiss`, which only prunes dedup memory on success)
+ * should catch this directly rather than using a swallowing wrapper.
+ */
+export async function resolveInvariant(params: ResolveInvariantParams): Promise<Invariant> {
+  const res = await fetch('/api/invariants/resolve', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  })
+  if (!res.ok) {
+    const data = await res.json().catch(() => null)
+    throw new Error(data?.error ?? `Failed to resolve invariant (HTTP ${res.status})`)
+  }
+  const data = await res.json()
+  return data.invariant
 }

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -7,7 +7,7 @@ import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
 import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import { generateId } from '@/lib/utils/id'
-import { listInvariants } from './captureInvariant'
+import { listInvariants, resolveInvariant } from './captureInvariant'
 import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
 import type { Annotation, CascadeEvidence, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
 
@@ -29,9 +29,36 @@ const FLAG_ACTIONS: ResolutionAction[] = [
   { label: 'Nevermind', kind: 'dismiss', handler: 'dismiss' },
 ]
 
+// Shared with `invariantIdFromFlagKey` below — the one source of truth for
+// this key's shape, so construction and parsing can't drift apart.
+const INVARIANT_KEY_MARKER = 'invariant'
+
 /** Deterministic key for one (invariant, conflicting block) pair — the dedup unit. */
 function violationKey(documentId: string, violation: InvariantViolation): string {
-  return `${documentId}:invariant:${violation.invariantId}:${violation.conflictBlockId}`
+  return `${documentId}:${INVARIANT_KEY_MARKER}:${violation.invariantId}:${violation.conflictBlockId}`
+}
+
+/**
+ * Recovers the invariantId from a `locationGroupKey` produced by
+ * `violationKey` above (an invariant-check flag's `Annotation.locationGroupKey`
+ * IS that key verbatim), or null for any other annotation. Used by
+ * `resolveInvariantFlagOnDismiss` below to detect "this is an invariant-check
+ * flag" without adding a new field to the general-purpose `Annotation` type.
+ *
+ * Anchored from the END of the string (the last 3 ':'-separated segments must
+ * be [marker, invariantId, conflictBlockId]) rather than searching for the
+ * marker from the front. `invariantId` (a Prisma cuid) and `conflictBlockId`
+ * (a ProseMirror block id) never contain colons by construction, but
+ * `documentId` is not similarly constrained here — an indexOf-from-the-front
+ * search would misparse a documentId that happens to contain the literal
+ * substring "invariant" bracketed by colons.
+ */
+export function invariantIdFromFlagKey(locationGroupKey: string): string | null {
+  const parts = locationGroupKey.split(':')
+  if (parts.length < 4) return null
+  const [invariantId, conflictBlockId] = parts.slice(-2)
+  if (parts[parts.length - 3] !== INVARIANT_KEY_MARKER) return null
+  return invariantId && conflictBlockId ? invariantId : null
 }
 
 /**
@@ -204,5 +231,30 @@ export async function runAndSurfaceInvariantChecks(
     }
   } catch (err) {
     console.warn('[invariants] Check runner failed:', err)
+  }
+}
+
+/**
+ * Resolves the ledger row behind a dismissed invariant-check flag ("Nevermind",
+ * #35) and prunes its dedup entry — but ONLY once the resolve genuinely
+ * succeeds. A failed network call leaves the dedup entry in place, so the
+ * still-`active` ledger row's dedup memory stays intact (bounded by
+ * `invariantFlagStore`'s own `MAX_SURFACED` eviction) instead of letting the
+ * next `runAndSurfaceInvariantChecks` pass treat the same conflict as
+ * never-seen and append an unbounded new entry to `annotationStore` (which,
+ * unlike the flag store, has no cap). No-op — and no network call — for a
+ * `locationGroupKey` that isn't an invariant-check flag's.
+ */
+export async function resolveInvariantFlagOnDismiss(annotation: {
+  documentId: string
+  locationGroupKey: string
+}): Promise<void> {
+  const invariantId = invariantIdFromFlagKey(annotation.locationGroupKey)
+  if (!invariantId) return
+  try {
+    await resolveInvariant({ documentId: annotation.documentId, invariantId, status: 'resolved' })
+    useInvariantFlagStore.getState().removeSurfaced(annotation.locationGroupKey)
+  } catch (err) {
+    console.warn('[invariants] Failed to resolve invariant on dismiss:', err)
   }
 }

--- a/src/lib/invariants/invariantSelect.ts
+++ b/src/lib/invariants/invariantSelect.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared Prisma `select` shape for DocInvariant reads, used by both
+ * /api/invariants and /api/invariants/resolve. Pulled out of route.ts
+ * because Next.js App Router route files may only export route handlers
+ * (GET/POST/etc.) and a small fixed set of config fields — any other named
+ * export fails the build's route-type check.
+ */
+export const INVARIANT_SELECT = {
+  id: true,
+  documentId: true,
+  statement: true,
+  blockIds: true,
+  checkKind: true,
+  status: true,
+  provenanceCommitHash: true,
+  supersedesId: true,
+  createdAt: true,
+} as const

--- a/src/stores/invariantFlagStore.ts
+++ b/src/stores/invariantFlagStore.ts
@@ -20,6 +20,7 @@ interface InvariantFlagState {
   surfaced: string[]
   hasSurfaced: (key: string) => boolean
   markSurfaced: (key: string) => void
+  removeSurfaced: (key: string) => void
   clear: () => void
 }
 
@@ -34,6 +35,11 @@ export const useInvariantFlagStore = create<InvariantFlagState>()(
             ? s
             : { surfaced: [...s.surfaced, key].slice(-MAX_SURFACED) },
         ),
+      // Called when the underlying invariant is resolved/dismissed (#35) —
+      // the ledger itself now excludes it from future checks, so holding
+      // onto its dedup entry serves no purpose and just crowds out the
+      // MAX_SURFACED window for pairs that might still recur.
+      removeSurfaced: (key) => set((s) => ({ surfaced: s.surfaced.filter((k) => k !== key) })),
       clear: () => set({ surfaced: [] }),
     }),
     { name: 'intent-ide-invariant-flags' },


### PR DESCRIPTION
## Summary

Phase 1 (#26, PR #29) and Phase 2 (#32, PR #34) never gave a `DocInvariant` row a way to leave `status: 'active'` — clicking "Nevermind" on a surfaced conflict only dismissed the local annotation, not the underlying ledger row. This adds that transition.

- **New `POST /api/invariants/resolve`** — an append-only status transition. It does **not** mutate the target row's `statement`/`blockIds`/`checkKind`/`provenanceCommitHash`/`status` in place. Instead it creates a **new** row that duplicates the target's evidentiary content forward, sets `status` to `'resolved'` or `'superseded'`, and points a new `supersedesId` column at the row it replaces — the same parent-pointer-chain shape `DocCommit.parentHash` already uses elsewhere in this codebase. Chosen over an in-place `PATCH` because it matches this project's "tamper-evident, not immutable, but auditable" posture (`docs/compliance.md`) instead of introducing the one kind of row in this ledger whose evidentiary fields could silently change after the fact.
- **`GET /api/invariants`** now computes a "live" set — a row is live iff no other row's `supersedesId` points at it — so a resolved invariant naturally stops being checked without its history being rewritten. Scans up to a disclosed `SUPERSEDE_SCAN_CAP` (2000 rows/document) to compute this, same disclosed-limit posture as `/api/audit`'s body cap.
- **`supersedesId` is a DB-enforced unique column** (SQLite allows unlimited `NULL`s, so ordinary capture rows are unaffected) — at most one row can ever point at a given target, so two concurrent resolve requests can't both succeed and write duplicate ledger rows for one logical dismissal.
- **Wired "Nevermind"**: `invariantCascade.ts`'s `FLAG_ACTIONS` `'dismiss'` handler (in `ResolutionActions.tsx`) now calls the new endpoint via `invariantIdFromFlagKey()` — parsed from the flag annotation's existing `locationGroupKey`, so no new field was needed on the general-purpose `Annotation` type — and prunes the now-pointless dedup entry from `invariantFlagStore`.

## Process record

Pre-push adversarial (troublemaker) review returned **NO-MERGE with 2 HIGH findings**, both fixed before this PR was opened:

- **TOCTOU race in the resolve endpoint**, reachable via a plain double-click (the "Nevermind" button had no disabled/processing guard) — two concurrent requests could both pass the existence pre-check before either wrote, producing two ledger rows for one dismissal. Fixed with the DB-level unique constraint on `supersedesId` plus a catch-and-requery on the create call (same idempotent-collision pattern `/api/history` already uses for its own unique-constraint race), and a client-side idempotency guard that reads live store state so a double-click can't fire the resolve call twice.
- **Unconditional dedup-entry removal on dismiss** — `invariantFlagStore`'s dedup key was being pruned regardless of whether the resolve network call ever succeeded. On a persistent failure, the still-`active` ledger row would keep getting rediscovered by the doc-CI check runner with no dedup memory to stop it, appending an unbounded new row to `annotationStore` (which, unlike the flag store, has no cap) on every future apply. Fixed: the dedup entry is now only pruned after the resolve call genuinely succeeds; a failure leaves it in place, matching the pre-#35 bounded (`MAX_SURFACED`-capped) behavior.

Also fixed on review: `invariantIdFromFlagKey` now parses the invariantId from the **end** of the `locationGroupKey` (anchoring on the last three `:`-separated segments) instead of searching for the `:invariant:` marker from the front — a `documentId` containing that literal substring would otherwise misparse into resolving the wrong invariant. Not reachable today (`documentId` is always a colon-free `nanoid()`), but untested before this fix and cheap to make robust regardless.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 903 passing + 10 skipped (was 897 before the review-fix pass, 887 before this branch)
- [x] `npm run build` — clean
- [x] `npx prisma migrate deploy` against a fresh SQLite DB (mirrors the CI step) — all 5 migrations apply cleanly
- [x] New coverage: the resolve route's validation/404/409/race/chained-resolve paths, `GET /api/invariants` excluding superseded rows (including a two-level supersede chain), `runAndSurfaceInvariantChecks` skipping a newly-`resolved` invariant, `resolveInvariantFlagOnDismiss`'s success/failure/no-op paths, and `invariantIdFromFlagKey`'s adversarial-documentId case
- [x] Adversarial (troublemaker) review completed; both HIGH findings fixed and regression-tested before push

Closes #35

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar191tgTbZPVx1j7GprDnE)_