### PR TITLE
Recover stranded answer-placement + a11y work from claude/pr-audit-sidebar-options-nvwfu8

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,11 +1,27 @@
 import { defineConfig, devices } from '@playwright/test'
 
+/**
+ * Some sandboxes ship a Chromium that predates the revision this Playwright
+ * version would download, and cannot fetch a new one. Point
+ * PLAYWRIGHT_CHROMIUM_PATH at that binary to use it instead; unset (the CI
+ * case, where `playwright install` runs normally) keeps the default browser.
+ */
+const chromiumPath = process.env.PLAYWRIGHT_CHROMIUM_PATH
+
 export default defineConfig({
   testDir: './tests',
   // First Next.js dev compile of the page can take well over 30s.
   timeout: 120_000,
   retries: 0,
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(chromiumPath ? { launchOptions: { executablePath: chromiumPath } } : {}),
+      },
+    },
+  ],
   use: {
     baseURL: 'http://localhost:3000',
     headless: true,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -751,3 +751,144 @@
     animation: none;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Floating answer panel — the `floating` answer placement. The resolved
+   annotation card detaches from the sidebar and parks beside the passage it
+   belongs to, so the answer sits next to the text it is about. Positioned by
+   computeFloatingPosition(); this file only styles the shell.
+   --------------------------------------------------------------------------- */
+.floating-answer-panel {
+  position: fixed;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 24px);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 120, 93, 0.24);
+  background: rgba(255, 252, 247, 0.98);
+  backdrop-filter: blur(14px);
+  box-shadow:
+    0 24px 60px rgba(71, 48, 28, 0.16),
+    0 2px 8px rgba(71, 48, 28, 0.06);
+  overflow: hidden;
+  animation: floating-answer-in 0.14s ease;
+}
+
+@keyframes floating-answer-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .floating-answer-panel {
+    animation: none;
+  }
+}
+
+.floating-answer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 8px 12px;
+  border-bottom: 1px solid rgba(148, 120, 93, 0.18);
+  background: rgba(246, 239, 228, 0.7);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.floating-answer-header:active {
+  cursor: grabbing;
+}
+
+.floating-answer-grip {
+  font-size: 12px;
+  line-height: 1;
+  color: rgba(136, 113, 90, 0.7);
+}
+
+.floating-answer-title {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.floating-answer-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.floating-answer-btn {
+  padding: 2px 8px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 120, 93, 0.24);
+  background: rgba(255, 252, 247, 0.9);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.floating-answer-btn:hover {
+  background: #fff;
+  color: hsl(var(--foreground));
+}
+
+.floating-answer-close {
+  padding: 2px 7px;
+  font-size: 13px;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.floating-answer-body {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* Segmented control for choosing where answers appear. */
+.placement-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 9999px;
+  border: 1px solid rgba(148, 120, 93, 0.2);
+  background: rgba(255, 251, 245, 0.8);
+}
+
+.placement-toggle-btn {
+  padding: 3px 9px;
+  border-radius: 9999px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.placement-toggle-btn:hover {
+  color: hsl(var(--foreground));
+}
+
+.placement-toggle-btn[aria-pressed='true'] {
+  background: hsl(var(--foreground));
+  color: #fff;
+  box-shadow: 0 1px 2px rgba(71, 48, 28, 0.18);
+}

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -144,8 +144,12 @@ export function AnnotationCard({
   // this card's ANSWER is held, poll the read-line high-water mark against the
   // anchor block's end; with no reading signal at all, fall back to the dwell
   // timer. On reveal, flash a transient "Answer ready" chip.
+  // Gated by showDetail for the same reason as the cascade-reveal effect above:
+  // when detailElsewhere is set, a second AnnotationCard for this annotation is
+  // mounted elsewhere (the floating panel) and must be the sole owner of this
+  // poll, or both copies flash their own "Answer ready" chip independently.
   useEffect(() => {
-    if (!heldEntry || !view) return
+    if (!heldEntry || !view || !showDetail) return
     const timer = setInterval(() => {
       const highWaterMark = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
       const breakpointPos = answerBreakpointPos(view.state.doc, annotation.anchor)
@@ -158,7 +162,7 @@ export function AnnotationCard({
       }
     }, 500)
     return () => clearInterval(timer)
-  }, [heldEntry, view, annotation.id, annotation.anchor])
+  }, [heldEntry, view, annotation.id, annotation.anchor, showDetail])
 
   // Auto-clear the transient chip after the fade animation (~4s).
   useEffect(() => {

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -364,6 +364,7 @@ export function AnnotationCard({
       <button
         onClick={(e) => { e.stopPropagation(); scrollToAnchor() }}
         className="w-full text-left text-xs text-ink/60 bg-warm/40 hover:bg-warm/70 rounded-lg px-2.5 py-1.5 border-l-2 border-accent/30 transition-colors cursor-pointer truncate"
+        aria-label="Scroll to the annotated passage"
         title="Click to scroll to this passage"
       >
         &ldquo;{annotation.anchor.text.slice(0, 50)}{annotation.anchor.text.length > 50 ? '...' : ''}&rdquo;

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -37,6 +37,19 @@ function isMutatingOverride(from: AnnotationType, to: AnnotationType): boolean {
 interface AnnotationCardProps {
   annotation: Annotation
   isActive: boolean
+  /**
+   * This card's expanded body is rendered somewhere else (the floating answer
+   * panel). The row keeps its active highlight but renders no detail and runs
+   * no cascade-decoration effect, so exactly one card owns the proposed-edit
+   * decorations at a time no matter how many copies of the thread are on
+   * screen.
+   */
+  detailElsewhere?: boolean
+  /**
+   * Clicking the card never deactivates it. The floating panel owns dismissal,
+   * so a click inside it must not collapse the thread out from under the user.
+   */
+  lockActive?: boolean
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -57,7 +70,15 @@ const STATUS_STYLES: Record<string, string> = {
   dismissed: 'bg-stone-200 text-stone-700',
 }
 
-export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
+export function AnnotationCard({
+  annotation,
+  isActive,
+  detailElsewhere = false,
+  lockActive = false,
+}: AnnotationCardProps) {
+  // The expanded body — and everything that only makes sense alongside it —
+  // belongs to whichever card is actually rendering the detail.
+  const showDetail = isActive && !detailElsewhere
   const setActive = useAnnotationStore((s) => s.setActive)
   const updateAnnotation = useAnnotationStore((s) => s.update)
   const addMessage = useAnnotationStore((s) => s.addMessage)
@@ -89,7 +110,7 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
   // tracked yet — reveals everything immediately (see partitionCascadeReveal).
   const reviewEdits = annotation.resolution?.edits
   useEffect(() => {
-    if (!view || !isActive) return
+    if (!view || !showDetail) return
     if (annotation.status === 'resolved' && reviewEdits && reviewEdits.length > 1) {
       const primary = reviewEdits.find((e) => e.relation === 'primary')
       const breakpoint = cascadeBreakpointPos(view.state.doc, primary)
@@ -117,7 +138,7 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
     return () => {
       clearProposedEdits(view)
     }
-  }, [isActive, annotation.status, reviewEdits, view])
+  }, [showDetail, annotation.status, reviewEdits, view])
 
   // Sibling effect to the cascade-reveal poll above (do NOT merge them): while
   // this card's ANSWER is held, poll the read-line high-water mark against the
@@ -260,7 +281,9 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
     // mark — this click is user attention, not capture plumbing.
     revealAnswer(annotation.id)
     markUserActivated(annotation.id)
-    setActive(isActive ? null : annotation.id)
+    if (!lockActive) {
+      setActive(isActive ? null : annotation.id)
+    }
     if (!isActive) {
       scrollToAnchor()
     }
@@ -370,7 +393,7 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
       )}
 
       {/* Verbosity toggle (when active and resolved; hidden while the answer is held) */}
-      {isActive && !held && annotation.resolution && (
+      {showDetail && !held && annotation.resolution && (
         <div className="mt-2 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
           <span className="text-[10px] font-mono text-muted-foreground mr-1">Length:</span>
           {(['concise', 'normal', 'detailed'] as const).map((v) => (
@@ -418,7 +441,7 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
       )}
 
       {/* Inline provocation callout (when MADS raised an unresolved objection; hidden while held) */}
-      {isActive && !held && annotation.resolution?.provocation && (
+      {showDetail && !held && annotation.resolution?.provocation && (
         <div className="mt-3 mx-1 p-3 border border-amber-300 bg-amber-50 rounded-xl shadow-sm">
           <div className="flex items-start gap-2">
             <span className="text-amber-600 text-xs font-bold shrink-0">⚠</span>
@@ -440,10 +463,10 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
       )}
 
       {/* Cascade review list — navigable "affects N sections" (when active) */}
-      {isActive && <CascadeList annotation={annotation} />}
+      {showDetail && <CascadeList annotation={annotation} />}
 
       {/* Conversation thread (when active and has conversation messages; hidden while the answer is held) */}
-      {isActive && !held && annotation.conversation && annotation.conversation.length > 0 && (
+      {showDetail && !held && annotation.conversation && annotation.conversation.length > 0 && (
         <div className="mt-3 pt-3 border-t border-border/70" onClick={(e) => e.stopPropagation()}>
           <ConversationThread messages={annotation.conversation} annotationId={annotation.id} isStreaming={annotation.status === 'resolving'} />
           {annotation.resolution && <ResolutionActions annotation={annotation} />}
@@ -456,7 +479,7 @@ export function AnnotationCard({ annotation, isActive }: AnnotationCardProps) {
       )}
 
       {/* Resolution content (when active, resolved, and no conversation — backward compatibility; hidden while the answer is held) */}
-      {isActive && !held && annotation.resolution && (!annotation.conversation || annotation.conversation.length === 0) && (
+      {showDetail && !held && annotation.resolution && (!annotation.conversation || annotation.conversation.length === 0) && (
         <div className="mt-3 pt-3 border-t border-border/70" onClick={(e) => e.stopPropagation()}>
           <div className="text-sm text-ink leading-relaxed">
             <AgentMarkdown content={annotation.resolution.content} />

--- a/src/components/Annotations/AnnotationComposer.tsx
+++ b/src/components/Annotations/AnnotationComposer.tsx
@@ -132,6 +132,8 @@ export function AnnotationComposer({
 
         <button
           onClick={handleVoiceToggle}
+          aria-label={isRecording ? 'Stop recording' : 'Voice input'}
+          aria-pressed={isRecording}
           title={isRecording ? 'Stop recording' : 'Voice input'}
           className={`w-8 h-8 flex items-center justify-center rounded-full transition-colors shrink-0 ${
             isRecording
@@ -139,7 +141,7 @@ export function AnnotationComposer({
               : 'text-muted-foreground hover:text-ink hover:bg-warm'
           }`}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
             <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
             <line x1="12" y1="19" x2="12" y2="23" />
@@ -149,10 +151,11 @@ export function AnnotationComposer({
         <button
           onClick={handleSubmit}
           disabled={!value.trim() || isSubmitting}
+          aria-label="Submit annotation"
           title="Submit"
           className="w-8 h-8 flex items-center justify-center rounded-full text-white bg-accent hover:bg-accent/80 transition-colors shrink-0 disabled:opacity-30 disabled:cursor-not-allowed"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <line x1="22" y1="2" x2="11" y2="13" />
             <polygon points="22 2 15 22 11 13 2 9 22 2" />
           </svg>

--- a/src/components/Annotations/AnnotationPanel.tsx
+++ b/src/components/Annotations/AnnotationPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAnnotationStore } from '@/stores/annotationStore'
+import { useLayoutStore } from '@/stores/layoutStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { AnnotationCard } from './AnnotationCard'
 import { AnnotationMap } from './AnnotationMap'
@@ -29,6 +30,8 @@ export function AnnotationPanel() {
   const annotations = useAnnotationStore((s) => s.annotations)
   const activeId = useAnnotationStore((s) => s.activeAnnotationId)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
+  const placement = useLayoutStore((s) => s.answerPlacement)
+  const setPlacement = useLayoutStore((s) => s.setAnswerPlacement)
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const listRef = useRef<HTMLDivElement>(null)
 
@@ -107,7 +110,25 @@ export function AnnotationPanel() {
         <span className="text-[10px] font-mono text-muted-foreground uppercase tracking-[0.2em]">
           {annotationCount} review item{annotationCount !== 1 ? 's' : ''}
         </span>
-        <div className="flex gap-1">
+        <div className="flex items-center gap-2">
+          <div className="placement-toggle" role="group" aria-label="Where answers appear">
+            <button
+              onClick={() => setPlacement('sidebar')}
+              aria-pressed={placement === 'sidebar'}
+              title="Answers expand here in the sidebar"
+              className="placement-toggle-btn"
+            >
+              Sidebar
+            </button>
+            <button
+              onClick={() => setPlacement('floating')}
+              aria-pressed={placement === 'floating'}
+              title="Answers float beside the passage they belong to"
+              className="placement-toggle-btn"
+            >
+              Floating
+            </button>
+          </div>
           <button
             onClick={() => setViewMode('list')}
             title="Grouped list view"
@@ -154,6 +175,7 @@ export function AnnotationPanel() {
                       <AnnotationCard
                         annotation={annotation}
                         isActive={annotation.id === activeId}
+                        detailElsewhere={placement === 'floating'}
                       />
                     </div>
                   ))}

--- a/src/components/Annotations/AnnotationPanel.tsx
+++ b/src/components/Annotations/AnnotationPanel.tsx
@@ -92,7 +92,7 @@ export function AnnotationPanel() {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-center px-6">
         <div className="w-12 h-12 rounded-full bg-warm flex items-center justify-center mb-3">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-muted-foreground">
+          <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-muted-foreground">
             <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
             <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
             <line x1="12" y1="19" x2="12" y2="23" />
@@ -131,20 +131,24 @@ export function AnnotationPanel() {
           </div>
           <button
             onClick={() => setViewMode('list')}
+            aria-label="Grouped list view"
+            aria-pressed={viewMode === 'list'}
             title="Grouped list view"
             className={`p-1.5 rounded-lg transition-colors ${viewMode === 'list' ? 'bg-ink text-white shadow-sm' : 'text-muted-foreground hover:bg-warm/80'}`}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
               <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
             </svg>
           </button>
           <button
             onClick={() => setViewMode('map')}
+            aria-label="Map view (beta)"
+            aria-pressed={viewMode === 'map'}
             title="Map view (beta)"
             className={`p-1.5 rounded-lg transition-colors ${viewMode === 'map' ? 'bg-ink text-white shadow-sm' : 'text-muted-foreground hover:bg-warm/80'}`}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="12" y1="3" x2="12" y2="21" />
             </svg>
           </button>

--- a/src/components/Annotations/FloatingAnswer.tsx
+++ b/src/components/Annotations/FloatingAnswer.tsx
@@ -137,6 +137,12 @@ export function FloatingAnswer() {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [visible, setActive])
 
+  // Cleared by the drag's own pointerup in the common case; the unmount effect
+  // below is the fallback for a drag interrupted by unmount (Escape, Dock,
+  // placement toggled mid-drag) — pointerup on window would otherwise never
+  // fire and the listeners would linger untracked by React.
+  const dragCleanupRef = useRef<(() => void) | null>(null)
+
   const handleDragStart = useCallback((e: React.PointerEvent) => {
     // Ignore drags started on the header's buttons.
     if ((e.target as HTMLElement).closest('button')) return
@@ -154,9 +160,15 @@ export function FloatingAnswer() {
     function handleUp() {
       window.removeEventListener('pointermove', handleMove)
       window.removeEventListener('pointerup', handleUp)
+      dragCleanupRef.current = null
     }
     window.addEventListener('pointermove', handleMove)
     window.addEventListener('pointerup', handleUp)
+    dragCleanupRef.current = handleUp
+  }, [])
+
+  useEffect(() => {
+    return () => dragCleanupRef.current?.()
   }, [])
 
   if (!mounted || !visible || !annotation || !position) return null

--- a/src/components/Annotations/FloatingAnswer.tsx
+++ b/src/components/Annotations/FloatingAnswer.tsx
@@ -1,0 +1,216 @@
+'use client'
+
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useEditorStore } from '@/stores/editorStore'
+import { useLayoutStore } from '@/stores/layoutStore'
+import { AnnotationCard } from './AnnotationCard'
+import {
+  computeFloatingPosition,
+  isAnchorOnScreen,
+  type AnchorRect,
+  type FloatingPosition,
+} from '@/lib/annotations/floatingPosition'
+
+/** Used until the panel has been measured once. */
+const DEFAULT_PANEL = { width: 380, height: 320 }
+const PANEL_WIDTH = 380
+
+/**
+ * Viewport rect covering the annotated passage, or null when ProseMirror
+ * cannot resolve the anchor (stale position after an edit, unmounted view).
+ */
+function anchorRect(
+  view: ReturnType<typeof useEditorStore.getState>['view'],
+  from: number,
+  to: number,
+): AnchorRect | null {
+  if (!view) return null
+  try {
+    const size = view.state.doc.content.size
+    const start = Math.max(0, Math.min(from, size))
+    const end = Math.max(start, Math.min(to, size))
+    const a = view.coordsAtPos(start)
+    const b = view.coordsAtPos(end)
+    return {
+      top: Math.min(a.top, b.top),
+      bottom: Math.max(a.bottom, b.bottom),
+      left: Math.min(a.left, b.left),
+      right: Math.max(a.right, b.right),
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The answer for the active annotation, detached from the sidebar and parked
+ * beside the passage it belongs to. Rendered only while the answer placement
+ * preference is `floating`; the sidebar keeps a compact index of the same
+ * threads and hands the detail over via `detailElsewhere`.
+ */
+export function FloatingAnswer() {
+  const placement = useLayoutStore((s) => s.answerPlacement)
+  const offset = useLayoutStore((s) => s.floatingOffset)
+  const activeId = useAnnotationStore((s) => s.activeAnnotationId)
+  const annotations = useAnnotationStore((s) => s.annotations)
+  const setActive = useAnnotationStore((s) => s.setActive)
+  const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
+  const view = useEditorStore((s) => s.view)
+
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState<FloatingPosition | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  const annotation = annotations.find((a) => a.id === activeId) ?? null
+  const visible =
+    placement === 'floating' && !!annotation && annotation.documentId === activeDocumentId
+
+  // Portals need a document; Next renders this component on the server too.
+  useEffect(() => setMounted(true), [])
+
+  const from = annotation?.anchor.from ?? 0
+  const to = annotation?.anchor.to ?? 0
+
+  const recompute = useCallback(() => {
+    if (!visible) return
+    const viewport = { width: window.innerWidth, height: window.innerHeight }
+    const rect = anchorRect(view, from, to)
+    const measured = panelRef.current?.getBoundingClientRect()
+    setPosition(
+      computeFloatingPosition({
+        anchor: isAnchorOnScreen(rect, viewport) ? rect : null,
+        panel: measured?.height
+          ? { width: measured.width, height: measured.height }
+          : DEFAULT_PANEL,
+        viewport,
+        offset,
+      }),
+    )
+  }, [visible, view, from, to, offset])
+
+  // Position before paint so the panel never flashes at the wrong place.
+  useLayoutEffect(() => {
+    recompute()
+  }, [recompute])
+
+  // Follow the passage while the user scrolls or resizes. `capture: true`
+  // catches the editor's own scroll container, which does not bubble.
+  useEffect(() => {
+    if (!visible) return
+    let frame = 0
+    const schedule = () => {
+      if (frame) return
+      frame = requestAnimationFrame(() => {
+        frame = 0
+        recompute()
+      })
+    }
+    window.addEventListener('scroll', schedule, true)
+    window.addEventListener('resize', schedule)
+    return () => {
+      if (frame) cancelAnimationFrame(frame)
+      window.removeEventListener('scroll', schedule, true)
+      window.removeEventListener('resize', schedule)
+    }
+  }, [visible, recompute])
+
+  // The card grows as the answer streams in; re-clamp when it does.
+  useEffect(() => {
+    const node = panelRef.current
+    if (!visible || !node || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(() => recompute())
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [visible, recompute])
+
+  // Escape closes the panel — the same gesture that dismisses every other
+  // overlay in the app.
+  useEffect(() => {
+    if (!visible) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setActive(null)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [visible, setActive])
+
+  const handleDragStart = useCallback((e: React.PointerEvent) => {
+    // Ignore drags started on the header's buttons.
+    if ((e.target as HTMLElement).closest('button')) return
+    e.preventDefault()
+    const startX = e.clientX
+    const startY = e.clientY
+    const start = useLayoutStore.getState().floatingOffset
+
+    function handleMove(move: PointerEvent) {
+      useLayoutStore.getState().setFloatingOffset({
+        dx: start.dx + (move.clientX - startX),
+        dy: start.dy + (move.clientY - startY),
+      })
+    }
+    function handleUp() {
+      window.removeEventListener('pointermove', handleMove)
+      window.removeEventListener('pointerup', handleUp)
+    }
+    window.addEventListener('pointermove', handleMove)
+    window.addEventListener('pointerup', handleUp)
+  }, [])
+
+  if (!mounted || !visible || !annotation || !position) return null
+
+  const dragged = offset.dx !== 0 || offset.dy !== 0
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label={`Answer for “${annotation.anchor.text.slice(0, 60)}”`}
+      className="floating-answer-panel"
+      style={{ left: position.left, top: position.top, width: PANEL_WIDTH }}
+    >
+      <div className="floating-answer-header" onPointerDown={handleDragStart}>
+        <span className="floating-answer-grip" aria-hidden="true">
+          ⠿
+        </span>
+        <span className="floating-answer-title">Answer</span>
+        <div className="floating-answer-header-actions">
+          {dragged && (
+            <button
+              type="button"
+              onClick={() => useLayoutStore.getState().resetFloatingOffset()}
+              className="floating-answer-btn"
+              title="Snap back beside the passage"
+            >
+              Snap back
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => useLayoutStore.getState().setAnswerPlacement('sidebar')}
+            className="floating-answer-btn"
+            title="Move answers back into the sidebar"
+          >
+            Dock
+          </button>
+          <button
+            type="button"
+            onClick={() => setActive(null)}
+            className="floating-answer-btn floating-answer-close"
+            aria-label="Close answer"
+            title="Close (Esc)"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+
+      <div className="floating-answer-body">
+        <AnnotationCard annotation={annotation} isActive lockActive />
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/Annotations/FollowUpInput.tsx
+++ b/src/components/Annotations/FollowUpInput.tsx
@@ -85,9 +85,10 @@ export function FollowUpInput({ annotation, onSend, disabled }: FollowUpInputPro
         }}
         disabled={!text.trim() || disabled}
         className="p-2 rounded-lg text-muted hover:text-ink hover:bg-warm transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+        aria-label="Send follow-up"
         title="Send"
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path d="M14 2L7 9M14 2L9.5 14L7 9M14 2L2 6.5L7 9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </button>
@@ -104,9 +105,11 @@ export function FollowUpInput({ annotation, onSend, disabled }: FollowUpInputPro
             ? 'text-red-500 bg-red-50 hover:bg-red-100'
             : 'text-muted hover:text-ink hover:bg-warm'
         }`}
+        aria-label={isRecording ? 'Stop recording' : isTranscribing ? 'Transcribing' : 'Voice input'}
+        aria-pressed={isRecording}
         title={isRecording ? 'Stop recording' : isTranscribing ? 'Transcribing...' : 'Voice input'}
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
           <rect x="5.5" y="1" width="5" height="9" rx="2.5" stroke="currentColor" strokeWidth="1.5" />
           <path d="M3 7.5C3 10.26 5.24 12.5 8 12.5C10.76 12.5 13 10.26 13 7.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
           <path d="M8 12.5V15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />

--- a/src/components/DocInput/DocInputModal.tsx
+++ b/src/components/DocInput/DocInputModal.tsx
@@ -106,7 +106,7 @@ export function DocInputModal({ onClose }: DocInputModalProps) {
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
           <h2 className="font-serif text-xl">Load Document</h2>
-          <button onClick={onClose} className="text-muted hover:text-ink text-xl leading-none">&times;</button>
+          <button onClick={onClose} aria-label="Close" title="Close" className="text-muted hover:text-ink text-xl leading-none">&times;</button>
         </div>
 
         {/* Mode tabs */}

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -27,20 +27,34 @@ import { triggerFloatingBar } from '@/lib/prosemirror/plugins/contextMenuPlugin'
 
 type SidebarTab = 'annotations' | 'changes' | 'documents' | 'history' | 'audit'
 
-/** Sidebar tabs, in display order. One row of markup serves all of them. */
-const SIDEBAR_TABS: { id: SidebarTab; label: string }[] = [
+/**
+ * Sidebar tabs, split by how they are used rather than alphabetically.
+ *
+ * The rail is a fixed 320px. Five equal tabs left each label about 55px, which
+ * is why they were set at 10px with wide tracking and still read poorly. The
+ * three workspaces people live in keep the rail; History and Audit are
+ * reference surfaces consulted occasionally, so they move behind an overflow
+ * menu that names whichever of them is active.
+ */
+const PRIMARY_TABS: { id: SidebarTab; label: string }[] = [
   { id: 'annotations', label: 'Annotations' },
   { id: 'changes', label: 'Changes' },
   { id: 'documents', label: 'Documents' },
+]
+
+const OVERFLOW_TABS: { id: SidebarTab; label: string }[] = [
   { id: 'history', label: 'History' },
   { id: 'audit', label: 'Audit' },
 ]
+
+const SIDEBAR_TABS = [...PRIMARY_TABS, ...OVERFLOW_TABS]
 
 const SIDEBAR_TAB_IDS = new Set<string>(SIDEBAR_TABS.map((tab) => tab.id))
 
 export function AppShell() {
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('annotations')
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  const [showTabOverflow, setShowTabOverflow] = useState(false)
   const [showDocInput, setShowDocInput] = useState(false)
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showAgentConfig, setShowAgentConfig] = useState(false)
@@ -67,6 +81,26 @@ export function AppShell() {
       }
     }
   }, [activeDocumentId])
+
+  // Overflow menu: dismiss on outside click or Escape, like every other
+  // transient surface in the app.
+  useEffect(() => {
+    if (!showTabOverflow) return
+    function handlePointerDown(e: MouseEvent) {
+      if (!(e.target as HTMLElement).closest('[data-tab-overflow]')) {
+        setShowTabOverflow(false)
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setShowTabOverflow(false)
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [showTabOverflow])
 
   // Warn on unsaved changes before unload
   useEffect(() => {
@@ -125,6 +159,7 @@ export function AppShell() {
       if (typeof detail === 'string' && SIDEBAR_TAB_IDS.has(detail)) {
         setSidebarTab(detail as SidebarTab)
         setIsSidebarCollapsed(false)
+        setShowTabOverflow(false)
       }
     }
     window.addEventListener('intent-ide:sidebar', handleSidebarEvent)
@@ -145,6 +180,8 @@ export function AppShell() {
     }
   }, [])
 
+  const overflowTab = OVERFLOW_TABS.find((tab) => tab.id === sidebarTab) ?? null
+
   return (
     <div className="flex flex-col h-screen app-shell-backdrop">
       {/* Main content */}
@@ -154,12 +191,12 @@ export function AppShell() {
         <div className="w-80 border-r border-border/70 panel-shell flex flex-col shrink-0">
           {/* Sidebar tabs */}
           <div className="flex items-center border-b border-border/70 bg-white/55">
-            {SIDEBAR_TABS.map((tab) => (
+            {PRIMARY_TABS.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setSidebarTab(tab.id)}
                 aria-current={sidebarTab === tab.id ? 'page' : undefined}
-                className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
+                className={`flex-1 px-3 py-3 text-[11px] font-mono uppercase tracking-[0.12em] transition-colors ${
                   sidebarTab === tab.id
                     ? 'text-accent border-b-2 border-accent bg-white/80'
                     : 'text-muted hover:text-ink hover:bg-white/40'
@@ -168,8 +205,51 @@ export function AppShell() {
                 {tab.label}
               </button>
             ))}
+
+            {/* History + Audit. The trigger takes the active tab's name when
+                one of them is showing, so the rail never hides where you are. */}
+            <div className="relative" data-tab-overflow>
+              <button
+                onClick={() => setShowTabOverflow((prev) => !prev)}
+                aria-haspopup="menu"
+                aria-expanded={showTabOverflow}
+                aria-label={overflowTab ? `${overflowTab.label} — more panels` : 'More panels'}
+                title="History and Audit"
+                className={`px-3 py-3 text-[11px] font-mono uppercase tracking-[0.12em] transition-colors ${
+                  overflowTab
+                    ? 'text-accent border-b-2 border-accent bg-white/80'
+                    : 'text-muted hover:text-ink hover:bg-white/40'
+                }`}
+              >
+                {overflowTab ? overflowTab.label : '\u22EF'}
+              </button>
+              {showTabOverflow && (
+                <div
+                  role="menu"
+                  className="absolute right-0 top-full z-30 mt-1 min-w-[10rem] rounded-xl border border-border/70 bg-white py-1 shadow-lg"
+                >
+                  {OVERFLOW_TABS.map((tab) => (
+                    <button
+                      key={tab.id}
+                      role="menuitem"
+                      onClick={() => {
+                        setSidebarTab(tab.id)
+                        setShowTabOverflow(false)
+                      }}
+                      className={`flex w-full items-center px-3 py-2 text-left text-xs transition-colors hover:bg-warm ${
+                        sidebarTab === tab.id ? 'font-semibold text-accent' : 'text-ink'
+                      }`}
+                    >
+                      {tab.label}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
             <button
               onClick={() => setIsSidebarCollapsed(true)}
+              aria-label="Collapse sidebar"
+              aria-expanded={true}
               className="px-3 py-3 text-xs text-muted hover:text-ink hover:bg-white/40 transition-colors"
               title="Collapse sidebar"
             >
@@ -196,6 +276,8 @@ export function AppShell() {
           <div className="w-12 border-r border-border/70 panel-shell flex items-start justify-center py-4 shrink-0">
             <button
               onClick={() => setIsSidebarCollapsed(false)}
+              aria-label="Expand sidebar"
+              aria-expanded={false}
               className="w-8 h-8 rounded-full border border-border/70 text-muted hover:text-ink hover:bg-white/70 transition-colors"
               title="Expand sidebar"
             >

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { EditorShell } from '@/components/Editor/EditorShell'
 import { AnnotationPanel } from '@/components/Annotations/AnnotationPanel'
+import { FloatingAnswer } from '@/components/Annotations/FloatingAnswer'
 import { ChangesPanel } from '@/components/Changes/ChangesPanel'
 import { VoiceButton } from '@/components/Voice/VoiceButton'
 import { VoiceOverlay } from '@/components/Voice/VoiceOverlay'
@@ -25,6 +26,17 @@ import { toggleVoiceCapture } from '@/lib/voice/pipeline'
 import { triggerFloatingBar } from '@/lib/prosemirror/plugins/contextMenuPlugin'
 
 type SidebarTab = 'annotations' | 'changes' | 'documents' | 'history' | 'audit'
+
+/** Sidebar tabs, in display order. One row of markup serves all of them. */
+const SIDEBAR_TABS: { id: SidebarTab; label: string }[] = [
+  { id: 'annotations', label: 'Annotations' },
+  { id: 'changes', label: 'Changes' },
+  { id: 'documents', label: 'Documents' },
+  { id: 'history', label: 'History' },
+  { id: 'audit', label: 'Audit' },
+]
+
+const SIDEBAR_TAB_IDS = new Set<string>(SIDEBAR_TABS.map((tab) => tab.id))
 
 export function AppShell() {
   const [sidebarTab, setSidebarTab] = useState<SidebarTab>('annotations')
@@ -110,8 +122,8 @@ export function AppShell() {
     // Listen for sidebar switch events from command palette
     function handleSidebarEvent(e: Event) {
       const detail = (e as CustomEvent).detail
-      if (detail === 'annotations' || detail === 'changes' || detail === 'documents') {
-        setSidebarTab(detail)
+      if (typeof detail === 'string' && SIDEBAR_TAB_IDS.has(detail)) {
+        setSidebarTab(detail as SidebarTab)
         setIsSidebarCollapsed(false)
       }
     }
@@ -142,56 +154,20 @@ export function AppShell() {
         <div className="w-80 border-r border-border/70 panel-shell flex flex-col shrink-0">
           {/* Sidebar tabs */}
           <div className="flex items-center border-b border-border/70 bg-white/55">
-            <button
-              onClick={() => setSidebarTab('annotations')}
-              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
-                sidebarTab === 'annotations'
-                  ? 'text-accent border-b-2 border-accent bg-white/80'
-                  : 'text-muted hover:text-ink hover:bg-white/40'
-              }`}
-            >
-              Annotations
-            </button>
-            <button
-              onClick={() => setSidebarTab('changes')}
-              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
-                sidebarTab === 'changes'
-                  ? 'text-accent border-b-2 border-accent bg-white/80'
-                  : 'text-muted hover:text-ink hover:bg-white/40'
-              }`}
-            >
-              Changes
-            </button>
-            <button
-              onClick={() => setSidebarTab('documents')}
-              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
-                sidebarTab === 'documents'
-                  ? 'text-accent border-b-2 border-accent bg-white/80'
-                  : 'text-muted hover:text-ink hover:bg-white/40'
-              }`}
-            >
-              Documents
-            </button>
-            <button
-              onClick={() => setSidebarTab('history')}
-              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
-                sidebarTab === 'history'
-                  ? 'text-accent border-b-2 border-accent bg-white/80'
-                  : 'text-muted hover:text-ink hover:bg-white/40'
-              }`}
-            >
-              History
-            </button>
-            <button
-              onClick={() => setSidebarTab('audit')}
-              className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
-                sidebarTab === 'audit'
-                  ? 'text-accent border-b-2 border-accent bg-white/80'
-                  : 'text-muted hover:text-ink hover:bg-white/40'
-              }`}
-            >
-              Audit
-            </button>
+            {SIDEBAR_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setSidebarTab(tab.id)}
+                aria-current={sidebarTab === tab.id ? 'page' : undefined}
+                className={`flex-1 px-4 py-3 text-[10px] font-mono uppercase tracking-[0.24em] transition-colors ${
+                  sidebarTab === tab.id
+                    ? 'text-accent border-b-2 border-accent bg-white/80'
+                    : 'text-muted hover:text-ink hover:bg-white/40'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
             <button
               onClick={() => setIsSidebarCollapsed(true)}
               className="px-3 py-3 text-xs text-muted hover:text-ink hover:bg-white/40 transition-colors"
@@ -299,6 +275,7 @@ export function AppShell() {
       {showDocInput && <DocInputModal onClose={() => setShowDocInput(false)} />}
       {showCommandPalette && <CommandPalette onClose={() => setShowCommandPalette(false)} />}
       <FloatingIconBar />
+      <FloatingAnswer />
 
       {/* Toast notifications */}
       <ToastContainer />

--- a/src/components/Layout/CommandPalette.tsx
+++ b/src/components/Layout/CommandPalette.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { useConflictStore } from '@/stores/conflictStore'
+import { useLayoutStore } from '@/stores/layoutStore'
 import { toggleVoiceCapture } from '@/lib/voice/pipeline'
 import { runImpactAnalysis } from '@/lib/ai/impactAnalysis'
 import { clearAllConflictDecorations } from '@/lib/prosemirror/plugins/conflictPlugin'
@@ -23,6 +24,8 @@ export function CommandPalette({ onClose }: CommandPaletteProps) {
   const [isAnalyzing, setIsAnalyzing] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const backdropRef = useRef<HTMLDivElement>(null)
+  // Read for the label only — the handler re-reads the live value on click.
+  const answerPlacement = useLayoutStore((s) => s.answerPlacement)
 
   const handleImpactAnalysis = useCallback(
     async (intent: string, withRewrites: boolean) => {
@@ -93,6 +96,17 @@ export function CommandPalette({ onClose }: CommandPaletteProps) {
         },
       },
       {
+        id: 'answer-placement',
+        label:
+          answerPlacement === 'floating'
+            ? 'Answers: dock to sidebar'
+            : 'Answers: float beside the passage',
+        handler: () => {
+          onClose()
+          useLayoutStore.getState().toggleAnswerPlacement()
+        },
+      },
+      {
         id: 'new-doc',
         label: 'New Document',
         handler: () => {
@@ -156,7 +170,7 @@ export function CommandPalette({ onClose }: CommandPaletteProps) {
         },
       },
     ],
-    [onClose]
+    [onClose, answerPlacement]
   )
 
   const filtered = useMemo(() => {

--- a/src/components/Layout/DocumentHubSidebar.tsx
+++ b/src/components/Layout/DocumentHubSidebar.tsx
@@ -213,20 +213,22 @@ export function DocumentHubSidebar() {
                       e.stopPropagation()
                       startRenameCollection(collection)
                     }}
+                    aria-label="Rename collection"
                     className="p-0.5 text-xs text-ink/45 hover:text-ink"
                     title="Rename collection"
                   >
-                    \u270E
+                    ✎
                   </button>
                   <button
                     onClick={(e) => {
                       e.stopPropagation()
                       deleteCollection(collection.id)
                     }}
+                    aria-label="Delete collection"
                     className="p-0.5 text-xs text-red-400 hover:text-red-600"
                     title="Delete collection"
                   >
-                    \u2715
+                    ✕
                   </button>
                 </div>
               </div>
@@ -353,14 +355,14 @@ function DocumentRow({
         </div>
 
         <div className="flex items-center gap-1 shrink-0">
-          <button onClick={onStartRename} className="w-7 h-7 rounded-full text-xs text-ink/45 hover:text-ink hover:bg-warm transition-colors" title="Rename document">
-            \u270E
+          <button onClick={onStartRename} aria-label="Rename document" className="w-7 h-7 rounded-full text-xs text-ink/45 hover:text-ink hover:bg-warm transition-colors" title="Rename document">
+            ✎
           </button>
-          <button onClick={onDuplicate} className="w-7 h-7 rounded-full text-xs text-ink/45 hover:text-ink hover:bg-warm transition-colors" title="Duplicate document">
-            \u2398
+          <button onClick={onDuplicate} aria-label="Duplicate document" className="w-7 h-7 rounded-full text-xs text-ink/45 hover:text-ink hover:bg-warm transition-colors" title="Duplicate document">
+            ⎘
           </button>
-          <button onClick={onDelete} className="w-7 h-7 rounded-full text-xs text-red-400 hover:text-red-600 hover:bg-red-50 transition-colors" title="Delete document">
-            \u2715
+          <button onClick={onDelete} aria-label="Delete document" className="w-7 h-7 rounded-full text-xs text-red-400 hover:text-red-600 hover:bg-red-50 transition-colors" title="Delete document">
+            ✕
           </button>
         </div>
       </div>

--- a/src/components/Settings/AgentConfigPanel.tsx
+++ b/src/components/Settings/AgentConfigPanel.tsx
@@ -84,6 +84,8 @@ export function AgentConfigPanel({ onClose }: AgentConfigPanelProps) {
           <h2 className="font-serif text-xl">Agent Configuration</h2>
           <button
             onClick={onClose}
+            aria-label="Close"
+            title="Close"
             className="text-muted hover:text-ink text-xl leading-none"
           >
             &times;

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -85,7 +85,7 @@ export function ApiKeyModal() {
       <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden">
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
           <h2 className="font-serif text-xl">API Configuration</h2>
-          <button onClick={() => setShow(false)} className="text-muted hover:text-ink text-xl leading-none">&times;</button>
+          <button onClick={() => setShow(false)} aria-label="Close" title="Close" className="text-muted hover:text-ink text-xl leading-none">&times;</button>
         </div>
 
         <div className="p-6 space-y-4 max-h-[75vh] overflow-y-auto">

--- a/src/components/Voice/VoiceButton.tsx
+++ b/src/components/Voice/VoiceButton.tsx
@@ -27,18 +27,20 @@ export function VoiceButton() {
           ? 'bg-annotation-question text-white'
           : 'bg-ink text-white hover:bg-ink/80'
       }`}
+      aria-label={isRecording ? 'Stop recording' : 'Start recording'}
+      aria-pressed={isRecording}
       title={isRecording ? 'Stop recording (Ctrl+Space)' : 'Start recording (Ctrl+Space)'}
     >
       {isRecording ? (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor" />
         </svg>
       ) : isTranscribing ? (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="animate-spin">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="animate-spin">
           <circle cx="12" cy="12" r="10" strokeDasharray="60" strokeDashoffset="20" />
         </svg>
       ) : (
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <svg aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
           <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
           <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
           <line x1="12" y1="19" x2="12" y2="23" />

--- a/src/lib/annotations/__tests__/floatingPosition.test.ts
+++ b/src/lib/annotations/__tests__/floatingPosition.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeFloatingPosition,
+  isAnchorOnScreen,
+  DEFAULT_MARGIN,
+  DEFAULT_GAP,
+} from '../floatingPosition'
+
+const VIEWPORT = { width: 1440, height: 900 }
+const PANEL = { width: 380, height: 320 }
+
+/** Passage sitting in a centred column with room on both sides. */
+const CENTRE_ANCHOR = { top: 200, bottom: 240, left: 500, right: 900 }
+
+describe('computeFloatingPosition', () => {
+  it('prefers the right of the passage when there is room', () => {
+    const pos = computeFloatingPosition({ anchor: CENTRE_ANCHOR, panel: PANEL, viewport: VIEWPORT })
+    expect(pos.side).toBe('right')
+    expect(pos.left).toBe(CENTRE_ANCHOR.right + DEFAULT_GAP)
+    expect(pos.top).toBe(CENTRE_ANCHOR.top)
+  })
+
+  it('falls back to the left when the right edge is too close', () => {
+    const anchor = { top: 200, bottom: 240, left: 600, right: 1200 }
+    const pos = computeFloatingPosition({ anchor, panel: PANEL, viewport: VIEWPORT })
+    expect(pos.side).toBe('left')
+    expect(pos.left).toBe(anchor.left - DEFAULT_GAP - PANEL.width)
+  })
+
+  it('drops below the passage when neither side fits', () => {
+    const narrow = { width: 700, height: 900 }
+    const anchor = { top: 100, bottom: 140, left: 150, right: 550 }
+    const pos = computeFloatingPosition({ anchor, panel: PANEL, viewport: narrow })
+    expect(pos.side).toBe('below')
+    expect(pos.top).toBe(anchor.bottom + DEFAULT_GAP)
+    // Centred on the passage: 150 + 400/2 - 380/2 = 160.
+    expect(pos.left).toBe(160)
+  })
+
+  it('never lets the panel leave the viewport, even when centring would', () => {
+    const narrow = { width: 420, height: 900 }
+    const anchor = { top: 100, bottom: 140, left: 0, right: 40 }
+    const pos = computeFloatingPosition({ anchor, panel: PANEL, viewport: narrow })
+    expect(pos.left).toBeGreaterThanOrEqual(DEFAULT_MARGIN)
+    expect(pos.left + PANEL.width).toBeLessThanOrEqual(narrow.width - DEFAULT_MARGIN)
+  })
+
+  it('pulls a panel that would overflow the bottom back into view', () => {
+    const anchor = { top: 850, bottom: 880, left: 400, right: 700 }
+    const pos = computeFloatingPosition({ anchor, panel: PANEL, viewport: VIEWPORT })
+    expect(pos.top).toBe(VIEWPORT.height - PANEL.height - DEFAULT_MARGIN)
+  })
+
+  it('clamps to the top margin when the panel is taller than the viewport', () => {
+    const tall = { width: 380, height: 2000 }
+    const pos = computeFloatingPosition({ anchor: CENTRE_ANCHOR, panel: tall, viewport: VIEWPORT })
+    // Vertically there is nowhere to go but the top margin; horizontally the
+    // panel still fits beside the passage, so the side choice is untouched.
+    expect(pos.top).toBe(DEFAULT_MARGIN)
+    expect(pos.left).toBe(CENTRE_ANCHOR.right + DEFAULT_GAP)
+  })
+
+  it('applies the drag offset before clamping', () => {
+    const pos = computeFloatingPosition({
+      anchor: CENTRE_ANCHOR,
+      panel: PANEL,
+      viewport: VIEWPORT,
+      offset: { dx: -40, dy: 60 },
+    })
+    expect(pos.left).toBe(CENTRE_ANCHOR.right + DEFAULT_GAP - 40)
+    expect(pos.top).toBe(CENTRE_ANCHOR.top + 60)
+  })
+
+  it('clamps a drag that would throw the panel off-screen', () => {
+    const pos = computeFloatingPosition({
+      anchor: CENTRE_ANCHOR,
+      panel: PANEL,
+      viewport: VIEWPORT,
+      offset: { dx: 9999, dy: -9999 },
+    })
+    expect(pos.left).toBe(VIEWPORT.width - PANEL.width - DEFAULT_MARGIN)
+    expect(pos.top).toBe(DEFAULT_MARGIN)
+  })
+
+  it('parks top-right with no anchor', () => {
+    const pos = computeFloatingPosition({ anchor: null, panel: PANEL, viewport: VIEWPORT })
+    expect(pos.side).toBe('fallback')
+    expect(pos.left).toBe(VIEWPORT.width - PANEL.width - DEFAULT_MARGIN)
+    expect(pos.top).toBe(DEFAULT_MARGIN)
+  })
+
+  it('still returns an in-bounds position when the viewport is smaller than the panel', () => {
+    const tiny = { width: 200, height: 200 }
+    const pos = computeFloatingPosition({ anchor: CENTRE_ANCHOR, panel: PANEL, viewport: tiny })
+    expect(pos.left).toBe(DEFAULT_MARGIN)
+    expect(pos.top).toBe(DEFAULT_MARGIN)
+  })
+})
+
+describe('isAnchorOnScreen', () => {
+  it('is false without an anchor', () => {
+    expect(isAnchorOnScreen(null, VIEWPORT)).toBe(false)
+  })
+
+  it('is true for a passage inside the viewport', () => {
+    expect(isAnchorOnScreen(CENTRE_ANCHOR, VIEWPORT)).toBe(true)
+  })
+
+  it('is false once the passage has scrolled above the fold', () => {
+    expect(isAnchorOnScreen({ top: -200, bottom: -120, left: 500, right: 900 }, VIEWPORT)).toBe(false)
+  })
+
+  it('is false for a passage below the fold', () => {
+    expect(isAnchorOnScreen({ top: 1200, bottom: 1260, left: 500, right: 900 }, VIEWPORT)).toBe(false)
+  })
+})

--- a/src/lib/annotations/floatingPosition.ts
+++ b/src/lib/annotations/floatingPosition.ts
@@ -1,0 +1,125 @@
+/**
+ * Placement maths for the floating answer panel.
+ *
+ * Kept free of React and the DOM so the clamping rules — the part that
+ * actually goes wrong — are unit-testable. The component supplies measured
+ * rects; this module only decides where the panel lands.
+ */
+
+/** Viewport-relative rect of the annotated passage (as ProseMirror reports it). */
+export interface AnchorRect {
+  top: number
+  bottom: number
+  left: number
+  right: number
+}
+
+export interface PanelSize {
+  width: number
+  height: number
+}
+
+export interface ViewportSize {
+  width: number
+  height: number
+}
+
+/** User drag offset, applied after the automatic side choice. */
+export interface DragOffset {
+  dx: number
+  dy: number
+}
+
+export type FloatingSide = 'right' | 'left' | 'below' | 'fallback'
+
+export interface FloatingPosition {
+  left: number
+  top: number
+  /** Which rule produced the position — surfaced for the caret/aria hints. */
+  side: FloatingSide
+}
+
+export interface FloatingPositionInput {
+  /** Null when the anchor is off-screen or ProseMirror cannot resolve it. */
+  anchor: AnchorRect | null
+  panel: PanelSize
+  viewport: ViewportSize
+  offset?: DragOffset
+  /** Minimum distance from any viewport edge. */
+  margin?: number
+  /** Gap between the anchor and the panel. */
+  gap?: number
+}
+
+export const DEFAULT_MARGIN = 12
+export const DEFAULT_GAP = 16
+
+/** Clamp `value` into [min, max], preferring `min` when the range is inverted. */
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min
+  return Math.min(Math.max(value, min), max)
+}
+
+/**
+ * Choose a resting place for the floating answer panel.
+ *
+ * Preference order: right of the passage, then left, then below it. Whatever
+ * the choice, the result is always clamped fully inside the viewport — a
+ * panel the user cannot reach is worse than one that overlaps the text.
+ */
+export function computeFloatingPosition({
+  anchor,
+  panel,
+  viewport,
+  offset = { dx: 0, dy: 0 },
+  margin = DEFAULT_MARGIN,
+  gap = DEFAULT_GAP,
+}: FloatingPositionInput): FloatingPosition {
+  const maxLeft = viewport.width - panel.width - margin
+  const maxTop = viewport.height - panel.height - margin
+
+  // No usable anchor: park the panel top-right and let the user drag it.
+  if (!anchor) {
+    return {
+      left: clamp(maxLeft + offset.dx, margin, maxLeft),
+      top: clamp(margin + offset.dy, margin, maxTop),
+      side: 'fallback',
+    }
+  }
+
+  let side: FloatingSide
+  let left: number
+
+  if (anchor.right + gap + panel.width <= viewport.width - margin) {
+    side = 'right'
+    left = anchor.right + gap
+  } else if (anchor.left - gap - panel.width >= margin) {
+    side = 'left'
+    left = anchor.left - gap - panel.width
+  } else {
+    side = 'below'
+    // Centre on the passage horizontally; the clamp below pulls it in.
+    left = anchor.left + (anchor.right - anchor.left) / 2 - panel.width / 2
+  }
+
+  // Vertically: top-align with the passage when beside it, drop below it
+  // otherwise. Nudge up if that would run off the bottom.
+  const top = side === 'below' ? anchor.bottom + gap : anchor.top
+
+  return {
+    left: clamp(left + offset.dx, margin, maxLeft),
+    top: clamp(top + offset.dy, margin, maxTop),
+    side,
+  }
+}
+
+/**
+ * Whether the anchor is visible enough to be worth pointing at. An anchor
+ * scrolled out of the viewport gets no arrow and no side preference — the
+ * panel falls back to its parked position instead of chasing off-screen
+ * coordinates.
+ */
+export function isAnchorOnScreen(anchor: AnchorRect | null, viewport: ViewportSize): boolean {
+  if (!anchor) return false
+  return anchor.bottom > 0 && anchor.top < viewport.height && anchor.right > 0 && anchor.left < viewport.width
+}

--- a/src/stores/__tests__/layoutStore.test.ts
+++ b/src/stores/__tests__/layoutStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useLayoutStore, normalizeAnswerPlacement, ZERO_OFFSET } from '../layoutStore'
+
+beforeEach(() => {
+  useLayoutStore.setState({ answerPlacement: 'sidebar', floatingOffset: ZERO_OFFSET })
+})
+
+describe('layoutStore', () => {
+  it('defaults to the sidebar placement', () => {
+    expect(useLayoutStore.getState().answerPlacement).toBe('sidebar')
+  })
+
+  it('toggles between sidebar and floating', () => {
+    const { toggleAnswerPlacement } = useLayoutStore.getState()
+    toggleAnswerPlacement()
+    expect(useLayoutStore.getState().answerPlacement).toBe('floating')
+    useLayoutStore.getState().toggleAnswerPlacement()
+    expect(useLayoutStore.getState().answerPlacement).toBe('sidebar')
+  })
+
+  it('re-parks the floating panel whenever the placement changes', () => {
+    useLayoutStore.getState().setFloatingOffset({ dx: 120, dy: -60 })
+    expect(useLayoutStore.getState().floatingOffset).toEqual({ dx: 120, dy: -60 })
+
+    useLayoutStore.getState().setAnswerPlacement('floating')
+    expect(useLayoutStore.getState().floatingOffset).toEqual(ZERO_OFFSET)
+
+    useLayoutStore.getState().setFloatingOffset({ dx: 30, dy: 30 })
+    useLayoutStore.getState().toggleAnswerPlacement()
+    expect(useLayoutStore.getState().floatingOffset).toEqual(ZERO_OFFSET)
+  })
+
+  it('resetFloatingOffset returns the panel to its computed place', () => {
+    useLayoutStore.getState().setFloatingOffset({ dx: 9, dy: 9 })
+    useLayoutStore.getState().resetFloatingOffset()
+    expect(useLayoutStore.getState().floatingOffset).toEqual(ZERO_OFFSET)
+  })
+
+  it('rejects a placement value this build does not know', () => {
+    useLayoutStore.getState().setAnswerPlacement('inline' as never)
+    expect(useLayoutStore.getState().answerPlacement).toBe('sidebar')
+  })
+})
+
+describe('normalizeAnswerPlacement', () => {
+  it('passes through known placements', () => {
+    expect(normalizeAnswerPlacement('sidebar')).toBe('sidebar')
+    expect(normalizeAnswerPlacement('floating')).toBe('floating')
+  })
+
+  it('falls back to sidebar for anything stale or malformed', () => {
+    expect(normalizeAnswerPlacement('inline')).toBe('sidebar')
+    expect(normalizeAnswerPlacement(undefined)).toBe('sidebar')
+    expect(normalizeAnswerPlacement(null)).toBe('sidebar')
+    expect(normalizeAnswerPlacement(3)).toBe('sidebar')
+  })
+})

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -1,0 +1,75 @@
+'use client'
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+/**
+ * Where a resolved annotation's answer is presented.
+ *
+ * `sidebar` — the original behaviour: the card expands in place in the
+ *   Annotations panel.
+ * `floating` — the card detaches into a panel anchored beside the passage it
+ *   belongs to, so the answer sits next to the text it is about rather than
+ *   across the window. The sidebar keeps a compact index of the same threads.
+ */
+export type AnswerPlacement = 'sidebar' | 'floating'
+
+export const ANSWER_PLACEMENTS: AnswerPlacement[] = ['sidebar', 'floating']
+
+const VALID_PLACEMENTS = new Set<string>(ANSWER_PLACEMENTS)
+
+/** Map a possibly-stale persisted value onto a placement this build knows. */
+export function normalizeAnswerPlacement(value: unknown): AnswerPlacement {
+  return typeof value === 'string' && VALID_PLACEMENTS.has(value)
+    ? (value as AnswerPlacement)
+    : 'sidebar'
+}
+
+interface LayoutState {
+  answerPlacement: AnswerPlacement
+  /**
+   * Manual drag offset for the floating panel, in pixels from its computed
+   * resting place. Session-scratch on purpose: a persisted offset taken from
+   * a different window size would strand the panel somewhere it no longer
+   * makes sense, and the automatic placement is the better default on load.
+   */
+  floatingOffset: { dx: number; dy: number }
+  setAnswerPlacement: (placement: AnswerPlacement) => void
+  toggleAnswerPlacement: () => void
+  setFloatingOffset: (offset: { dx: number; dy: number }) => void
+  resetFloatingOffset: () => void
+}
+
+export const ZERO_OFFSET = { dx: 0, dy: 0 }
+
+export const useLayoutStore = create<LayoutState>()(
+  persist(
+    (set) => ({
+      answerPlacement: 'sidebar',
+      floatingOffset: ZERO_OFFSET,
+      // Changing placement always re-parks the panel: the offset was chosen
+      // against the old layout and means nothing in the new one.
+      setAnswerPlacement: (placement) =>
+        set({ answerPlacement: normalizeAnswerPlacement(placement), floatingOffset: ZERO_OFFSET }),
+      toggleAnswerPlacement: () =>
+        set((s) => ({
+          answerPlacement: s.answerPlacement === 'sidebar' ? 'floating' : 'sidebar',
+          floatingOffset: ZERO_OFFSET,
+        })),
+      setFloatingOffset: (offset) => set({ floatingOffset: offset }),
+      resetFloatingOffset: () => set({ floatingOffset: ZERO_OFFSET }),
+    }),
+    {
+      name: 'intent-ide-layout',
+      partialize: (s) => ({ answerPlacement: s.answerPlacement }),
+      onRehydrateStorage: () => (state) => {
+        // A snapshot from an older build may carry a placement this one has
+        // never heard of; fall back to the sidebar rather than render nothing.
+        if (state) {
+          state.answerPlacement = normalizeAnswerPlacement(state.answerPlacement)
+          state.floatingOffset = ZERO_OFFSET
+        }
+      },
+    },
+  ),
+)

--- a/tests/cascade-review.spec.ts
+++ b/tests/cascade-review.spec.ts
@@ -257,10 +257,13 @@ test.describe('cascade review flow', () => {
     // 9. History tab shows the real 'apply' version row (kind badge "AI change",
     //    actor "AI + you") written through the real /api/history route. The
     //    commit is fire-and-forget after apply, so poll via Refresh.
-    // dispatchEvent instead of click: with headless font metrics the 5-tab
-    // sidebar row overflows its 320px container and the History tab's hit
-    // area lands under the topbar, so a positional click never lands.
-    await page.getByRole('button', { name: 'History' }).dispatchEvent('click')
+    // History and Audit live behind the sidebar's overflow menu, so open that
+    // first. This replaces a dispatchEvent workaround that existed because the
+    // old five-tab row overflowed its 320px container under headless font
+    // metrics and put the History tab's hit area under the topbar — the very
+    // crowding the overflow menu removes, so a real click works again.
+    await page.getByRole('button', { name: /more panels/i }).click()
+    await page.getByRole('menuitem', { name: 'History' }).click()
     await expect(async () => {
       await page.getByRole('button', { name: 'Refresh' }).click()
       await expect(page.getByText('AI change', { exact: true })).toBeVisible({

--- a/tests/ingestion.spec.ts
+++ b/tests/ingestion.spec.ts
@@ -47,17 +47,44 @@ test.describe('Intent IDE E2E', () => {
   })
 
   test('should connect to FalkorDB and query Episode nodes', async () => {
-    const redis = new Redis({ host: 'localhost', port: 6379, lazyConnect: true })
+    // Connectivity is probed separately from the query, and the probe never
+    // throws. Guarding the skip on one error string (ECONNREFUSED) was too
+    // narrow: with no server listening ioredis can also surface "Connection is
+    // closed", a timeout, or a DNS error depending on how the sandbox handles
+    // the dead port — all of which mean the same thing here, and none of which
+    // is a failure of this repository's code.
+    const redis = new Redis({
+      host: 'localhost',
+      port: 6379,
+      lazyConnect: true,
+      connectTimeout: 3_000,
+      // Without this, ioredis retries forever and the test dies on timeout
+      // instead of skipping.
+      retryStrategy: () => null,
+      maxRetriesPerRequest: 1,
+    })
+    // A dead connection emits 'error' asynchronously; unhandled, it crashes
+    // the worker rather than failing this test.
+    redis.on('error', () => {})
+
+    const connected = await redis
+      .connect()
+      .then(() => true)
+      .catch(() => false)
+
+    if (!connected) {
+      redis.disconnect()
+      test.skip(true, 'FalkorDB not reachable on localhost:6379 — skipping graph assertion')
+      return
+    }
 
     try {
-      await redis.connect()
-
       // Query the graphiti graph for Episode nodes
-      const result = await redis.call(
+      const result = (await redis.call(
         'GRAPH.QUERY',
         'graphiti',
         'MATCH (e:Episodic) RETURN count(e) AS cnt',
-      ) as unknown[][]
+      )) as unknown[][]
 
       // FalkorDB returns: [[headers], [data rows], [stats]]
       const dataRows = result[1] as unknown[][]
@@ -67,15 +94,8 @@ test.describe('Intent IDE E2E', () => {
       // Episode nodes are created by annotation resolution, not direct edits.
       // This test validates FalkorDB connectivity; count >= 0 is valid.
       expect(episodeCount).toBeGreaterThanOrEqual(0)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
-      if (message.includes('ECONNREFUSED')) {
-        test.skip(true, 'FalkorDB not running on localhost:6379 — skipping graph assertion')
-      } else {
-        throw err
-      }
     } finally {
-      await redis.quit()
+      await redis.quit().catch(() => redis.disconnect())
     }
   })
 })


### PR DESCRIPTION
## Summary

Recovers the salvageable half of `claude/pr-audit-sidebar-options-nvwfu8` (issue #49), a branch that drifted 32 commits behind `main` and 4 ahead with no PR ever opened.

- **`feat(ui): choose where answers appear — sidebar or floating beside the passage`** — new `layoutStore` (`answerPlacement: 'sidebar' | 'floating'`, persisted with a fallback normalizer for stale values), `computeFloatingPosition()` (DOM-free, unit-tested clamping math), and `FloatingAnswer` — a draggable panel parked beside the passage it answers, with dock-to-sidebar and Escape-to-close. Cherry-picked clean onto current `main`.
- **`fix(ui): name every icon-only control, repair glyph buttons, uncrowd the rail`** — `aria-label`/`aria-pressed`/`aria-expanded` on ~18 icon-only controls, fixes literal escaped-glyph characters (`✎`/`✕`/`⎘` were rendering as raw text), and moves History/Audit behind an overflow menu so the sidebar rail's five tabs stop overflowing their container. Cherry-picked with one conflict: it also edited `ProjectSidebar.tsx`, which `main` already deleted via #36 — resolved by dropping that file (keeping the deletion; nothing else in the diff referenced it, verified by grep).

### Deliberately dropped, not superseded

The stranded branch's third commit (`ci: run the e2e suite, and stop CODEOWNERS from deadlocking machinery changes`) touched `.github/workflows/ci.yml` and `.github/CODEOWNERS`. An unattended session cannot write `.github/workflows/**` — that's a platform-level restriction, not a judgment call, and `main`'s CODEOWNERS still carries the original `/.github/ @Vinylfigure` rule this commit meant to relax, so it isn't superseded either. **That part needs an operator-attended session.**

I did pull the *non-machinery* files out of that same commit, since they have nothing to do with the CODEOWNERS deadlock and fix a real regression this PR would otherwise have introduced (see below): `playwright.config.ts` (honors `PLAYWRIGHT_CHROMIUM_PATH` for sandboxes that ship a pinned Chromium build) and `tests/ingestion.spec.ts` (the FalkorDB connectivity probe no longer skips only on `ECONNREFUSED` — a dead port can also surface as "Connection is closed", a timeout, or a DNS error depending on the sandbox).

The branch's fourth commit (a merge reconciling with `main`) was dropped as genuinely superseded — `main` already has the `ProjectSidebar` removal it was merging in, via #36.

## Process record

Pre-push adversarial (troublemaker) review returned one HIGH and one MEDIUM finding, both fixed before this PR was opened:

- **HIGH — orphaned e2e assertion:** the a11y commit's own message cites `tests/cascade-review.spec.ts`'s old `dispatchEvent('click')` workaround on `getByRole('button', { name: 'History' })` as the reason it moved History/Audit behind an overflow menu — but never updated the test itself. After the UI change, no always-visible button named "History" exists; the spec would time out. Fixed by pulling forward the spec fix that already existed for this in the dropped CI commit (open the "More panels" overflow trigger, then click the `History` menuitem) — verified by running `tests/cascade-review.spec.ts` directly: it now gets past the History-tab click and the whole apply→history-row flow, failing only on a later assertion (`getByText('Created')`) that I confirmed **also fails identically on unmodified `main`** (pre-existing, unrelated to this PR — not fixed here).
- **MEDIUM — held-answer reveal double-polls when floating:** `AnnotationCard`'s `detailElsewhere` prop is documented as making "exactly one card own" the proposed-edit decorations when both a sidebar row and a floating panel exist for the same annotation — true for the cascade-reveal effect, but the sibling held-answer reveal-poll effect a few lines below wasn't gated the same way. Two live 500ms polls could each flash their own "Answer ready" chip. Fixed by gating it on `showDetail` like its sibling.

Also fixed on review (LOW, self-healing but sloppy): `FloatingAnswer`'s drag pointermove/pointerup listeners were only removed by the next `pointerup`, not on unmount — tied to a ref + unmount cleanup to match the rest of the file's effect discipline.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 924 passing + 10 skipped
- [x] `npm run build` — clean
- [x] `npx playwright test tests/cascade-review.spec.ts` — gets past the History-tab click (the regression this PR fixes); remaining failure reproduced identically on unmodified `main`, confirmed pre-existing and out of scope
- [x] Adversarial (troublemaker) review completed; HIGH + MEDIUM findings fixed before push

Closes #49

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsgPt582jEiP3YZPYUwipw)_