### PR TITLE
feat(invariants): add before/beforeId cursor pagination to GET /api/invariants

### DIFF
--- a/src/app/api/invariants/__tests__/route.test.ts
+++ b/src/app/api/invariants/__tests__/route.test.ts
@@ -28,7 +28,13 @@ vi.mock('@/lib/db', () => ({
       findMany: async (args: any) => {
         return rows
           .filter((r) => (args.where?.documentId ? r.documentId === args.where.documentId : true))
-          .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+          .sort((a, b) => {
+            const dt = b.createdAt.getTime() - a.createdAt.getTime()
+            // Matches the route's orderBy: [{createdAt:'desc'},{id:'desc'}] —
+            // a secondary sort is required for the tests below to exercise
+            // the real tie-break behavior rather than incidental array order.
+            return dt !== 0 ? dt : b.id.localeCompare(a.id)
+          })
           .slice(0, args.take)
       },
       create: async ({ data }: any) => {
@@ -218,7 +224,7 @@ describe('GET /api/invariants', () => {
     expect(rows.find((r) => r.id === original.id)?.status).toBe('active')
   })
 
-  it('pages past MAX_LIMIT via the before cursor, returning the next slice (not a repeat of page one)', async () => {
+  it('pages past MAX_LIMIT via the before/beforeId cursor, returning the next slice (not a repeat of page one)', async () => {
     const MAX_LIMIT = 200
     const total = MAX_LIMIT + 40
     for (let i = 0; i < total; i++) {
@@ -232,9 +238,13 @@ describe('GET /api/invariants', () => {
     expect(page1.invariants[0].statement).toBe(`fact ${total - 1}`)
     expect(page1.invariants[199].statement).toBe(`fact ${total - 200}`)
     expect(page1.nextCursor).toBeTruthy()
+    expect(page1.nextCursorId).toBeTruthy()
+    expect(page1.scanTruncated).toBe(false)
 
     const page2Res = await GET(
-      getRequest(`documentId=doc-1&limit=200&before=${encodeURIComponent(page1.nextCursor)}`),
+      getRequest(
+        `documentId=doc-1&limit=200&before=${encodeURIComponent(page1.nextCursor)}&beforeId=${encodeURIComponent(page1.nextCursorId)}`,
+      ),
     )
     const page2 = await page2Res.json()
     expect(page2.invariants).toHaveLength(40)
@@ -247,6 +257,21 @@ describe('GET /api/invariants', () => {
     }
     // The live set is exhausted — no further page.
     expect(page2.nextCursor).toBeNull()
+    expect(page2.nextCursorId).toBeNull()
+  })
+
+  it('a before param with no matching beforeId is treated as no cursor at all (page one again), not a crash', async () => {
+    for (let i = 0; i < 5; i++) {
+      await POST(postRequest({ documentId: 'doc-1', statement: `fact ${i}` }))
+    }
+    const page1Res = await GET(getRequest('documentId=doc-1&limit=2'))
+    const page1 = await page1Res.json()
+
+    const noBeforeIdRes = await GET(
+      getRequest(`documentId=doc-1&limit=2&before=${encodeURIComponent(page1.nextCursor)}`),
+    )
+    const noBeforeId = await noBeforeIdRes.json()
+    expect(noBeforeId.invariants).toEqual(page1.invariants)
   })
 
   it('before cursor still respects the supersede chain across the page boundary', async () => {
@@ -279,13 +304,76 @@ describe('GET /api/invariants', () => {
     expect(page1.nextCursor).toBeTruthy()
 
     const page2Res = await GET(
-      getRequest(`documentId=doc-1&limit=3&before=${encodeURIComponent(page1.nextCursor)}`),
+      getRequest(
+        `documentId=doc-1&limit=3&before=${encodeURIComponent(page1.nextCursor)}&beforeId=${encodeURIComponent(page1.nextCursorId)}`,
+      ),
     )
     const page2 = await page2Res.json()
     // 7 rows created (1 original + 5 filler + 1 resolve), minus the
     // superseded original = 6 live rows; page one took 3, page two the rest.
     expect(page2.invariants).toHaveLength(3)
     expect(page2.invariants.some((inv: { id: string }) => inv.id === original.id)).toBe(false)
+  })
+
+  it('breaks createdAt ties deterministically via id, never dropping or duplicating a row across pages', async () => {
+    // Four rows sharing the exact same createdAt millisecond — reachable in
+    // production via concurrent POSTs racing each other.
+    const tiedTime = new Date(1700000000000)
+    for (const id of ['tied-0', 'tied-1', 'tied-2', 'tied-3']) {
+      rows.push({
+        id,
+        documentId: 'doc-1',
+        statement: `statement for ${id}`,
+        blockIds: '[]',
+        checkKind: 'deterministic',
+        status: 'active',
+        provenanceCommitHash: null,
+        supersedesId: null,
+        createdAt: tiedTime,
+      })
+    }
+
+    const page1Res = await GET(getRequest('documentId=doc-1&limit=2'))
+    const page1 = await page1Res.json()
+    expect(page1.invariants).toHaveLength(2)
+    expect(page1.nextCursor).toBeTruthy()
+    expect(page1.nextCursorId).toBeTruthy()
+
+    const page2Res = await GET(
+      getRequest(
+        `documentId=doc-1&limit=2&before=${encodeURIComponent(page1.nextCursor)}&beforeId=${encodeURIComponent(page1.nextCursorId)}`,
+      ),
+    )
+    const page2 = await page2Res.json()
+    expect(page2.invariants).toHaveLength(2)
+    expect(page2.nextCursor).toBeNull()
+
+    const allIds = [...page1.invariants, ...page2.invariants].map((inv: { id: string }) => inv.id)
+    // All four tied rows show up exactly once across both pages combined.
+    expect(new Set(allIds).size).toBe(4)
+    expect([...allIds].sort()).toEqual(['tied-0', 'tied-1', 'tied-2', 'tied-3'])
+  })
+
+  it('flags scanTruncated when the document has more raw rows than SUPERSEDE_SCAN_CAP, so a null nextCursor is not mistaken for "no more data"', async () => {
+    const SUPERSEDE_SCAN_CAP = 2000
+    for (let i = 0; i < SUPERSEDE_SCAN_CAP + 5; i++) {
+      rows.push({
+        id: `bulk-${i}`,
+        documentId: 'doc-1',
+        statement: `bulk fact ${i}`,
+        blockIds: '[]',
+        checkKind: 'deterministic',
+        status: 'active',
+        provenanceCommitHash: null,
+        supersedesId: null,
+        createdAt: new Date(1700000000000 + i * 1000),
+      })
+    }
+
+    const res = await GET(getRequest('documentId=doc-1&limit=10'))
+    const data = await res.json()
+    expect(data.invariants).toHaveLength(10)
+    expect(data.scanTruncated).toBe(true)
   })
 
   it('follows a two-level supersede chain, surfacing only the newest terminal row', async () => {

--- a/src/app/api/invariants/__tests__/route.test.ts
+++ b/src/app/api/invariants/__tests__/route.test.ts
@@ -218,6 +218,76 @@ describe('GET /api/invariants', () => {
     expect(rows.find((r) => r.id === original.id)?.status).toBe('active')
   })
 
+  it('pages past MAX_LIMIT via the before cursor, returning the next slice (not a repeat of page one)', async () => {
+    const MAX_LIMIT = 200
+    const total = MAX_LIMIT + 40
+    for (let i = 0; i < total; i++) {
+      await POST(postRequest({ documentId: 'doc-1', statement: `fact ${i}` }))
+    }
+
+    const page1Res = await GET(getRequest('documentId=doc-1&limit=200'))
+    const page1 = await page1Res.json()
+    expect(page1.invariants).toHaveLength(200)
+    // Newest-first: page one holds facts total-1 .. 40.
+    expect(page1.invariants[0].statement).toBe(`fact ${total - 1}`)
+    expect(page1.invariants[199].statement).toBe(`fact ${total - 200}`)
+    expect(page1.nextCursor).toBeTruthy()
+
+    const page2Res = await GET(
+      getRequest(`documentId=doc-1&limit=200&before=${encodeURIComponent(page1.nextCursor)}`),
+    )
+    const page2 = await page2Res.json()
+    expect(page2.invariants).toHaveLength(40)
+    // Page two continues where page one left off — no overlap with page one.
+    expect(page2.invariants[0].statement).toBe(`fact ${total - 201}`)
+    expect(page2.invariants[39].statement).toBe('fact 0')
+    const page1Ids = new Set(page1.invariants.map((inv: { id: string }) => inv.id))
+    for (const inv of page2.invariants) {
+      expect(page1Ids.has(inv.id)).toBe(false)
+    }
+    // The live set is exhausted — no further page.
+    expect(page2.nextCursor).toBeNull()
+  })
+
+  it('before cursor still respects the supersede chain across the page boundary', async () => {
+    // Seed enough rows that the superseded original and its resolve row can
+    // land on different pages, then verify the original never reappears.
+    const created = await POST(
+      postRequest({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' }),
+    )
+    const original = (await created.json()).invariant
+    for (let i = 0; i < 5; i++) {
+      await POST(postRequest({ documentId: 'doc-1', statement: `filler ${i}` }))
+    }
+    // The resolve row is newest, so it lands on page one; the original it
+    // supersedes is oldest, so it would land on page two if not excluded.
+    rows.push({
+      id: `inv-${nextId++}`,
+      documentId: 'doc-1',
+      statement: original.statement,
+      blockIds: original.blockIds,
+      checkKind: original.checkKind,
+      status: 'resolved',
+      provenanceCommitHash: original.provenanceCommitHash,
+      supersedesId: original.id,
+      createdAt: new Date(1700000000000 + clock++ * 1000),
+    })
+
+    const page1Res = await GET(getRequest('documentId=doc-1&limit=3'))
+    const page1 = await page1Res.json()
+    expect(page1.invariants).toHaveLength(3)
+    expect(page1.nextCursor).toBeTruthy()
+
+    const page2Res = await GET(
+      getRequest(`documentId=doc-1&limit=3&before=${encodeURIComponent(page1.nextCursor)}`),
+    )
+    const page2 = await page2Res.json()
+    // 7 rows created (1 original + 5 filler + 1 resolve), minus the
+    // superseded original = 6 live rows; page one took 3, page two the rest.
+    expect(page2.invariants).toHaveLength(3)
+    expect(page2.invariants.some((inv: { id: string }) => inv.id === original.id)).toBe(false)
+  })
+
   it('follows a two-level supersede chain, surfacing only the newest terminal row', async () => {
     const created = await POST(postRequest({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' }))
     const original = (await created.json()).invariant

--- a/src/app/api/invariants/route.ts
+++ b/src/app/api/invariants/route.ts
@@ -31,10 +31,12 @@ const MAX_LIMIT = 200
 // beyond this cutoff (ordered newest-first) are invisible to this endpoint —
 // a disclosed limit, not silently unbounded, matching this app's public-
 // exposure hardening posture elsewhere (e.g. /api/audit's body cap). The
-// `before` cursor below (#56) lets a caller page past MAX_LIMIT, but it pages
-// over the live set computed from THIS scan window — a document whose live
-// set exceeds SUPERSEDE_SCAN_CAP still has rows beyond the cutoff that no
-// cursor value can reach. Each resolve now leaves BOTH the original and its
+// `before`/`beforeId` cursor below (#56) lets a caller page past MAX_LIMIT,
+// but it pages over the live set computed from THIS scan window — a document
+// whose live set exceeds SUPERSEDE_SCAN_CAP still has rows beyond the cutoff
+// that no cursor value can reach (surfaced to callers as `scanTruncated` on
+// the response, so a null `nextCursor` there isn't mistaken for "no more
+// data exists"). Each resolve now leaves BOTH the original and its
 // resolution row present in the DB (only the original drops out of the live
 // view), so an actively-dismissed document's live-row count grows faster
 // post-#35 than pre-#35.
@@ -48,11 +50,23 @@ const SUPERSEDE_SCAN_CAP = 2000
  * its place in the result if it is itself still live — which it always is
  * unless something later supersedes it too.
  *
- * `&before=<ISO>` (#56) pages past the first page: only live rows strictly
- * older than that timestamp are returned, mirroring /api/history's cursor.
- * The response's `nextCursor` is the createdAt of the last row on this page
- * (or null if this page reached the end of the live set) — pass it as the
- * next request's `before` to keep paging.
+ * `&before=<ISO>&beforeId=<id>` (#56) pages past the first page: only live
+ * rows strictly after the given (createdAt, id) pair — in the same
+ * createdAt-desc/id-desc order the query itself uses — are returned. Both
+ * must be given together; either alone is treated as no cursor. `createdAt`
+ * alone is not a safe cursor key: two rows created in the same millisecond
+ * (concurrent POSTs) would tie under a timestamp-only comparison, silently
+ * dropping or duplicating one of them across the page boundary. `id` breaks
+ * the tie deterministically instead — it doesn't need to be chronologically
+ * meaningful, only stable, and `orderBy` below sorts by it explicitly so
+ * every request (and thus every page) sees the same tie order.
+ *
+ * The response's `nextCursor`/`nextCursorId` are that pair for the last row
+ * on this page, or both null once the live set (within the scan window
+ * below) is exhausted. `scanTruncated: true` means this document has more
+ * raw rows than `SUPERSEDE_SCAN_CAP` — in that case a null `nextCursor` means
+ * only "no more pages within what this endpoint scanned," not "no more live
+ * invariants exist"; older ones beyond the scan window are unreachable here.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -68,15 +82,21 @@ export async function GET(request: NextRequest) {
       : DEFAULT_LIMIT
 
     const beforeParam = searchParams.get('before')
-    const before = beforeParam ? new Date(beforeParam) : null
-    const useBefore = before !== null && !Number.isNaN(before.getTime())
+    const beforeIdParam = searchParams.get('beforeId')
+    const beforeDate = beforeParam ? new Date(beforeParam) : null
+    const useBefore =
+      beforeDate !== null && !Number.isNaN(beforeDate.getTime()) && !!beforeIdParam
 
     const scanned = await prisma.docInvariant.findMany({
       where: { documentId },
-      orderBy: { createdAt: 'desc' },
+      // Secondary sort by id makes ordering deterministic across separate
+      // requests even when two rows share a createdAt millisecond — required
+      // for the cursor's tiebreak below to mean the same thing on every page.
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       take: SUPERSEDE_SCAN_CAP,
       select: INVARIANT_SELECT,
     })
+    const scanTruncated = scanned.length >= SUPERSEDE_SCAN_CAP
     const supersededIds = new Set(
       scanned.filter((r) => r.supersedesId).map((r) => r.supersedesId as string),
     )
@@ -85,11 +105,19 @@ export async function GET(request: NextRequest) {
     // is resolved above from the full scan window so a resolve row on an
     // earlier page still correctly hides the original it supersedes on a
     // later one, even though the resolve row itself isn't on that later page.
-    const page = useBefore ? live.filter((r) => r.createdAt.getTime() < before.getTime()) : live
+    const page = useBefore
+      ? live.filter((r) => {
+          const rt = r.createdAt.getTime()
+          const bt = beforeDate!.getTime()
+          return rt !== bt ? rt < bt : r.id < (beforeIdParam as string)
+        })
+      : live
     const invariants = page.slice(0, limit)
-    const nextCursor =
-      page.length > limit ? invariants[invariants.length - 1].createdAt.toISOString() : null
-    return NextResponse.json({ invariants, nextCursor })
+    const last = invariants[invariants.length - 1]
+    const hasMore = page.length > limit
+    const nextCursor = hasMore && last ? last.createdAt.toISOString() : null
+    const nextCursorId = hasMore && last ? last.id : null
+    return NextResponse.json({ invariants, nextCursor, nextCursorId, scanTruncated })
   } catch (err) {
     console.error('[/api/invariants GET] Error:', err)
     return NextResponse.json(

--- a/src/app/api/invariants/route.ts
+++ b/src/app/api/invariants/route.ts
@@ -30,15 +30,14 @@ const MAX_LIMIT = 200
 // and their resolve/supersede rows) GET scans to compute the live set. Rows
 // beyond this cutoff (ordered newest-first) are invisible to this endpoint —
 // a disclosed limit, not silently unbounded, matching this app's public-
-// exposure hardening posture elsewhere (e.g. /api/audit's body cap).
-// Disclosed interaction (#35 review): there is no offset/cursor param on
-// this route (pre-existing, not introduced here), so a document whose live
-// set exceeds MAX_LIMIT has no way to fetch a second page — each resolve now
-// leaves BOTH the original and its resolution row present in the DB (only
-// the original drops out of the live view), so an actively-dismissed
-// document's live-row count grows faster post-#35 than pre-#35. Acceptable
-// for now given expected per-document invariant volume; a real follow-up if
-// it becomes user-visible.
+// exposure hardening posture elsewhere (e.g. /api/audit's body cap). The
+// `before` cursor below (#56) lets a caller page past MAX_LIMIT, but it pages
+// over the live set computed from THIS scan window — a document whose live
+// set exceeds SUPERSEDE_SCAN_CAP still has rows beyond the cutoff that no
+// cursor value can reach. Each resolve now leaves BOTH the original and its
+// resolution row present in the DB (only the original drops out of the live
+// view), so an actively-dismissed document's live-row count grows faster
+// post-#35 than pre-#35.
 const SUPERSEDE_SCAN_CAP = 2000
 
 /**
@@ -48,6 +47,12 @@ const SUPERSEDE_SCAN_CAP = 2000
  * the row recording that resolution (status 'resolved'|'superseded') takes
  * its place in the result if it is itself still live — which it always is
  * unless something later supersedes it too.
+ *
+ * `&before=<ISO>` (#56) pages past the first page: only live rows strictly
+ * older than that timestamp are returned, mirroring /api/history's cursor.
+ * The response's `nextCursor` is the createdAt of the last row on this page
+ * (or null if this page reached the end of the live set) — pass it as the
+ * next request's `before` to keep paging.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -62,6 +67,10 @@ export async function GET(request: NextRequest) {
       ? Math.min(Math.max(Math.floor(rawLimit), 1), MAX_LIMIT)
       : DEFAULT_LIMIT
 
+    const beforeParam = searchParams.get('before')
+    const before = beforeParam ? new Date(beforeParam) : null
+    const useBefore = before !== null && !Number.isNaN(before.getTime())
+
     const scanned = await prisma.docInvariant.findMany({
       where: { documentId },
       orderBy: { createdAt: 'desc' },
@@ -71,8 +80,16 @@ export async function GET(request: NextRequest) {
     const supersededIds = new Set(
       scanned.filter((r) => r.supersedesId).map((r) => r.supersedesId as string),
     )
-    const invariants = scanned.filter((r) => !supersededIds.has(r.id)).slice(0, limit)
-    return NextResponse.json({ invariants })
+    const live = scanned.filter((r) => !supersededIds.has(r.id))
+    // The cursor filters the LIVE set (not the raw scan) — supersede status
+    // is resolved above from the full scan window so a resolve row on an
+    // earlier page still correctly hides the original it supersedes on a
+    // later one, even though the resolve row itself isn't on that later page.
+    const page = useBefore ? live.filter((r) => r.createdAt.getTime() < before.getTime()) : live
+    const invariants = page.slice(0, limit)
+    const nextCursor =
+      page.length > limit ? invariants[invariants.length - 1].createdAt.toISOString() : null
+    return NextResponse.json({ invariants, nextCursor })
   } catch (err) {
     console.error('[/api/invariants GET] Error:', err)
     return NextResponse.json(


### PR DESCRIPTION
## Summary

`GET /api/invariants` computed a document's "live" invariant set (superseded rows filtered out) by scanning up to `SUPERSEDE_SCAN_CAP` (2000) rows and slicing to `limit` (default 100, max 200) — with no way to fetch a second page. The route's own comment disclosed this gap explicitly. This PR adds cursor pagination so a document whose live set exceeds `MAX_LIMIT` can page through the rest.

- `GET /api/invariants?documentId=...&before=<ISO>&beforeId=<id>` returns the next page of live rows strictly after that (createdAt, id) pair. Both params are required together; either alone is treated as no cursor (page one).
- Response gains `nextCursor` / `nextCursorId` (both `null` once the reachable live set is exhausted) and `scanTruncated`.
- The DB query's `orderBy` gains a secondary `id: 'desc'` key, matching the cursor's tiebreak.
- New test: seeds > `MAX_LIMIT` live rows for one document and asserts a second page is reachable and returns the next slice (not a repeat of page one), per issue #56's done-means.

## Why `before` + `beforeId`, and why the cursor filters the already-deduplicated live set

Mirrors `/api/history`'s existing `before=<ISO>` cursor pattern in this repo rather than inventing a new one. The pagination cursor is applied to the **live** array (after supersede-chain resolution from the full scan window), not pushed into the DB `where` clause — filtering by `createdAt < before` before computing `supersededIds` would let an already-superseded row wrongly reappear on a later page whenever its resolve/supersede row (newer, so on an earlier page) fell outside that page's DB query window. A dedicated test (`before cursor still respects the supersede chain across the page boundary`) locks this in.

## Process note: adversarial review found two real bugs, fixed before this push

A troublemaker subagent review of the first draft (single `before=<ISO>` cursor, no secondary sort) found two silent-data-loss risks, both fixed in the second commit:

1. **No tiebreaker on `createdAt`.** Two rows created in the same millisecond (concurrent POSTs — double-submit, two tabs) tied under timestamp-only comparison; the review showed this could drop a row from every page or duplicate it across two, and that the original test suite couldn't catch it by construction (its mock assigns strictly increasing timestamps). Fixed with a `beforeId` cursor param and an explicit `id: 'desc'` secondary sort in both the real query and the test's Prisma mock, plus a dedicated tie-break regression test.
2. **`nextCursor: null` was an unconditional "done" signal**, even when `SUPERSEDE_SCAN_CAP` had truncated the scan — silently implying no more live rows exist when older ones were simply unreachable within the scan window. Fixed by adding a `scanTruncated` response field, with a regression test seeding rows past the cap.

## Scope note (deliberately left out)

No caller in this repo (`src/lib/invariants/captureInvariant.ts`'s `listInvariants`) reads `before`/`nextCursor` yet — wiring a real consumer is out of issue #56's stated done-means (route + test only) and is being filed as its own follow-up so it isn't a silent gap.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 964 passing + 10 skipped (was 959 + 10 on `main`; +5 new tests in this route's suite: page-past-limit, malformed-cursor-fallback, supersede-across-page-boundary, tiebreak, scan-truncated)
- [x] Adversarial (troublemaker) subagent review completed on the first draft; both findings fixed before this push

Closes #56

---
_Generated by [Claude Code](https://claude.ai/code/session_01TALejnSC4beXcj2dGBeWjf)_