### PR TITLE
Document Invariant Ledger — LLM entailment lane (Phase 4)

### DIFF
--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -32,6 +32,7 @@ import { refreshAnchorAfterApply, refreshedAnchorForMultiRegionApply } from '@/l
 import { createCommit } from '@/lib/history/commits'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
 import { resolveInvariantFlagOnDismiss, runAndSurfaceInvariantChecks } from '@/lib/invariants/invariantCascade'
+import { classifyCheckKind } from '@/lib/invariants/invariantCheckRunner'
 import { SemanticCommitModal, type InvariantCapture } from '@/components/Editor/SemanticCommitModal'
 import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
 import { SEVERITY_ORDER } from '@/lib/annotations/types'
@@ -154,6 +155,11 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             documentId: annotation.documentId,
             statement: invariant.statement,
             blockIds: invariant.blockIds,
+            // Decide the lane at capture time (#51) instead of letting every
+            // row default to 'deterministic' — a statement the figure-matching
+            // lane cannot check ("thirty days") is routed to the entailment
+            // lane rather than silently going unchecked forever.
+            checkKind: classifyCheckKind(invariant.statement),
             provenanceCommitHash: hash,
           })
         }

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -156,9 +156,11 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             statement: invariant.statement,
             blockIds: invariant.blockIds,
             // Decide the lane at capture time (#51) instead of letting every
-            // row default to 'deterministic' — a statement the figure-matching
-            // lane cannot check ("thirty days") is routed to the entailment
-            // lane rather than silently going unchecked forever.
+            // row default to 'deterministic'. This routes the statements the
+            // figure-matching lane provably cannot check ("thirty days") to
+            // the entailment lane up front; statements it can only sometimes
+            // check still start here and fall through at check time — see
+            // `classifyCheckKind` for the split.
             checkKind: classifyCheckKind(invariant.statement),
             provenanceCommitHash: hash,
           })

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -245,10 +245,15 @@ export function ApiKeyModal() {
               <span className="text-sm text-ink leading-snug">
                 Check declared facts for meaning, not just figures
                 <span className="block text-xs text-muted">
-                  Off by default. When on, applying a change also asks the small model whether any
-                  passage contradicts a fact you declared in words rather than numbers
-                  (&ldquo;thirty days&rdquo;). Sends those passages to your provider; the
-                  figure-matching check stays on your machine either way.
+                  Off by default. When on, applying a change also asks whether any passage
+                  contradicts a fact you declared in words rather than numbers (&ldquo;thirty
+                  days&rdquo;). Sends those passages to your provider; the figure-matching check
+                  stays on your machine either way.
+                </span>
+                <span className="block text-xs text-muted">
+                  {provider === 'claude'
+                    ? 'Runs on Haiku, not your selected model.'
+                    : `Runs on your selected model (${llmConfig.model}) — only Claude has a cheaper model wired up for this.`}
                 </span>
               </span>
             </label>

--- a/src/components/Settings/ApiKeyModal.tsx
+++ b/src/components/Settings/ApiKeyModal.tsx
@@ -20,6 +20,8 @@ export function ApiKeyModal() {
   const setShow = useSettingsStore((s) => s.setShowApiKeyModal)
   const judgeEnabled = useSettingsStore((s) => s.judgeEnabled)
   const setJudgeEnabled = useSettingsStore((s) => s.setJudgeEnabled)
+  const invariantEntailmentEnabled = useSettingsStore((s) => s.invariantEntailmentEnabled)
+  const setInvariantEntailmentEnabled = useSettingsStore((s) => s.setInvariantEntailmentEnabled)
   const embeddingsEnabled = useSettingsStore((s) => s.embeddingsEnabled)
   const setEmbeddingsEnabled = useSettingsStore((s) => s.setEmbeddingsEnabled)
   const telemetryEnabled = useSettingsStore((s) => s.telemetryEnabled)
@@ -229,6 +231,24 @@ export function ApiKeyModal() {
                 <span className="block text-xs text-muted">
                   Extra small model call that double-checks each cited conflict before it is
                   marked &ldquo;must change&rdquo;.
+                </span>
+              </span>
+            </label>
+
+            <label className="flex items-start gap-2.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={invariantEntailmentEnabled}
+                onChange={(e) => setInvariantEntailmentEnabled(e.target.checked)}
+                className="mt-0.5 accent-ink"
+              />
+              <span className="text-sm text-ink leading-snug">
+                Check declared facts for meaning, not just figures
+                <span className="block text-xs text-muted">
+                  Off by default. When on, applying a change also asks the small model whether any
+                  passage contradicts a fact you declared in words rather than numbers
+                  (&ldquo;thirty days&rdquo;). Sends those passages to your provider; the
+                  figure-matching check stays on your machine either way.
                 </span>
               </span>
             </label>

--- a/src/lib/invariants/__tests__/entailmentCheck.test.ts
+++ b/src/lib/invariants/__tests__/entailmentCheck.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { DocGraph } from '@/lib/graphrag/docGraph'
+import {
+  checkEntailmentInvariants,
+  judgeEntailmentPairs,
+  selectCandidates,
+  type EntailmentPair,
+  type EntailmentVerdict,
+} from '../entailmentCheck'
+import type { Invariant } from '../captureInvariant'
+
+function p(blockId: string, text: string): PMNode {
+  return schema.node('paragraph', { blockId }, [schema.text(text)])
+}
+
+const DECLARE_TEXT = 'Terminations are now thirty days per the updated policy.'
+const CONFLICT_TEXT = 'Under the new policy, terminations occur within one and a half months.'
+
+const DOC = schema.node('doc', null, [p('b-declare', DECLARE_TEXT), p('b-conflict', CONFLICT_TEXT)])
+
+const CONFIG: LLMConfig = {
+  provider: 'claude',
+  apiKey: 'k',
+  model: 'claude-sonnet-4-6',
+  baseUrl: undefined,
+}
+
+/** No deterministic edges — proves the term-sharing recall floor does the work. */
+const EMPTY_GRAPH: DocGraph = {
+  contentHash: 'h',
+  builtAt: 0,
+  llmApplied: false,
+  llmPartial: false,
+  embeddingsApplied: false,
+  graphitiApplied: false,
+  nodes: new Map(),
+  edges: [],
+  adjacency: new Map(),
+} as unknown as DocGraph
+
+function invariantRecord(overrides: Partial<Invariant> = {}): Invariant {
+  return {
+    id: 'inv-1',
+    documentId: 'doc-A',
+    statement: 'terminations are now thirty days',
+    blockIds: JSON.stringify(['b-declare']),
+    checkKind: 'entailment',
+    status: 'active',
+    provenanceCommitHash: 'hash-1',
+    supersedesId: null,
+    createdAt: '2026-08-20T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+/** A judge that returns the given verdict for every pair it is handed. */
+function judgeReturning(verdict: EntailmentVerdict) {
+  return vi.fn(async (pairs: EntailmentPair[]) => {
+    const map = new Map<number, EntailmentVerdict>()
+    pairs.forEach((_, i) => map.set(i, verdict))
+    return map
+  })
+}
+
+describe('checkEntailmentInvariants', () => {
+  it('flags a passage the judge says contradicts a word-form declared fact', async () => {
+    const judge = judgeReturning({ contradicts: true, reason: 'One and a half months is not thirty days.' })
+
+    const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
+      judge,
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      checkKind: 'entailment',
+      invariantId: 'inv-1',
+      statement: 'terminations are now thirty days',
+      evidenceBlockIds: ['b-declare'],
+      conflictBlockId: 'b-conflict',
+      conflictText: CONFLICT_TEXT,
+      judgeReason: 'One and a half months is not thirty days.',
+    })
+    // No figure fields on this lane — the discriminated union keeps them off.
+    expect(violations[0]).not.toHaveProperty('statementNumber')
+  })
+
+  it('produces no flag when the judge says the passage is consistent', async () => {
+    const judge = judgeReturning({ contradicts: false, reason: 'Same period, different wording.' })
+
+    const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
+      judge,
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toEqual([])
+  })
+
+  it('produces no flag when the judge throws — a broken judge never fabricates a positive', async () => {
+    const judge = vi.fn(async () => {
+      throw new Error('provider down')
+    })
+
+    const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
+      judge,
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toEqual([])
+  })
+
+  it('produces no flag when the judge returns verdicts for no candidate', async () => {
+    const judge = vi.fn(async () => new Map<number, EntailmentVerdict>())
+
+    const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
+      judge,
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toEqual([])
+  })
+
+  it('never calls the judge for deterministic-kind or inactive rows', async () => {
+    const judge = judgeReturning({ contradicts: true, reason: 'should not be reached' })
+
+    const violations = await checkEntailmentInvariants(
+      DOC,
+      [
+        invariantRecord({ id: 'inv-det', checkKind: 'deterministic' }),
+        invariantRecord({ id: 'inv-resolved', status: 'resolved' }),
+      ],
+      CONFIG,
+      { judge, graph: EMPTY_GRAPH },
+    )
+
+    expect(violations).toEqual([])
+    expect(judge).not.toHaveBeenCalled()
+  })
+
+  it('reports at most one violation per invariant even when several passages contradict', async () => {
+    const doc = schema.node('doc', null, [
+      p('b-declare', DECLARE_TEXT),
+      p('b-conflict-1', CONFLICT_TEXT),
+      p('b-conflict-2', 'Terminations elsewhere are handled in under a week.'),
+    ])
+    const judge = judgeReturning({ contradicts: true, reason: 'conflicts' })
+
+    const violations = await checkEntailmentInvariants(doc, [invariantRecord()], CONFIG, {
+      judge,
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toHaveLength(1)
+  })
+})
+
+describe('selectCandidates', () => {
+  it('never offers an evidence block as a candidate against its own fact', () => {
+    const pairs = selectCandidates(DOC, invariantRecord(), EMPTY_GRAPH)
+    expect(pairs.map((c) => c.blockId)).toEqual(['b-conflict'])
+  })
+
+  it('skips blocks that neither share a term nor sit in the graph neighborhood', () => {
+    const doc = schema.node('doc', null, [
+      p('b-declare', DECLARE_TEXT),
+      p('b-unrelated', 'Office parking permits are issued each January.'),
+    ])
+    expect(selectCandidates(doc, invariantRecord(), EMPTY_GRAPH)).toEqual([])
+  })
+
+  it('caps candidates per invariant rather than scanning the whole document', () => {
+    const blocks = [p('b-declare', DECLARE_TEXT)]
+    for (let i = 0; i < 20; i++) {
+      blocks.push(p(`b-${i}`, `Section ${i} also describes terminations in some detail.`))
+    }
+    const pairs = selectCandidates(schema.node('doc', null, blocks), invariantRecord(), EMPTY_GRAPH)
+    expect(pairs.length).toBeLessThanOrEqual(6)
+  })
+})
+
+describe('judgeEntailmentPairs', () => {
+  const PAIRS: EntailmentPair[] = [
+    {
+      invariantId: 'inv-1',
+      statement: 'terminations are now thirty days',
+      evidenceBlockIds: ['b-declare'],
+      blockId: 'b-conflict',
+      blockText: CONFLICT_TEXT,
+    },
+    {
+      invariantId: 'inv-1',
+      statement: 'terminations are now thirty days',
+      evidenceBlockIds: ['b-declare'],
+      blockId: 'b-other',
+      blockText: 'Terminations follow the schedule above.',
+    },
+  ]
+
+  it('routes the call to the cheap utility model, never the user-selected one', async () => {
+    const call = vi.fn(async (_req: unknown, config: unknown) => {
+      void _req
+      void config
+      return {
+        toolCalls: [
+          { name: 'entailment_verdict', input: { index: 1, contradicts: true, reason: 'r' } },
+        ],
+      }
+    })
+
+    await judgeEntailmentPairs(PAIRS, CONFIG, call as never)
+
+    expect(call.mock.calls[0][1]).toMatchObject({ model: 'claude-haiku-4-5' })
+  })
+
+  it('defaults every candidate the judge skipped to not-contradicting', async () => {
+    const call = vi.fn(async () => ({
+      toolCalls: [{ name: 'entailment_verdict', input: { index: 1, contradicts: true, reason: 'r' } }],
+    }))
+
+    const verdicts = await judgeEntailmentPairs(PAIRS, CONFIG, call as never)
+
+    expect(verdicts.get(0)?.contradicts).toBe(true)
+    expect(verdicts.get(1)?.contradicts).toBe(false)
+  })
+
+  it('lets the safe answer win when the judge returns two verdicts for one index', async () => {
+    const call = vi.fn(async () => ({
+      toolCalls: [
+        { name: 'entailment_verdict', input: { index: 1, contradicts: true, reason: 'yes' } },
+        { name: 'entailment_verdict', input: { index: 1, contradicts: false, reason: 'no' } },
+      ],
+    }))
+
+    const verdicts = await judgeEntailmentPairs(PAIRS, CONFIG, call as never)
+
+    expect(verdicts.get(0)?.contradicts).toBe(false)
+  })
+
+  it('throws on a transport-successful call that yields zero valid verdicts', async () => {
+    const call = vi.fn(async () => ({ toolCalls: [{ name: 'something_else', input: {} }] }))
+
+    await expect(judgeEntailmentPairs(PAIRS, CONFIG, call as never)).rejects.toThrow(
+      /zero valid verdicts/,
+    )
+  })
+
+  it('ignores an out-of-range index rather than flagging the wrong candidate', async () => {
+    const call = vi.fn(async () => ({
+      toolCalls: [
+        { name: 'entailment_verdict', input: { index: 99, contradicts: true, reason: 'r' } },
+        { name: 'entailment_verdict', input: { index: 2, contradicts: true, reason: 'r' } },
+      ],
+    }))
+
+    const verdicts = await judgeEntailmentPairs(PAIRS, CONFIG, call as never)
+
+    expect(verdicts.get(0)?.contradicts).toBe(false)
+    expect(verdicts.get(1)?.contradicts).toBe(true)
+  })
+})

--- a/src/lib/invariants/__tests__/entailmentCheck.test.ts
+++ b/src/lib/invariants/__tests__/entailmentCheck.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Node as PMNode } from 'prosemirror-model'
 import { schema } from '@/lib/prosemirror/schema'
 import type { LLMConfig } from '@/stores/settingsStore'
-import type { DocGraph } from '@/lib/graphrag/docGraph'
+import type { DocGraph, DocGraphEdge, DocGraphNode } from '@/lib/graphrag/docGraph'
 import {
   checkEntailmentInvariants,
   judgeEntailmentPairs,
@@ -28,18 +28,46 @@ const CONFIG: LLMConfig = {
   baseUrl: undefined,
 }
 
-/** No deterministic edges — proves the term-sharing recall floor does the work. */
-const EMPTY_GRAPH: DocGraph = {
-  contentHash: 'h',
-  builtAt: 0,
-  llmApplied: false,
-  llmPartial: false,
-  embeddingsApplied: false,
-  graphitiApplied: false,
-  nodes: new Map(),
-  edges: [],
-  adjacency: new Map(),
-} as unknown as DocGraph
+function graphOf(edges: DocGraphEdge[]): DocGraph {
+  const nodes = new Map<string, DocGraphNode>()
+  const adjacency = new Map<string, DocGraphEdge[]>()
+  for (const edge of edges) {
+    for (const id of [edge.from, edge.to]) {
+      if (!nodes.has(id)) {
+        nodes.set(id, {
+          blockId: id,
+          pos: 0,
+          nodeType: 'paragraph',
+          text: '',
+          headingPath: [],
+          definedTerms: [],
+        })
+      }
+      adjacency.set(id, [...(adjacency.get(id) ?? []), edge])
+    }
+  }
+  return {
+    contentHash: 'h',
+    builtAt: 0,
+    llmApplied: false,
+    llmPartial: false,
+    embeddingsApplied: false,
+    embeddingsPartial: false,
+    graphitiApplied: false,
+    blockHashes: new Map(),
+    nodes,
+    edges,
+    adjacency,
+  }
+}
+
+/** One deterministic edge between two blocks — the graph-scoping fixture. */
+function graphWithEdge(from: string, to: string): DocGraph {
+  return graphOf([{ from, to, type: 'depends-on', source: 'deterministic' }])
+}
+
+/** No edges — isolates the term-sharing recall floor from the graph lane. */
+const EMPTY_GRAPH: DocGraph = graphOf([])
 
 function invariantRecord(overrides: Partial<Invariant> = {}): Invariant {
   return {
@@ -84,8 +112,9 @@ describe('checkEntailmentInvariants', () => {
       conflictText: CONFLICT_TEXT,
       judgeReason: 'One and a half months is not thirty days.',
     })
-    // No figure fields on this lane — the discriminated union keeps them off.
-    expect(violations[0]).not.toHaveProperty('statementNumber')
+    // The union's discriminant is what downstream branches on, so pin it
+    // rather than asserting the absence of a key nothing ever sets.
+    expect(violations[0].checkKind).toBe('entailment')
   })
 
   it('produces no flag when the judge says the passage is consistent', async () => {
@@ -112,32 +141,108 @@ describe('checkEntailmentInvariants', () => {
     expect(violations).toEqual([])
   })
 
-  it('produces no flag when the judge returns verdicts for no candidate', async () => {
-    const judge = vi.fn(async () => new Map<number, EntailmentVerdict>())
-
+  it('produces no flag when the real judge path yields zero verdicts', async () => {
+    // Drives the REAL judge (not a hand-written empty Map, which
+    // judgeEntailmentPairs can never actually return — it throws first), so
+    // this exercises the malfunction path the production code really takes.
     const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
-      judge,
+      judge: (pairs, config) =>
+        judgeEntailmentPairs(pairs, config, (async () => ({
+          toolCalls: [{ name: 'not_a_verdict', input: {} }],
+        })) as never),
       graph: EMPTY_GRAPH,
     })
 
     expect(violations).toEqual([])
   })
 
-  it('never calls the judge for deterministic-kind or inactive rows', async () => {
-    const judge = judgeReturning({ contradicts: true, reason: 'should not be reached' })
+  it('produces no flag when the judge confirms an index that matches no candidate', async () => {
+    const violations = await checkEntailmentInvariants(DOC, [invariantRecord()], CONFIG, {
+      judge: (pairs, config) =>
+        judgeEntailmentPairs(pairs, config, (async () => ({
+          toolCalls: [
+            { name: 'entailment_verdict', input: { index: 99, contradicts: true, reason: 'r' } },
+            { name: 'entailment_verdict', input: { index: 1.7, contradicts: true, reason: 'r' } },
+          ],
+        })) as never),
+      graph: EMPTY_GRAPH,
+    })
+
+    expect(violations).toEqual([])
+  })
+
+  it('never judges an invariant with no evidence links — the flag could not anchor anyway', async () => {
+    const judge = judgeReturning({ contradicts: true, reason: 'r' })
 
     const violations = await checkEntailmentInvariants(
       DOC,
-      [
-        invariantRecord({ id: 'inv-det', checkKind: 'deterministic' }),
-        invariantRecord({ id: 'inv-resolved', status: 'resolved' }),
-      ],
+      [invariantRecord({ blockIds: JSON.stringify([]) })],
       CONFIG,
       { judge, graph: EMPTY_GRAPH },
     )
 
     expect(violations).toEqual([])
     expect(judge).not.toHaveBeenCalled()
+  })
+
+  it('caps the batch across invariants and names what it could not check', async () => {
+    const blocks = [p('b-declare', DECLARE_TEXT)]
+    for (let i = 0; i < 10; i++) {
+      blocks.push(p(`b-${i}`, `Section ${i} also describes terminations in detail.`))
+    }
+    const doc = schema.node('doc', null, blocks)
+    const invariants = Array.from({ length: 6 }, (_, i) =>
+      invariantRecord({ id: `inv-${i}` }),
+    )
+    const judge = vi.fn(async (pairs: EntailmentPair[]) => {
+      const map = new Map<number, EntailmentVerdict>()
+      pairs.forEach((_, i) => map.set(i, { contradicts: false, reason: 'ok' }))
+      return map
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await checkEntailmentInvariants(doc, invariants, CONFIG, { judge, graph: EMPTY_GRAPH })
+
+    // Hard budget: never more than MAX_TOTAL_PAIRS passages in one batch.
+    expect(judge.mock.calls[0][0].length).toBe(20)
+    // Both the per-run invariant cap and the shared-budget starvation are
+    // disclosed, not silently truncated.
+    const warned = warn.mock.calls.map((c) => String(c[0])).join('\n')
+    expect(warned).toMatch(/never reached/)
+    expect(warned).toMatch(/batch budget/)
+    warn.mockRestore()
+  })
+
+  it('never calls the judge for a row that is no longer active', async () => {
+    const judge = judgeReturning({ contradicts: true, reason: 'should not be reached' })
+
+    const violations = await checkEntailmentInvariants(
+      DOC,
+      [invariantRecord({ id: 'inv-resolved', status: 'resolved' })],
+      CONFIG,
+      { judge, graph: EMPTY_GRAPH },
+    )
+
+    expect(violations).toEqual([])
+    expect(judge).not.toHaveBeenCalled()
+  })
+
+  it('judges whatever active rows the caller selected, kind included', () => {
+    // Lane membership is the CALLER's call (invariantCascade decides which
+    // deterministic-classified rows deserve a second look), so this function
+    // must not second-guess checkKind — otherwise the fallthrough that closes
+    // the plural/date hole would be silently filtered out here.
+    const judge = judgeReturning({ contradicts: true, reason: 'conflicts' })
+
+    return checkEntailmentInvariants(
+      DOC,
+      [invariantRecord({ id: 'inv-det', checkKind: 'deterministic' })],
+      CONFIG,
+      { judge, graph: EMPTY_GRAPH },
+    ).then((violations) => {
+      expect(judge).toHaveBeenCalled()
+      expect(violations).toHaveLength(1)
+    })
   })
 
   it('reports at most one violation per invariant even when several passages contradict', async () => {
@@ -176,8 +281,58 @@ describe('selectCandidates', () => {
     for (let i = 0; i < 20; i++) {
       blocks.push(p(`b-${i}`, `Section ${i} also describes terminations in some detail.`))
     }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const pairs = selectCandidates(schema.node('doc', null, blocks), invariantRecord(), EMPTY_GRAPH)
-    expect(pairs.length).toBeLessThanOrEqual(6)
+    // Exactly the cap, not merely "at most" — an assertion that also passes on
+    // an empty result would go green if selection were entirely broken.
+    expect(pairs).toHaveLength(6)
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('prefers the block matching more of the statement over mere document order', () => {
+    const doc = schema.node('doc', null, [
+      p('b-declare', DECLARE_TEXT),
+      // Earlier in the document, but matches only "terminations".
+      p('b-weak', 'Terminations are discussed in the appendix.'),
+      // Later, but matches both "terminations" and "notice".
+      p('b-strong', 'Terminations require notice of one and a half months.'),
+    ])
+    const pairs = selectCandidates(
+      doc,
+      invariantRecord({ statement: 'terminations now require thirty days notice' }),
+      EMPTY_GRAPH,
+    )
+    expect(pairs[0].blockId).toBe('b-strong')
+  })
+
+  it('ranks a graph neighbor ahead of a block that only shares a term', () => {
+    const doc = schema.node('doc', null, [
+      p('b-declare', DECLARE_TEXT),
+      p('b-term-only', 'Terminations are discussed in the appendix.'),
+      p('b-neighbor', 'That period governs how much warning staff receive.'),
+    ])
+    // b-neighbor shares no statement term; it is reachable ONLY via the graph.
+    const graph = graphWithEdge('b-declare', 'b-neighbor')
+
+    const pairs = selectCandidates(doc, invariantRecord(), graph)
+
+    expect(pairs.map((c) => c.blockId)).toEqual(['b-neighbor', 'b-term-only'])
+  })
+
+  it('reaches a graph neighbor that shares no wording with the statement at all', () => {
+    const doc = schema.node('doc', null, [
+      p('b-declare', DECLARE_TEXT),
+      p('b-neighbor', 'That period governs how much warning staff receive.'),
+    ])
+    const graph = graphWithEdge('b-declare', 'b-neighbor')
+
+    expect(selectCandidates(doc, invariantRecord(), graph).map((c) => c.blockId)).toEqual([
+      'b-neighbor',
+    ])
+    // Without the graph the same block is unreachable — proving the
+    // neighborhood lane, not the term floor, is what found it.
+    expect(selectCandidates(doc, invariantRecord(), EMPTY_GRAPH)).toEqual([])
   })
 })
 

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -13,6 +13,7 @@ import {
   resolveInvariantFlagOnDismiss,
   runAndSurfaceInvariantChecks,
 } from '../invariantCascade'
+import { checkInvariants, classifyCheckKind } from '../invariantCheckRunner'
 
 function p(blockId: string, text: string): PMNode {
   return schema.node('paragraph', { blockId }, [schema.text(text)])
@@ -324,6 +325,61 @@ describe('entailment lane surfacing (#51)', () => {
 
   const confirmingJudge = async (pairs: { blockId: string }[]) =>
     new Map(pairs.map((_, i) => [i, { contradicts: true, reason: 'Not thirty days.' }]))
+
+  it('makes no entailment call on the production call shape, which passes no opts', async () => {
+    // The real call site (ResolutionActions) passes no third argument at all,
+    // so this walks the uninstrumented path and pins that the store default
+    // (OFF) is what actually governs egress — not a test-only override.
+    stubListInvariants([entailmentRecord()])
+    const state = EditorState.create({ schema, doc: ENTAILMENT_DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(useAnnotationStore.getState().annotations).toEqual([])
+  })
+
+  it('falls a deterministic-classified invariant through when its lane found nothing', async () => {
+    // The plural-variant hole: "each termination requires 30 days notice"
+    // classifies deterministic (it has a figure AND a subject term), but the
+    // drift block says "Terminations now require 45 days" — unstemmed
+    // containsTerm never matches, so the deterministic lane returns nothing.
+    // Without the fallthrough this fact would be checked by neither lane.
+    const doc = schema.node('doc', null, [
+      p('b-declare', 'Each termination requires 30 days notice under the policy.'),
+      p('b-conflict', 'Terminations now require 45 days.'),
+    ])
+    const record = invariantRecord({
+      id: 'inv-plural',
+      statement: 'each termination requires 30 days notice',
+      checkKind: 'deterministic',
+    })
+    expect(classifyCheckKind(record.statement)).toBe('deterministic')
+    expect(checkInvariants(doc, [record])).toEqual([])
+
+    stubListInvariants([record])
+    const judge = vi.fn(confirmingJudge)
+
+    await runAndSurfaceInvariantChecks('doc-A', EditorState.create({ schema, doc }), {
+      entailmentEnabled: true,
+      entailmentDeps: { judge, graph: null },
+    })
+
+    expect(judge).toHaveBeenCalled()
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+  })
+
+  it('does not re-judge an invariant the deterministic lane already flagged', async () => {
+    stubListInvariants([invariantRecord()]) // the 30-vs-45 fixture: deterministic hit
+    const judge = vi.fn(confirmingJudge)
+
+    await runAndSurfaceInvariantChecks('doc-A', EditorState.create({ schema, doc: DOC }), {
+      entailmentEnabled: true,
+      entailmentDeps: { judge, graph: null },
+    })
+
+    expect(judge).not.toHaveBeenCalled()
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+  })
 
   it('makes no entailment call at all while the setting is off', async () => {
     stubListInvariants([entailmentRecord()])

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -308,3 +308,93 @@ describe('resolveInvariantFlagOnDismiss', () => {
     warn.mockRestore()
   })
 })
+
+describe('entailment lane surfacing (#51)', () => {
+  const ENTAILMENT_DOC = schema.node('doc', null, [
+    p('b-declare', 'Terminations are now thirty days per the updated policy.'),
+    p('b-conflict', 'Under the new policy, terminations occur within one and a half months.'),
+  ])
+
+  const entailmentRecord = () =>
+    invariantRecord({
+      id: 'inv-e',
+      statement: 'terminations are now thirty days',
+      checkKind: 'entailment',
+    })
+
+  const confirmingJudge = async (pairs: { blockId: string }[]) =>
+    new Map(pairs.map((_, i) => [i, { contradicts: true, reason: 'Not thirty days.' }]))
+
+  it('makes no entailment call at all while the setting is off', async () => {
+    stubListInvariants([entailmentRecord()])
+    const judge = vi.fn(confirmingJudge)
+    const state = EditorState.create({ schema, doc: ENTAILMENT_DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state, {
+      entailmentEnabled: false,
+      entailmentDeps: { judge, graph: null },
+    })
+
+    expect(judge).not.toHaveBeenCalled()
+    expect(useAnnotationStore.getState().annotations).toEqual([])
+  })
+
+  it('surfaces a confirmed entailment conflict through the same CascadeList flag', async () => {
+    stubListInvariants([entailmentRecord()])
+    const state = EditorState.create({ schema, doc: ENTAILMENT_DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state, {
+      entailmentEnabled: true,
+      entailmentDeps: { judge: vi.fn(confirmingJudge), graph: null },
+    })
+
+    const annotations = useAnnotationStore.getState().annotations
+    expect(annotations).toHaveLength(1)
+    const [primary, cascade] = annotations[0].resolution!.edits!
+    expect(primary.status).toBe('rejected')
+    expect(cascade.newText).toBe(cascade.targetText) // still a no-op — flags never edit
+    expect(cascade.blockId).toBe('b-conflict')
+    expect(cascade.reason).toContain('Not thirty days.')
+    // No verbatim figure to cite, so it degrades to a lead — an uncited
+    // proposal can never be 'must'.
+    expect(cascade.evidence).toBeNull()
+    expect(cascade.severity).toBe('optional')
+  })
+
+  it('surfaces nothing when the entailment judge fails', async () => {
+    stubListInvariants([entailmentRecord()])
+    const state = EditorState.create({ schema, doc: ENTAILMENT_DOC })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await runAndSurfaceInvariantChecks('doc-A', state, {
+      entailmentEnabled: true,
+      entailmentDeps: {
+        judge: vi.fn(async () => {
+          throw new Error('provider down')
+        }),
+        graph: null,
+      },
+    })
+
+    expect(useAnnotationStore.getState().annotations).toEqual([])
+    warn.mockRestore()
+  })
+
+  it('aborts without flagging when the active document changed during the judge call', async () => {
+    stubListInvariants([entailmentRecord()])
+    const state = EditorState.create({ schema, doc: ENTAILMENT_DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state, {
+      entailmentEnabled: true,
+      entailmentDeps: {
+        judge: async (pairs) => {
+          useDocumentStore.setState({ activeDocumentId: 'doc-B' })
+          return new Map(pairs.map((_, i) => [i, { contradicts: true, reason: 'r' }]))
+        },
+        graph: null,
+      },
+    })
+
+    expect(useAnnotationStore.getState().annotations).toEqual([])
+  })
+})

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -223,4 +223,36 @@ describe('classifyCheckKind', () => {
     expect(classifyCheckKind(statement)).toBe('deterministic')
     expect(checkInvariants(doc, [invariant({ statement })])).toHaveLength(1)
   })
+
+  it("classifies 'deterministic' for statements the lane can still MISS — the fallthrough's reason to exist", () => {
+    // Pinning the honest limit rather than the flattering claim: the split is
+    // statement-shaped, but the deterministic lane's real gate is the
+    // per-block containsTerm match, which depends on text that does not exist
+    // at capture time. Both of these classify deterministic and find nothing,
+    // which is exactly why invariantCascade falls them through to the
+    // entailment lane instead of trusting classification alone.
+    const plural = 'each termination requires 30 days notice'
+    expect(classifyCheckKind(plural)).toBe('deterministic')
+    expect(
+      checkInvariants(
+        docOf(
+          p('b-declare', 'Each termination requires 30 days notice under the policy.'),
+          p('b-conflict', 'Terminations now require 45 days.'),
+        ),
+        [invariant({ statement: plural })],
+      ),
+    ).toEqual([])
+
+    const dated = 'the filing deadline is March 15'
+    expect(classifyCheckKind(dated)).toBe('deterministic')
+    expect(
+      checkInvariants(
+        docOf(
+          p('b-declare', 'The filing deadline is March 15 for all staff.'),
+          p('b-conflict', 'Filings are due by April 20 this year.'),
+        ),
+        [invariant({ statement: dated })],
+      ),
+    ).toEqual([])
+  })
 })

--- a/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
+++ b/src/lib/invariants/__tests__/invariantCheckRunner.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { Node as PMNode } from 'prosemirror-model'
 import { schema } from '@/lib/prosemirror/schema'
-import { checkInvariants } from '../invariantCheckRunner'
+import { checkInvariants, classifyCheckKind } from '../invariantCheckRunner'
 import type { Invariant } from '../captureInvariant'
 
 function p(blockId: string, text: string): PMNode {
@@ -180,5 +180,47 @@ describe('checkInvariants', () => {
     ])
     expect(violations).toHaveLength(1)
     expect(violations[0].conflictBlockId).toBe('b-conflict')
+  })
+
+  it('tags every violation it produces as the deterministic lane', () => {
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const violations = checkInvariants(doc, [invariant()])
+    expect(violations[0].checkKind).toBe('deterministic')
+  })
+})
+
+describe('classifyCheckKind', () => {
+  it('routes a figure-and-subject fact to the deterministic lane', () => {
+    expect(classifyCheckKind('terminations are now 30 days')).toBe('deterministic')
+    expect(classifyCheckKind('the cancellation fee is now $30')).toBe('deterministic')
+  })
+
+  it('routes a word-form-number fact to the entailment lane', () => {
+    expect(classifyCheckKind('terminations are now thirty days')).toBe('entailment')
+  })
+
+  it('routes a fact with no figure at all to the entailment lane', () => {
+    expect(classifyCheckKind('contractors are no longer eligible for severance')).toBe('entailment')
+  })
+
+  it('routes a bare figure with no subject term to the entailment lane', () => {
+    // The deterministic lane skips these outright — it cannot tell WHICH block
+    // the fact is even about — so they must not be classified into it.
+    expect(classifyCheckKind('30')).toBe('entailment')
+  })
+
+  it('agrees with the deterministic lane about what that lane can actually check', () => {
+    // The contract between the two: anything classified 'deterministic' must
+    // be something checkInvariants will genuinely evaluate rather than skip.
+    const doc = docOf(
+      p('b-declare', 'Terminations are now 30 days per the updated policy.'),
+      p('b-conflict', 'Under the new policy, terminations occur within 45 days of notice.'),
+    )
+    const statement = 'terminations are now 30 days'
+    expect(classifyCheckKind(statement)).toBe('deterministic')
+    expect(checkInvariants(doc, [invariant({ statement })])).toHaveLength(1)
   })
 })

--- a/src/lib/invariants/entailmentCheck.ts
+++ b/src/lib/invariants/entailmentCheck.ts
@@ -1,0 +1,348 @@
+import type { Node as PMNode } from 'prosemirror-model'
+import type { LLMConfig } from '@/stores/settingsStore'
+import { collectTextblocks } from '@/lib/prosemirror/blockIds'
+import { containsTerm, getDocGraph, getNeighborhood, type DocGraph } from '@/lib/graphrag/docGraph'
+import { extractChangedTokens } from '@/lib/ai/orchestrator'
+import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
+import type { Invariant } from './captureInvariant'
+import type { EntailmentViolation } from './invariantCheckRunner'
+
+/**
+ * Document Invariant Ledger — Phase 4 (issue #51): the LLM entailment lane,
+ * for the semantic facts the deterministic lane (`invariantCheckRunner.ts`)
+ * discloses it cannot check — word-form numbers ("thirty days"), calendar-date
+ * fragments, singular/plural variants, and claims with no exact-match anchor
+ * at all. Those statements are routed here at capture time by
+ * `classifyCheckKind`; nothing reaches this lane by accident.
+ *
+ * Trust boundary, inherited verbatim from `relevanceJudge.ts`: the judge only
+ * produces a CANDIDATE flag that still flows through the normal HITL cascade
+ * surface — it never mutates the ledger and never edits the document. The
+ * fail-safe direction is inverted relative to the relevance judge, and
+ * deliberately so: there, a malfunction PRESERVES a derived severity the
+ * system already believed; here there is no prior belief to preserve, so a
+ * thrown call, a malformed reply, or a missing verdict yields NO flag. A
+ * broken judge must never manufacture a false positive.
+ *
+ * Data egress: this lane never runs in the background. It is gated on the
+ * explicit `invariantEntailmentEnabled` setting (default OFF, "AI data &
+ * spend" panel) and only executes on the same user-initiated apply that the
+ * deterministic lane already runs on — never on typing.
+ */
+
+/** Judge verdict for one (invariant, candidate block) pair. */
+export interface EntailmentVerdict {
+  contradicts: boolean
+  reason: string
+}
+
+/** One (invariant, candidate block) pair put to the judge. */
+export interface EntailmentPair {
+  invariantId: string
+  statement: string
+  evidenceBlockIds: string[]
+  blockId: string
+  blockText: string
+}
+
+export type EntailmentJudgeFn = (
+  pairs: EntailmentPair[],
+  config: LLMConfig,
+) => Promise<Map<number, EntailmentVerdict>>
+
+/**
+ * Budget caps. The whole point of the graph scoping below is that this lane
+ * costs a bounded, predictable amount per run rather than scaling with
+ * document length — so the caps are hard, and what they drop is logged rather
+ * than silently truncated.
+ */
+const MAX_INVARIANTS_PER_RUN = 5
+const MAX_CANDIDATES_PER_INVARIANT = 6
+const MAX_TOTAL_PAIRS = 20
+/** How much of a candidate block the judge sees (mirrors relevanceJudge). */
+const CONTEXT_MAX_CHARS = 300
+/** Neighborhood radius around each evidence block — same 2 hops as the cascade. */
+const NEIGHBORHOOD_HOPS = 2
+
+const VERDICT_TOOL = {
+  name: 'entailment_verdict',
+  description:
+    'Deliver your verdict for ONE listed candidate. Call this tool exactly once per candidate, using the [n] index shown in brackets.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      index: {
+        type: 'number',
+        description: 'The [n] index of the candidate this verdict is for.',
+      },
+      contradicts: {
+        type: 'boolean',
+        description:
+          'true only when the passage cannot both be true and leave the declared fact true — a genuine contradiction, not merely a related topic.',
+      },
+      reason: {
+        type: 'string',
+        description: 'One short sentence justifying the verdict.',
+      },
+    },
+    required: ['index', 'contradicts', 'reason'],
+  },
+}
+
+const JUDGE_SYSTEM =
+  'You check whether a passage from a document CONTRADICTS a fact the author declared earlier. Be skeptical and conservative: sharing a topic, restating the fact, adding detail, or describing a different situation are all NOT contradictions. Answer true only when the passage and the declared fact cannot both be true at once. When you are unsure, answer false. For each numbered candidate, call entailment_verdict once with its index.'
+
+/** Safe default for any candidate the judge skipped or garbled: no flag. */
+const NO_VERDICT: EntailmentVerdict = { contradicts: false, reason: 'no verdict returned' }
+
+interface VerdictInput {
+  index?: unknown
+  contradicts?: unknown
+  reason?: unknown
+}
+
+function pairLine(pair: EntailmentPair, n: number): string {
+  return [
+    `[${n}] DECLARED FACT: "${pair.statement}"`,
+    `PASSAGE: "${pair.blockText.slice(0, CONTEXT_MAX_CHARS)}"`,
+  ].join(' | ')
+}
+
+/**
+ * One batched structured call over every (invariant, block) pair. Returns a
+ * verdict for EVERY index: anything the model skipped, duplicated away, or
+ * garbled comes back as not-contradicting.
+ *
+ * Throws when the structured call fails OR when a transport-successful call
+ * yields zero valid verdicts (protocol malfunction — the system prompt allows
+ * no silent path). Callers treat both as "no flags this run".
+ */
+export async function judgeEntailmentPairs(
+  pairs: EntailmentPair[],
+  config: LLMConfig,
+  call: CallStructuredFn = fetchStructured,
+): Promise<Map<number, EntailmentVerdict>> {
+  const verdicts = new Map<number, EntailmentVerdict>()
+  if (pairs.length === 0) return verdicts
+
+  const userPrompt = [
+    'CANDIDATES (does each passage contradict its declared fact?):',
+    ...pairs.map((pair, i) => pairLine(pair, i + 1)),
+  ].join('\n')
+
+  const { toolCalls } = await call(
+    {
+      messages: [
+        { role: 'system', content: JUDGE_SYSTEM },
+        { role: 'user', content: userPrompt },
+      ],
+      tools: [VERDICT_TOOL],
+      maxTokens: Math.min(8000, 400 + 200 * pairs.length),
+      temperature: 0,
+    },
+    // Entailment checking is utility work — route it to the cheap model, the
+    // same pin the relevance judge uses.
+    { ...config, model: pickUtilityModel(config) },
+  )
+
+  for (const tc of toolCalls) {
+    if (tc.name !== VERDICT_TOOL.name) continue
+    const input = tc.input as VerdictInput
+    const n = typeof input?.index === 'number' ? Math.trunc(input.index) : NaN
+    if (!Number.isInteger(n) || n < 1 || n > pairs.length) continue
+    const parsed: EntailmentVerdict = {
+      contradicts: input.contradicts === true,
+      reason: typeof input.reason === 'string' && input.reason ? input.reason : 'no reason given',
+    }
+    // Duplicate indexes: the SAFE answer wins, which here is "no contradiction"
+    // — the mirror image of relevanceJudge's deny-wins rule, because there the
+    // safe answer was the denial and here it is the absence of a flag.
+    const existing = verdicts.get(n - 1)
+    if (existing && !existing.contradicts) continue
+    verdicts.set(n - 1, parsed)
+  }
+
+  if (verdicts.size === 0) {
+    throw new Error('entailment judge returned zero valid verdicts')
+  }
+
+  for (let i = 0; i < pairs.length; i++) {
+    if (!verdicts.has(i)) verdicts.set(i, NO_VERDICT)
+  }
+  return verdicts
+}
+
+function parseBlockIds(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+interface ScoredCandidate {
+  blockId: string
+  blockText: string
+  /** Lower sorts first: graph distance, or PLAIN_TERM_HOP for a term-only hit. */
+  hop: number
+  sourceRank: number
+}
+
+/**
+ * Term-only candidates sort after every real graph neighbor. They are a
+ * recall floor, not a peer of graph evidence.
+ */
+const PLAIN_TERM_HOP = Number.MAX_SAFE_INTEGER
+
+/**
+ * Candidate blocks for one invariant, bounded two ways rather than scanning
+ * the document:
+ *
+ * 1. The 2-hop deterministic-graph neighborhood of each evidence block — the
+ *    same scoping the cascade already uses to decide what a change can affect.
+ * 2. Blocks sharing a substantive term with the statement. This is the
+ *    deterministic lane's own subject-match signal minus its figure
+ *    requirement, and it is what makes the lane actually reach a word-form
+ *    fact ("terminations are now thirty days" → blocks about terminations)
+ *    in a document whose deterministic graph happens to have no edges at all.
+ *
+ * Evidence blocks themselves are never candidates — a fact cannot contradict
+ * the block that declared it.
+ */
+export function selectCandidates(
+  doc: PMNode,
+  invariant: Invariant,
+  graph: DocGraph | null,
+): EntailmentPair[] {
+  const evidenceBlockIds = parseBlockIds(invariant.blockIds)
+  const evidence = new Set(evidenceBlockIds)
+
+  const reach = new Map<string, { hop: number; sourceRank: number }>()
+  if (graph) {
+    for (const evidenceBlockId of evidenceBlockIds) {
+      for (const [blockId, entry] of getNeighborhood(graph, evidenceBlockId, NEIGHBORHOOD_HOPS)) {
+        const existing = reach.get(blockId)
+        if (!existing || entry.hop < existing.hop) reach.set(blockId, { ...entry })
+      }
+    }
+  }
+
+  const terms = extractChangedTokens(invariant.statement, '').filter((t) => !/^[$€£]?\d/.test(t))
+
+  const scored: ScoredCandidate[] = []
+  for (const block of collectTextblocks(doc)) {
+    const { blockId } = block
+    if (!blockId || evidence.has(blockId)) continue
+    const blockText = block.node.textContent
+    if (!blockText.trim()) continue
+
+    const neighbor = reach.get(blockId)
+    const sharesTerm = terms.some((term) => containsTerm(blockText, term))
+    if (!neighbor && !sharesTerm) continue
+
+    scored.push({
+      blockId,
+      blockText,
+      hop: neighbor ? neighbor.hop : PLAIN_TERM_HOP,
+      sourceRank: neighbor ? neighbor.sourceRank : 0,
+    })
+  }
+
+  scored.sort((a, b) => a.hop - b.hop || a.sourceRank - b.sourceRank)
+
+  return scored.slice(0, MAX_CANDIDATES_PER_INVARIANT).map((c) => ({
+    invariantId: invariant.id,
+    statement: invariant.statement,
+    evidenceBlockIds,
+    blockId: c.blockId,
+    blockText: c.blockText,
+  }))
+}
+
+export interface EntailmentCheckDeps {
+  /** Injectable judge (tests: scripted verdicts). */
+  judge?: EntailmentJudgeFn
+  /** Injectable graph, so tests need not build one. `null` skips graph scoping. */
+  graph?: DocGraph | null
+}
+
+/**
+ * Run the entailment lane over a document's entailment-kind active
+ * invariants. Never throws and never returns a flag it is not sure about: any
+ * failure anywhere (graph build, judge call, malformed reply) yields an empty
+ * result.
+ */
+export async function checkEntailmentInvariants(
+  doc: PMNode,
+  invariants: Invariant[],
+  config: LLMConfig,
+  deps: EntailmentCheckDeps = {},
+): Promise<EntailmentViolation[]> {
+  const active = invariants.filter(
+    (inv) => inv.checkKind === 'entailment' && inv.status === 'active',
+  )
+  if (active.length === 0) return []
+
+  const considered = active.slice(0, MAX_INVARIANTS_PER_RUN)
+  if (considered.length < active.length) {
+    console.warn(
+      `[invariants] entailment lane capped at ${MAX_INVARIANTS_PER_RUN} invariants; ${active.length - considered.length} not checked this run`,
+    )
+  }
+
+  try {
+    let graph: DocGraph | null
+    if (deps.graph !== undefined) {
+      graph = deps.graph
+    } else {
+      // Deterministic-only, exactly as `directEditTrigger` does: a warm cache
+      // hit off the background rebuild, and never itself a network call.
+      graph = await getDocGraph(doc, config, {
+        skipLlm: true,
+        skipEmbeddings: true,
+        skipGraphiti: true,
+      })
+    }
+
+    const pairs: EntailmentPair[] = []
+    for (const invariant of considered) {
+      if (pairs.length >= MAX_TOTAL_PAIRS) break
+      const remaining = MAX_TOTAL_PAIRS - pairs.length
+      pairs.push(...selectCandidates(doc, invariant, graph).slice(0, remaining))
+    }
+    if (pairs.length === 0) return []
+
+    const judge: EntailmentJudgeFn =
+      deps.judge ?? ((p, c) => judgeEntailmentPairs(p, c))
+    const verdicts = await judge(pairs, config)
+
+    const violations: EntailmentViolation[] = []
+    const flaggedInvariants = new Set<string>()
+    for (let i = 0; i < pairs.length; i++) {
+      const verdict = verdicts.get(i)
+      if (!verdict?.contradicts) continue
+      const pair = pairs[i]
+      // At most one violation per invariant, matching the deterministic lane:
+      // enough signal to flag; the cascade review surface is where the user
+      // inspects the rest.
+      if (flaggedInvariants.has(pair.invariantId)) continue
+      flaggedInvariants.add(pair.invariantId)
+      violations.push({
+        checkKind: 'entailment',
+        invariantId: pair.invariantId,
+        statement: pair.statement,
+        evidenceBlockIds: pair.evidenceBlockIds,
+        conflictBlockId: pair.blockId,
+        conflictText: pair.blockText,
+        judgeReason: verdict.reason,
+      })
+    }
+    return violations
+  } catch (err) {
+    // Fail safe: a broken judge produces no flags, never a false positive.
+    console.warn('[invariants] Entailment lane failed:', err)
+    return []
+  }
+}

--- a/src/lib/invariants/entailmentCheck.ts
+++ b/src/lib/invariants/entailmentCheck.ts
@@ -149,8 +149,12 @@ export async function judgeEntailmentPairs(
   for (const tc of toolCalls) {
     if (tc.name !== VERDICT_TOOL.name) continue
     const input = tc.input as VerdictInput
-    const n = typeof input?.index === 'number' ? Math.trunc(input.index) : NaN
-    if (!Number.isInteger(n) || n < 1 || n > pairs.length) continue
+    // No `Math.trunc` here, unlike relevanceJudge: coercing a malformed 2.9
+    // into slot 2 is fail-OPEN, and in a lane whose charter is "a broken judge
+    // never manufactures a false positive" a garbled index must be discarded,
+    // not rounded into a real candidate.
+    const n = input?.index
+    if (typeof n !== 'number' || !Number.isInteger(n) || n < 1 || n > pairs.length) continue
     const parsed: EntailmentVerdict = {
       contradicts: input.contradicts === true,
       reason: typeof input.reason === 'string' && input.reason ? input.reason : 'no reason given',
@@ -188,6 +192,14 @@ interface ScoredCandidate {
   /** Lower sorts first: graph distance, or PLAIN_TERM_HOP for a term-only hit. */
   hop: number
   sourceRank: number
+  /**
+   * How many distinct statement terms this block matches. Breaks the tie
+   * between term-only candidates, which all share `PLAIN_TERM_HOP` — without
+   * it the comparator returns 0 for every one of them and the stable sort
+   * silently pins selection to the first N blocks in document order, run
+   * after run, leaving later blocks permanently unreachable.
+   */
+  termHits: number
 }
 
 /**
@@ -217,6 +229,13 @@ export function selectCandidates(
   graph: DocGraph | null,
 ): EntailmentPair[] {
   const evidenceBlockIds = parseBlockIds(invariant.blockIds)
+  // An invariant with no evidence links has nothing to exclude, so every
+  // block — including the one that declared the fact — would be offered to
+  // the judge as possibly contradicting it. `invariantCascade` would then
+  // drop any resulting flag anyway (`primaryAnchor` needs an evidence block
+  // to anchor to), so the whole round-trip is spend with no reachable
+  // outcome. Skip it here instead of paying for it.
+  if (evidenceBlockIds.length === 0) return []
   const evidence = new Set(evidenceBlockIds)
 
   const reach = new Map<string, { hop: number; sourceRank: number }>()
@@ -239,18 +258,27 @@ export function selectCandidates(
     if (!blockText.trim()) continue
 
     const neighbor = reach.get(blockId)
-    const sharesTerm = terms.some((term) => containsTerm(blockText, term))
-    if (!neighbor && !sharesTerm) continue
+    const termHits = terms.reduce((n, term) => (containsTerm(blockText, term) ? n + 1 : n), 0)
+    if (!neighbor && termHits === 0) continue
 
     scored.push({
       blockId,
       blockText,
       hop: neighbor ? neighbor.hop : PLAIN_TERM_HOP,
       sourceRank: neighbor ? neighbor.sourceRank : 0,
+      termHits,
     })
   }
 
-  scored.sort((a, b) => a.hop - b.hop || a.sourceRank - b.sourceRank)
+  scored.sort(
+    (a, b) => a.hop - b.hop || a.sourceRank - b.sourceRank || b.termHits - a.termHits,
+  )
+
+  if (scored.length > MAX_CANDIDATES_PER_INVARIANT) {
+    console.warn(
+      `[invariants] entailment candidates for ${invariant.id} capped at ${MAX_CANDIDATES_PER_INVARIANT}; ${scored.length - MAX_CANDIDATES_PER_INVARIANT} matching blocks not checked`,
+    )
+  }
 
   return scored.slice(0, MAX_CANDIDATES_PER_INVARIANT).map((c) => ({
     invariantId: invariant.id,
@@ -280,15 +308,22 @@ export async function checkEntailmentInvariants(
   config: LLMConfig,
   deps: EntailmentCheckDeps = {},
 ): Promise<EntailmentViolation[]> {
-  const active = invariants.filter(
-    (inv) => inv.checkKind === 'entailment' && inv.status === 'active',
-  )
+  // Which invariants belong in this lane — `checkKind: 'entailment'` rows,
+  // plus any `'deterministic'`-classified row `invariantCascade.ts` decided
+  // deserves a second look — is the CALLER's decision (see its docstring for
+  // why). This function only re-asserts `status === 'active'` as a defensive
+  // floor for any other caller.
+  const active = invariants.filter((inv) => inv.status === 'active')
   if (active.length === 0) return []
 
+  // No rotation: `listInvariants` returns newest-first and this takes the same
+  // prefix on every run, so an over-cap ledger's oldest rows are never checked
+  // by this lane at all — not merely deferred. Disclosed as a real coverage
+  // limit rather than implied away by a "this run" that suggests a next turn.
   const considered = active.slice(0, MAX_INVARIANTS_PER_RUN)
   if (considered.length < active.length) {
     console.warn(
-      `[invariants] entailment lane capped at ${MAX_INVARIANTS_PER_RUN} invariants; ${active.length - considered.length} not checked this run`,
+      `[invariants] entailment lane checks at most ${MAX_INVARIANTS_PER_RUN} invariants (newest first); ${active.length - considered.length} older ones are never reached`,
     )
   }
 
@@ -307,10 +342,23 @@ export async function checkEntailmentInvariants(
     }
 
     const pairs: EntailmentPair[] = []
+    const starved: string[] = []
     for (const invariant of considered) {
-      if (pairs.length >= MAX_TOTAL_PAIRS) break
       const remaining = MAX_TOTAL_PAIRS - pairs.length
-      pairs.push(...selectCandidates(doc, invariant, graph).slice(0, remaining))
+      const selected = selectCandidates(doc, invariant, graph)
+      // The batch budget is shared and spent in order, so a later invariant
+      // can get fewer slots than it has candidates — or none at all. Say so:
+      // "no contradictions" must not quietly mean "never looked".
+      if (selected.length > 0 && remaining < selected.length) {
+        starved.push(invariant.id)
+      }
+      if (remaining <= 0) continue
+      pairs.push(...selected.slice(0, remaining))
+    }
+    if (starved.length > 0) {
+      console.warn(
+        `[invariants] entailment batch budget (${MAX_TOTAL_PAIRS} passages) exhausted; these invariants were checked partially or not at all: ${starved.join(', ')}`,
+      )
     }
     if (pairs.length === 0) return []
 

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -223,9 +223,29 @@ export async function runAndSurfaceInvariantChecks(
       opts.entailmentEnabled ?? useSettingsStore.getState().invariantEntailmentEnabled
     if (entailmentOn) {
       const config = useSettingsStore.getState().llmConfig
+      // Candidates for this lane are NOT just `checkKind: 'entailment'` rows.
+      // `classifyCheckKind` decides the lane from the statement text ALONE —
+      // it cannot see the future drift text, so it cannot always predict
+      // whether the deterministic lane's exact-word `containsTerm` subject
+      // match will actually fire (a plural variant or a reworded date can
+      // defeat it even when a figure and a term are both present, which is
+      // all `classifyCheckKind` can check). A `'deterministic'`-classified
+      // invariant that produced no deterministic violation this run is given
+      // a second look here rather than assumed clean. This also covers every
+      // ledger row written before this phase shipped, when capture
+      // unconditionally defaulted to `checkKind: 'deterministic'` — those
+      // rows need no migration to reach this lane; they just need this run
+      // to find nothing wrong with them deterministically, which a genuinely
+      // stale row won't.
+      const flaggedByDeterministic = new Set(violations.map((v) => v.invariantId))
+      const entailmentCandidates = invariants.filter((inv) => {
+        if (inv.status !== 'active') return false
+        if (inv.checkKind === 'entailment') return true
+        return inv.checkKind === 'deterministic' && !flaggedByDeterministic.has(inv.id)
+      })
       const entailed = await checkEntailmentInvariants(
         state.doc,
-        invariants,
+        entailmentCandidates,
         config,
         opts.entailmentDeps,
       )

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -9,6 +9,8 @@ import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import { generateId } from '@/lib/utils/id'
 import { listInvariants, resolveInvariant } from './captureInvariant'
 import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
+import { checkEntailmentInvariants, type EntailmentCheckDeps } from './entailmentCheck'
+import { useSettingsStore } from '@/stores/settingsStore'
 import type { Annotation, CascadeEvidence, ProposedEdit, ResolutionAction } from '@/lib/annotations/types'
 
 /**
@@ -107,19 +109,40 @@ function verifiedEvidence(
   return { evidence: null, severity: 'optional' }
 }
 
+/**
+ * An entailment violation (Phase 4, #51) has no figure to cite — the absence
+ * of any exact-match anchor is precisely why it needed a judge rather than the
+ * deterministic lane. So it degrades to no evidence and `'optional'` severity,
+ * under the same rule that governs every other cascade path in this codebase:
+ * an uncited proposal can never be `must`. A model's say-so is a lead.
+ */
+function violationEvidence(
+  doc: EditorState['doc'],
+  violation: InvariantViolation,
+): { evidence: CascadeEvidence | null; severity: 'must' | 'optional' } {
+  if (violation.checkKind !== 'deterministic') return { evidence: null, severity: 'optional' }
+  return verifiedEvidence(doc, violation.evidenceBlockIds, violation.statementNumber)
+}
+
+function violationReason(violation: InvariantViolation): string {
+  return violation.checkKind === 'deterministic'
+    ? `Declared "${violation.statementNumber}", but this section says "${violation.conflictNumber}": "${violation.statement}"`
+    : `Declared "${violation.statement}", but this section may contradict it: ${violation.judgeReason}`
+}
+
 function conflictEdit(doc: EditorState['doc'], violation: InvariantViolation): ProposedEdit | null {
   const block = findBlockById(doc, violation.conflictBlockId)
   if (!block) return null
   const from = block.pos + 1
   const to = block.pos + block.node.nodeSize - 1
   const text = block.node.textContent
-  const { evidence, severity } = verifiedEvidence(doc, violation.evidenceBlockIds, violation.statementNumber)
+  const { evidence, severity } = violationEvidence(doc, violation)
   return {
     id: generateId(),
     from,
     to,
     newText: text,
-    reason: `Declared "${violation.statementNumber}", but this section says "${violation.conflictNumber}": "${violation.statement}"`,
+    reason: violationReason(violation),
     relation: 'cascade',
     status: 'pending',
     targetText: text,
@@ -177,6 +200,12 @@ function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): 
 export async function runAndSurfaceInvariantChecks(
   documentId: string,
   state: EditorState,
+  opts: {
+    /** Test/caller override for the settings-store entailment toggle. */
+    entailmentEnabled?: boolean
+    /** Injectable judge/graph for the entailment lane (tests). */
+    entailmentDeps?: EntailmentCheckDeps
+  } = {},
 ): Promise<void> {
   try {
     if (useDocumentStore.getState().activeDocumentId !== documentId) return
@@ -184,7 +213,28 @@ export async function runAndSurfaceInvariantChecks(
     const invariants = await listInvariants(documentId)
     if (useDocumentStore.getState().activeDocumentId !== documentId) return
 
-    const violations = checkInvariants(state.doc, invariants)
+    const violations: InvariantViolation[] = checkInvariants(state.doc, invariants)
+
+    // Entailment lane (Phase 4, #51): opt-in only. Off by default because it
+    // is the one doc-CI path that spends money and sends document text — the
+    // deterministic lane above stays local and always-on regardless. Runs on
+    // this same user-initiated apply, never on typing.
+    const entailmentOn =
+      opts.entailmentEnabled ?? useSettingsStore.getState().invariantEntailmentEnabled
+    if (entailmentOn) {
+      const config = useSettingsStore.getState().llmConfig
+      const entailed = await checkEntailmentInvariants(
+        state.doc,
+        invariants,
+        config,
+        opts.entailmentDeps,
+      )
+      // The judge call is a second async gap — re-check the doc-switch guard
+      // before tagging anything with this documentId.
+      if (useDocumentStore.getState().activeDocumentId !== documentId) return
+      violations.push(...entailed)
+    }
+
     if (violations.length === 0) return
 
     const flagStore = useInvariantFlagStore.getState()

--- a/src/lib/invariants/invariantCheckRunner.ts
+++ b/src/lib/invariants/invariantCheckRunner.ts
@@ -2,7 +2,7 @@ import type { Node as PMNode } from 'prosemirror-model'
 import { collectTextblocks } from '@/lib/prosemirror/blockIds'
 import { containsTerm } from '@/lib/graphrag/docGraph'
 import { extractChangedTokens } from '@/lib/ai/orchestrator'
-import type { Invariant } from './captureInvariant'
+import type { Invariant, InvariantCheckKind } from './captureInvariant'
 
 /**
  * Document Invariant Ledger — Phase 2 (issue #32): the deterministic check
@@ -19,8 +19,8 @@ import type { Invariant } from './captureInvariant'
  * before/after diff extractor as a plain tokenizer — nothing in an empty
  * `after` can match, so every token in `text` comes back.
  *
- * The LLM/NLI entailment lane for semantic (non-deterministic) facts is out
- * of scope for this slice (#20's own phasing) — entailment-kind and
+ * The LLM/NLI entailment lane for semantic (non-deterministic) facts lives in
+ * the sibling `entailmentCheck.ts` (Phase 4, #51) — entailment-kind and
  * inactive rows are silently skipped here, never errored.
  *
  * Known false-negative limitations, disclosed rather than silently assumed
@@ -28,6 +28,8 @@ import type { Invariant } from './captureInvariant'
  * numbers ("thirty days"), calendar-date fragments, and singular/plural term
  * variants (`containsTerm` is exact-word, not stemmed) are not matched. These
  * make the lane conservative — it can miss a real drift — never the reverse.
+ * `classifyCheckKind` below routes exactly those statements to the entailment
+ * lane instead, so a fact this lane cannot check is not simply dropped.
  *
  * Known remaining false-positive limitation: a statement whose ONLY
  * substantive term is a single generic word ("the deadline is $500") cannot
@@ -37,7 +39,7 @@ import type { Invariant } from './captureInvariant'
  * not, and this is a deliberate reuse-only tradeoff, not an oversight.
  */
 
-export interface InvariantViolation {
+interface InvariantViolationBase {
   invariantId: string
   statement: string
   /** The invariant's own evidence blocks — never treated as a conflict target. */
@@ -45,13 +47,53 @@ export interface InvariantViolation {
   /** The block whose content no longer agrees with the declared statement. */
   conflictBlockId: string
   conflictText: string
+}
+
+export interface DeterministicViolation extends InvariantViolationBase {
+  checkKind: 'deterministic'
   /** The specific figure the statement declared (verbatim substring of it). */
   statementNumber: string
   /** The specific figure found in the conflicting block (verbatim substring of it). */
   conflictNumber: string
 }
 
+export interface EntailmentViolation extends InvariantViolationBase {
+  checkKind: 'entailment'
+  /** The judge's one-sentence justification — there is no figure to cite here. */
+  judgeReason: string
+}
+
+/**
+ * Discriminated on `checkKind` so the two lanes cannot be confused downstream:
+ * a deterministic violation always carries the two figures it compared, an
+ * entailment violation never does (that absence is precisely why it needed a
+ * judge) and carries the judge's reason instead.
+ */
+export type InvariantViolation = DeterministicViolation | EntailmentViolation
+
 const NUMERIC_TOKEN_RE = /^[$€£]?\d/
+
+/**
+ * Which lane a newly declared fact belongs to, decided at capture time so the
+ * ledger row is written with the right `checkKind` instead of the hardcoded
+ * `'deterministic'` every caller used through Phase 3.
+ *
+ * Deliberately mirrors `checkInvariants`'s own skip gate below rather than
+ * inventing a second notion of "deterministically checkable": a statement the
+ * deterministic lane would silently `continue` past (no figure, or no
+ * substantive subject term to identify WHICH block is about the fact) is
+ * exactly the statement that needs the entailment lane. Keeping both reads of
+ * `extractChangedTokens` in one file is what stops them drifting apart and
+ * opening a gap where a fact belongs to neither lane.
+ *
+ * Local and free — no LLM call is made just to classify.
+ */
+export function classifyCheckKind(statement: string): InvariantCheckKind {
+  const tokens = extractChangedTokens(statement, '')
+  const hasNumber = tokens.some((t) => NUMERIC_TOKEN_RE.test(t))
+  const hasTerm = tokens.some((t) => !NUMERIC_TOKEN_RE.test(t))
+  return hasNumber && hasTerm ? 'deterministic' : 'entailment'
+}
 
 function parseBlockIds(raw: string): string[] {
   try {
@@ -85,11 +127,11 @@ function normalizeNumeric(token: string): string {
  * conflicting block found) — enough signal to flag; the cascade review flow
  * is where the user inspects the rest of the document.
  */
-export function checkInvariants(doc: PMNode, invariants: Invariant[]): InvariantViolation[] {
+export function checkInvariants(doc: PMNode, invariants: Invariant[]): DeterministicViolation[] {
   const blocks = collectTextblocks(doc).filter(
     (b): b is { blockId: string; pos: number; node: (typeof b)['node'] } => Boolean(b.blockId),
   )
-  const violations: InvariantViolation[] = []
+  const violations: DeterministicViolation[] = []
 
   for (const invariant of invariants) {
     if (invariant.checkKind !== 'deterministic' || invariant.status !== 'active') continue
@@ -134,6 +176,7 @@ export function checkInvariants(doc: PMNode, invariants: Invariant[]): Invariant
       if (differentIdx === -1) continue
 
       violations.push({
+        checkKind: 'deterministic',
         invariantId: invariant.id,
         statement: invariant.statement,
         evidenceBlockIds,

--- a/src/lib/invariants/invariantCheckRunner.ts
+++ b/src/lib/invariants/invariantCheckRunner.ts
@@ -28,8 +28,17 @@ import type { Invariant, InvariantCheckKind } from './captureInvariant'
  * numbers ("thirty days"), calendar-date fragments, and singular/plural term
  * variants (`containsTerm` is exact-word, not stemmed) are not matched. These
  * make the lane conservative — it can miss a real drift — never the reverse.
- * `classifyCheckKind` below routes exactly those statements to the entailment
- * lane instead, so a fact this lane cannot check is not simply dropped.
+ *
+ * `classifyCheckKind` below cannot fully close that gap by itself: it decides
+ * the lane from the STATEMENT text alone, before any conflicting block
+ * exists, so it can confirm a statement has a figure and a subject term but
+ * cannot predict whether a future block's phrasing of that same term will
+ * survive `containsTerm`'s exact-word match (a plural, a reworded date, a
+ * synonym all defeat it silently). What actually closes the gap is
+ * `invariantCascade.ts`'s `runAndSurfaceInvariantChecks`: when the entailment
+ * lane is on, a `'deterministic'`-classified invariant that this lane finds
+ * NO violation for is handed to the entailment lane as a fallback, rather
+ * than trusted as clean on classification alone.
  *
  * Known remaining false-positive limitation: a statement whose ONLY
  * substantive term is a single generic word ("the deadline is $500") cannot
@@ -78,13 +87,23 @@ const NUMERIC_TOKEN_RE = /^[$€£]?\d/
  * ledger row is written with the right `checkKind` instead of the hardcoded
  * `'deterministic'` every caller used through Phase 3.
  *
- * Deliberately mirrors `checkInvariants`'s own skip gate below rather than
- * inventing a second notion of "deterministically checkable": a statement the
- * deterministic lane would silently `continue` past (no figure, or no
- * substantive subject term to identify WHICH block is about the fact) is
- * exactly the statement that needs the entailment lane. Keeping both reads of
- * `extractChangedTokens` in one file is what stops them drifting apart and
- * opening a gap where a fact belongs to neither lane.
+ * Deliberately mirrors `checkInvariants`'s STATEMENT-side skip gate below
+ * rather than inventing a second notion of "deterministically checkable": a
+ * statement the deterministic lane would silently `continue` past (no figure,
+ * or no substantive subject term to identify WHICH block is about the fact)
+ * is exactly the statement that needs the entailment lane. Keeping both reads
+ * of `extractChangedTokens` in one file is what stops them drifting apart.
+ *
+ * What this CANNOT decide, and deliberately does not pretend to: the
+ * deterministic lane's *effective* gate is the per-block `containsTerm`
+ * subject match, which depends on text that does not exist yet at capture
+ * time. So `'deterministic'` here means "worth trying deterministically
+ * first", NOT "guaranteed deterministically checkable" — e.g. "each
+ * termination requires 30 days notice" classifies deterministic and still
+ * misses a later "Terminations now require 45 days." (unstemmed plural).
+ * `runAndSurfaceInvariantChecks` is what catches those, by falling such
+ * invariants through to the entailment lane when it finds no deterministic
+ * violation for them.
  *
  * Local and free — no LLM call is made just to classify.
  */

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -98,6 +98,16 @@ interface SettingsState {
    */
   judgeEnabled: boolean
   /**
+   * LLM entailment checking for semantic declared facts the deterministic
+   * doc-CI lane cannot check — word-form numbers, dates, claims with no
+   * exact-match anchor (default OFF). When on, applying an AI change sends
+   * the declared statement and a bounded set of candidate passages to the
+   * small model. Off by default because it is the only doc-CI path that costs
+   * money and sends document text; the deterministic lane stays local and
+   * always-on either way.
+   */
+  invariantEntailmentEnabled: boolean
+  /**
    * Anonymous severity-calibration telemetry (default OFF — public repo,
    * other users). When on, cascade accept/reject decisions send metadata-only
    * events (severity × action, never document content or ids) to PostHog if
@@ -110,6 +120,7 @@ interface SettingsState {
   setShowApiKeyModal: (show: boolean) => void
   setEmbeddingsEnabled: (enabled: boolean) => void
   setJudgeEnabled: (enabled: boolean) => void
+  setInvariantEntailmentEnabled: (enabled: boolean) => void
   setTelemetryEnabled: (enabled: boolean) => void
   hasKeys: () => boolean
 }
@@ -127,6 +138,7 @@ export const useSettingsStore = create<SettingsState>()(
       showApiKeyModal: false,
       embeddingsEnabled: true,
       judgeEnabled: true,
+      invariantEntailmentEnabled: false,
       telemetryEnabled: false,
       setLLMConfig: (config) =>
         set((s) => ({ llmConfig: { ...s.llmConfig, ...config } })),
@@ -134,6 +146,7 @@ export const useSettingsStore = create<SettingsState>()(
       setShowApiKeyModal: (show) => set({ showApiKeyModal: show }),
       setEmbeddingsEnabled: (enabled) => set({ embeddingsEnabled: enabled }),
       setJudgeEnabled: (enabled) => set({ judgeEnabled: enabled }),
+      setInvariantEntailmentEnabled: (enabled) => set({ invariantEntailmentEnabled: enabled }),
       setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
       hasKeys: () => {
         const s = get()
@@ -168,9 +181,17 @@ export const useSettingsStore = create<SettingsState>()(
           state.setJudgeEnabled(true)
         }
         // Privacy-sensitive: anything other than an explicit stored `true`
-        // resolves to OFF.
+        // resolves to OFF. Same rule for the entailment lane, which is the
+        // only doc-CI path that spends money and sends document text.
         if (state && typeof (state as { telemetryEnabled?: unknown }).telemetryEnabled !== 'boolean') {
           state.setTelemetryEnabled(false)
+        }
+        if (
+          state &&
+          typeof (state as { invariantEntailmentEnabled?: unknown }).invariantEntailmentEnabled !==
+            'boolean'
+        ) {
+          state.setInvariantEntailmentEnabled(false)
         }
       },
     }


### PR DESCRIPTION
## Summary

Closes the gap `checkKind: 'entailment'` has carried since Phase 1. No code path had ever created or checked an entailment-kind invariant: `POST /api/invariants` defaulted every statement to `'deterministic'`, the one real call site never passed `checkKind` at all, and `invariantCheckRunner.ts` skipped entailment rows outright. Every declared fact the figure-matching lane cannot check — word-form numbers, date fragments, plural variants, claims with no exact-match anchor — was captured as deterministic and then silently skipped forever.

**Capture-time classification.** `classifyCheckKind` decides the lane instead of hardcoding `'deterministic'`. It lives in `invariantCheckRunner.ts` beside the skip gate it mirrors and reuses that gate's own `extractChangedTokens` read. Local and free — no LLM call just to classify.

**New entailment lane** (`entailmentCheck.ts`). One batched structured call over (invariant, candidate block) pairs, pinned to the cheap utility model via `pickUtilityModel` exactly as `relevanceJudge` does. The trust boundary is inherited, but the fail-safe direction is deliberately **inverted**: the relevance judge preserves a severity the system already derived, whereas here there is no prior belief to preserve — so a thrown call, a malformed reply, a duplicate verdict, an out-of-range index, or a missing verdict all yield **no flag**. A broken judge must never manufacture a false positive.

**Bounded candidates**, not a whole-document scan: the 2-hop deterministic-graph neighborhood of each evidence block, unioned with blocks sharing a substantive statement term, capped per-invariant and per-run. The graph build is `skipLlm`/`skipEmbeddings`/`skipGraphiti`, so it is a cache hit and never itself a network call.

**Data egress.** Gated on a new `invariantEntailmentEnabled` setting, default OFF and rehydrate-backfilled to OFF (anything other than an explicit stored `true` resolves to off — same rule as `telemetryEnabled`). It is the only doc-CI path that spends money and sends document text; the deterministic lane stays local and always-on regardless. Runs on the same user-initiated apply, never on typing.

**Surfacing unchanged.** Entailment violations flow through the existing `invariantCascade` → `CascadeList` surface, so the one-cascade-surface rule holds. `InvariantViolation` became a union discriminated on `checkKind`. An entailment violation has no verbatim figure to cite by construction, so it degrades to no evidence and `'optional'` severity under the standing rule that an uncited proposal can never be `must`.

## Process record

Pre-push adversarial (troublemaker) review returned **NO-MERGE with 2 HIGH findings**, both reproducible, both meaning the feature did not do what the first commit and three docstrings claimed. Both fixed with regression tests before this PR was opened.

**HIGH-1 — statements in neither lane.** `classifyCheckKind` mirrored only the statement-side skip gate, not the *effective* one: the per-block exact-word `containsTerm` subject match. A statement can clear the first and be structurally unmatchable by the second — so it was classified deterministic, skipped by that lane, then filtered out of the entailment lane by its `checkKind === 'entailment'` test. Two of the three blind spots the runner's own docstring names were affected:

- `"each termination requires 30 days notice"` vs `"Terminations now require 45 days."` — unstemmed plural, no match, no flag from either lane.
- `"the filing deadline is March 15"` vs `"Filings are due by April 20"` — required terms `deadline`/`March` appear in neither.

Fixed by moving lane membership to `runAndSurfaceInvariantChecks`, which falls a deterministic-classified invariant through to the entailment lane when the deterministic lane found no violation for it. Classification is now documented honestly as "worth trying deterministically first", not "guaranteed deterministically checkable".

**HIGH-2 — permanent no-op on existing ledgers.** Capture defaulted every row to `'deterministic'` through Phase 3 and the ledger is append-only, so no pre-#51 row could ever reach the new lane and no migration could reclassify one — the feature would have been unverifiable by hand on any real document. The HIGH-1 fallthrough closes this too, and without a migration: those rows find nothing deterministically and fall through. A genuinely stale one gets judged; a clean one costs nothing.

Also fixed from the same review: term-only candidates all tied on the sort key so stable sort pinned selection to the first N blocks in document order forever (added a matched-term-count tiebreak); two of three caps dropped work without logging it despite the docstring claiming otherwise; the settings copy said "the small model" which is only true for Claude, since `pickUtilityModel` is a no-op for openai/openrouter/ollama; `Math.trunc` on the judge's index rounded a malformed `2.9` into a real slot (fail-open, dropped); an invariant with no evidence links made the declaring block its own candidate, spending a judge call on a flag `primaryAnchor` would then drop.

Test-quality findings, also acted on: removed a **false gate** — a test injected an empty verdict `Map`, a state the real `judgeEntailmentPairs` cannot produce because it throws first — and replaced it with tests driving the real judge through the malfunction and bad-index paths. `toBeLessThanOrEqual(6)` would have passed with selection entirely broken (now `toHaveLength(6)`). A vacuously-true `not.toHaveProperty` now pins the union's real discriminant. Every test previously injected an edgeless graph, so the 2-hop `getNeighborhood` scoping — the issue's stated budget mechanism — had **zero** coverage; added a real `DocGraph` fixture proving a neighbor sharing no wording with the statement is reached and outranks a term-only hit. Added the caps test and a test walking the production call shape with no `opts`, so the store default governs egress rather than a test-only override.

## Deliberately not done

- **No `checkKind` backfill migration.** The fallthrough makes one unnecessary, and the ledger's append-only discipline means rewriting historical rows would be the wrong tool regardless.
- **Cheap-model routing for non-Claude providers.** `pickUtilityModel` returning the user's own model for openai/openrouter/ollama is pre-existing and shared with `relevanceJudge`; widening it is out of scope here. The panel now discloses it instead of misstating it.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 938 passing + 10 skipped (was 924 on `main`)
- [x] `npm run build` — clean
- [x] Adversarial (troublemaker) review completed; NO-MERGE verdict, 2 HIGH + 6 MEDIUM/LOW findings fixed with regression tests before this PR was opened

Not exercised: the entailment lane has never run against a live provider — every test injects a scripted judge. That needs an operator-supplied key, same constraint as #19.

Closes #51

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGSpfGjK64ZGRYBTmTgice)_