### PR TITLE
feat(invariants): wire listInvariants() to the GET /api/invariants cursor

### DIFF
--- a/src/lib/invariants/__tests__/captureInvariant.test.ts
+++ b/src/lib/invariants/__tests__/captureInvariant.test.ts
@@ -15,6 +15,11 @@ import {
 // ---------------------------------------------------------------------------
 
 const MOCK_PAGE_SIZE = 2
+// Deliberately tiny (vs. the route's real SUPERSEDE_SCAN_CAP=2000) so a
+// scanTruncated:true response is cheap to trigger in a unit test — this file
+// only pins listInvariants()'s passthrough of that flag, not the route's own
+// scan-cap value or logic (covered in route.test.ts).
+const MOCK_SCAN_CAP = 5
 
 let store: Invariant[] = []
 let nextId = 0
@@ -75,37 +80,48 @@ function fetchStub(url: string, init?: RequestInit) {
     store.push(invariant)
     return Promise.resolve(jsonResponse({ invariant }))
   }
-  // GET — mirrors the real route's "exclude superseded rows" + before/beforeId
-  // cursor computation (see route.test.ts for the route's own coverage,
-  // including the supersede-scan-cap/tiebreak edge cases). MOCK_PAGE_SIZE is
-  // deliberately much smaller than the route's real DEFAULT_LIMIT/MAX_LIMIT —
-  // this file is only pinning listInvariants()'s cursor-passthrough contract,
-  // not the route's actual page-size values.
+  // GET — mirrors the real route's scan-then-dedupe-then-page pipeline (see
+  // route.test.ts for the route's own exhaustive coverage): a capped,
+  // (createdAt desc, id desc)-ordered scan; supersede exclusion computed from
+  // THAT scan window; a before/beforeId cursor applied to the live set; and a
+  // NaN-safe cursor validity check (an unparseable `before` is treated as no
+  // cursor, exactly like the route, rather than silently returning an empty
+  // page). MOCK_PAGE_SIZE/MOCK_SCAN_CAP are deliberately much smaller than the
+  // route's real constants — this file only pins listInvariants()'s
+  // passthrough of the route's contract, not the route's own values.
   const parsed = new URL(url, 'http://localhost')
   const documentId = parsed.searchParams.get('documentId')
-  const before = parsed.searchParams.get('before')
-  const beforeId = parsed.searchParams.get('beforeId')
-  const supersededIds = new Set(store.filter((r) => r.supersedesId).map((r) => r.supersedesId as string))
-  const live = [...store]
-    .filter((r) => r.documentId === documentId && !supersededIds.has(r.id))
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-  const windowed =
-    before && beforeId
-      ? live.filter((r) => {
-          const rt = new Date(r.createdAt).getTime()
-          const bt = new Date(before).getTime()
-          return rt !== bt ? rt < bt : r.id < beforeId
-        })
-      : live
-  const invariants = windowed.slice(0, MOCK_PAGE_SIZE)
+  const beforeParam = parsed.searchParams.get('before')
+  const beforeIdParam = parsed.searchParams.get('beforeId')
+  const beforeDate = beforeParam ? new Date(beforeParam) : null
+  const useBefore = beforeDate !== null && !Number.isNaN(beforeDate.getTime()) && !!beforeIdParam
+
+  const scanned = store
+    .filter((r) => r.documentId === documentId)
+    .sort((a, b) => {
+      const dt = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      return dt !== 0 ? dt : b.id.localeCompare(a.id)
+    })
+    .slice(0, MOCK_SCAN_CAP)
+  const scanTruncated = scanned.length >= MOCK_SCAN_CAP
+  const supersededIds = new Set(scanned.filter((r) => r.supersedesId).map((r) => r.supersedesId as string))
+  const live = scanned.filter((r) => !supersededIds.has(r.id))
+  const page = useBefore
+    ? live.filter((r) => {
+        const rt = new Date(r.createdAt).getTime()
+        const bt = beforeDate!.getTime()
+        return rt !== bt ? rt < bt : r.id < (beforeIdParam as string)
+      })
+    : live
+  const invariants = page.slice(0, MOCK_PAGE_SIZE)
   const last = invariants[invariants.length - 1]
-  const hasMore = windowed.length > MOCK_PAGE_SIZE
+  const hasMore = page.length > MOCK_PAGE_SIZE
   return Promise.resolve(
     jsonResponse({
       invariants,
       nextCursor: hasMore && last ? last.createdAt : null,
       nextCursorId: hasMore && last ? last.id : null,
-      scanTruncated: false,
+      scanTruncated,
     }),
   )
 }
@@ -253,6 +269,79 @@ describe('listInvariants', () => {
     expect(page1Ids.has(page2.invariants[0].id)).toBe(false)
     expect(page2.nextCursor).toBeNull()
     expect(page2.nextCursorId).toBeNull()
+
+    // Paging past the exhausted cursor returns an empty page, not an error.
+    const page3 = await listInvariants('doc-1', {
+      before: page2.invariants[0].createdAt,
+      beforeId: page2.invariants[0].id,
+    })
+    expect(page3.invariants).toEqual([])
+    expect(page3.nextCursor).toBeNull()
+    expect(page3.nextCursorId).toBeNull()
+  })
+
+  it('a before param with no matching beforeId is treated as no cursor at all (page one again)', async () => {
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact one.' })
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact two.' })
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact three.' })
+
+    const page1 = await listInvariants('doc-1')
+    // Cast past the type: production code always sends both fields together
+    // (ListInvariantsCursor requires both), but the route treats a lone
+    // `before` as no cursor at all — this pins that the wrapper's fetch
+    // still round-trips that fail-safe rather than assuming callers are
+    // well-behaved.
+    const noBeforeId = await listInvariants('doc-1', {
+      before: page1.nextCursor as string,
+      beforeId: '',
+    } as unknown as { before: string; beforeId: string })
+    expect(noBeforeId.invariants).toEqual(page1.invariants)
+  })
+
+  it('breaks createdAt ties deterministically via id, never dropping or duplicating a row across pages', async () => {
+    // Four rows sharing the exact same createdAt millisecond — reachable in
+    // production via concurrent POSTs racing each other (mirrors the
+    // equivalent route.test.ts tiebreak regression test).
+    const tiedTime = new Date(1700000000000).toISOString()
+    for (const id of ['tied-0', 'tied-1', 'tied-2', 'tied-3']) {
+      store.push({
+        id,
+        documentId: 'doc-1',
+        statement: `statement for ${id}`,
+        blockIds: '[]',
+        checkKind: 'deterministic',
+        status: 'active',
+        provenanceCommitHash: null,
+        supersedesId: null,
+        createdAt: tiedTime,
+      })
+    }
+
+    const page1 = await listInvariants('doc-1')
+    expect(page1.invariants).toHaveLength(2)
+    expect(page1.nextCursor).not.toBeNull()
+    expect(page1.nextCursorId).not.toBeNull()
+
+    const page2 = await listInvariants('doc-1', {
+      before: page1.nextCursor as string,
+      beforeId: page1.nextCursorId as string,
+    })
+    expect(page2.invariants).toHaveLength(2)
+    expect(page2.nextCursor).toBeNull()
+
+    const allIds = [...page1.invariants, ...page2.invariants].map((i) => i.id)
+    expect(new Set(allIds).size).toBe(4)
+    expect([...allIds].sort()).toEqual(['tied-0', 'tied-1', 'tied-2', 'tied-3'])
+  })
+
+  it('round-trips scanTruncated:true, so a null nextCursor is not mistaken for "no more data"', async () => {
+    // MOCK_SCAN_CAP is 5 — six rows for the same document overflows it.
+    for (let i = 0; i < 6; i++) {
+      await captureInvariant({ documentId: 'doc-1', statement: `fact ${i}` })
+    }
+
+    const { scanTruncated } = await listInvariants('doc-1')
+    expect(scanTruncated).toBe(true)
   })
 })
 

--- a/src/lib/invariants/__tests__/captureInvariant.test.ts
+++ b/src/lib/invariants/__tests__/captureInvariant.test.ts
@@ -14,6 +14,8 @@ import {
 // wrapper without re-testing the route itself (covered in route.test.ts).
 // ---------------------------------------------------------------------------
 
+const MOCK_PAGE_SIZE = 2
+
 let store: Invariant[] = []
 let nextId = 0
 let failNextPost = false
@@ -73,13 +75,39 @@ function fetchStub(url: string, init?: RequestInit) {
     store.push(invariant)
     return Promise.resolve(jsonResponse({ invariant }))
   }
-  // GET — mirrors the real route's "exclude superseded rows" computation.
-  const documentId = new URL(url, 'http://localhost').searchParams.get('documentId')
+  // GET — mirrors the real route's "exclude superseded rows" + before/beforeId
+  // cursor computation (see route.test.ts for the route's own coverage,
+  // including the supersede-scan-cap/tiebreak edge cases). MOCK_PAGE_SIZE is
+  // deliberately much smaller than the route's real DEFAULT_LIMIT/MAX_LIMIT —
+  // this file is only pinning listInvariants()'s cursor-passthrough contract,
+  // not the route's actual page-size values.
+  const parsed = new URL(url, 'http://localhost')
+  const documentId = parsed.searchParams.get('documentId')
+  const before = parsed.searchParams.get('before')
+  const beforeId = parsed.searchParams.get('beforeId')
   const supersededIds = new Set(store.filter((r) => r.supersedesId).map((r) => r.supersedesId as string))
-  const invariants = [...store]
+  const live = [...store]
     .filter((r) => r.documentId === documentId && !supersededIds.has(r.id))
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-  return Promise.resolve(jsonResponse({ invariants }))
+  const windowed =
+    before && beforeId
+      ? live.filter((r) => {
+          const rt = new Date(r.createdAt).getTime()
+          const bt = new Date(before).getTime()
+          return rt !== bt ? rt < bt : r.id < beforeId
+        })
+      : live
+  const invariants = windowed.slice(0, MOCK_PAGE_SIZE)
+  const last = invariants[invariants.length - 1]
+  const hasMore = windowed.length > MOCK_PAGE_SIZE
+  return Promise.resolve(
+    jsonResponse({
+      invariants,
+      nextCursor: hasMore && last ? last.createdAt : null,
+      nextCursorId: hasMore && last ? last.id : null,
+      scanTruncated: false,
+    }),
+  )
 }
 
 beforeEach(() => {
@@ -182,21 +210,49 @@ describe('listInvariants', () => {
       blockIds: ['blk-hr'],
     })
 
-    const invariants = await listInvariants('doc-1')
+    const { invariants, nextCursor, nextCursorId, scanTruncated } = await listInvariants('doc-1')
     expect(invariants).toHaveLength(2)
     expect(invariants[0].statement).toBe('Termination notices go through HR.')
     expect(invariants[1].statement).toBe('Terminations are now 30 days.')
     expect(JSON.parse(invariants[1].blockIds)).toEqual(['blk-terminations'])
+    expect(nextCursor).toBeNull()
+    expect(nextCursorId).toBeNull()
+    expect(scanTruncated).toBe(false)
   })
 
   it('excludes a resolved invariant\'s original row, keeping the resolution row live (#35)', async () => {
     const original = await captureInvariant({ documentId: 'doc-1', statement: 'Terminations are now 30 days.' })
     await resolveInvariant({ documentId: 'doc-1', invariantId: original.id, status: 'resolved' })
 
-    const invariants = await listInvariants('doc-1')
+    const { invariants } = await listInvariants('doc-1')
     expect(invariants).toHaveLength(1)
     expect(invariants[0].status).toBe('resolved')
     expect(invariants[0].supersedesId).toBe(original.id)
+  })
+
+  it('fetches a second page via the returned cursor — the wrapper matches what the route (PR #57) can already do (#58)', async () => {
+    // MOCK_PAGE_SIZE is 2, so 3 declared facts force a second page.
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact one.' })
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact two.' })
+    await captureInvariant({ documentId: 'doc-1', statement: 'Fact three.' })
+
+    const page1 = await listInvariants('doc-1')
+    expect(page1.invariants).toHaveLength(2)
+    expect(page1.invariants.map((i) => i.statement)).toEqual(['Fact three.', 'Fact two.'])
+    expect(page1.nextCursor).not.toBeNull()
+    expect(page1.nextCursorId).not.toBeNull()
+
+    const page2 = await listInvariants('doc-1', {
+      before: page1.nextCursor as string,
+      beforeId: page1.nextCursorId as string,
+    })
+    expect(page2.invariants).toHaveLength(1)
+    expect(page2.invariants[0].statement).toBe('Fact one.')
+    // Second page is the remaining slice, not a repeat of page one.
+    const page1Ids = new Set(page1.invariants.map((i) => i.id))
+    expect(page1Ids.has(page2.invariants[0].id)).toBe(false)
+    expect(page2.nextCursor).toBeNull()
+    expect(page2.nextCursorId).toBeNull()
   })
 })
 

--- a/src/lib/invariants/captureInvariant.ts
+++ b/src/lib/invariants/captureInvariant.ts
@@ -83,12 +83,50 @@ export function shouldCaptureInvariant(acceptedIds: string[], primaryId: string)
   return acceptedIds.includes(primaryId)
 }
 
-/** All invariants declared for a document, newest first. */
-export async function listInvariants(documentId: string): Promise<Invariant[]> {
-  const res = await fetch(`/api/invariants?documentId=${encodeURIComponent(documentId)}`)
+export interface ListInvariantsCursor {
+  before: string
+  beforeId: string
+}
+
+export interface ListInvariantsPage {
+  invariants: Invariant[]
+  /** Cursor for the next page, or null once the reachable live set is exhausted. */
+  nextCursor: string | null
+  nextCursorId: string | null
+  /**
+   * True when the route's own scan window (`SUPERSEDE_SCAN_CAP`) cut off
+   * before reaching the end of this document's raw rows — see the doc-comment
+   * on `GET /api/invariants`. A null `nextCursor` alongside `scanTruncated:
+   * true` means "no more pages within what the route scanned," not "no more
+   * live invariants exist."
+   */
+  scanTruncated: boolean
+}
+
+/**
+ * One page of a document's live invariants, newest first. Pass the previous
+ * page's `{ nextCursor, nextCursorId }` (renamed here to `before`/`beforeId`
+ * to match the route's own query param names) to fetch the next page; omit
+ * `cursor` for the first page.
+ */
+export async function listInvariants(
+  documentId: string,
+  cursor?: ListInvariantsCursor,
+): Promise<ListInvariantsPage> {
+  const params = new URLSearchParams({ documentId })
+  if (cursor) {
+    params.set('before', cursor.before)
+    params.set('beforeId', cursor.beforeId)
+  }
+  const res = await fetch(`/api/invariants?${params.toString()}`)
   if (!res.ok) throw new Error(`Failed to load invariants (HTTP ${res.status})`)
   const data = await res.json()
-  return data.invariants ?? []
+  return {
+    invariants: data.invariants ?? [],
+    nextCursor: data.nextCursor ?? null,
+    nextCursorId: data.nextCursorId ?? null,
+    scanTruncated: data.scanTruncated ?? false,
+  }
 }
 
 export interface ResolveInvariantParams {

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -210,7 +210,7 @@ export async function runAndSurfaceInvariantChecks(
   try {
     if (useDocumentStore.getState().activeDocumentId !== documentId) return
 
-    const invariants = await listInvariants(documentId)
+    const { invariants } = await listInvariants(documentId)
     if (useDocumentStore.getState().activeDocumentId !== documentId) return
 
     const violations: InvariantViolation[] = checkInvariants(state.doc, invariants)


### PR DESCRIPTION
## Summary

Stacked on #57 (still open, green, awaiting operator merge — this PR builds on its `before`/`beforeId` cursor route rather than duplicating it). `listInvariants(documentId)` previously made a single unparameterized fetch and returned a bare `Invariant[]`, so it could never reach anything past page one of a document's live invariant set — even though the route itself (#57) already supports paging past it.

- `listInvariants(documentId, cursor?)` now accepts an optional `{ before, beforeId }` cursor and returns `{ invariants, nextCursor, nextCursorId, scanTruncated }` instead of a bare array, matching what the route already exposes.
- The one production caller, `runAndSurfaceInvariantChecks` (`invariantCascade.ts`), is updated to destructure `{ invariants }` from the new shape — no behavior change there (see the scope note below).
- New tests in `captureInvariant.test.ts` exercise fetching a second page via the returned cursor.

Closes #58

## Process note: adversarial review found real test-quality gaps, fixed before this push

A troublemaker subagent review of the first commit found:

1. **Mock GET handler was more lenient than the real route** — it used a single `createdAt`-only sort with no scan cap and no NaN-guard on an unparseable `before`, unlike the real route's `(createdAt desc, id desc)` order, `SUPERSEDE_SCAN_CAP` truncation, and fail-safe cursor validation. Fixed by mirroring the route's actual pipeline (with much smaller constants, since this file only pins the wrapper's passthrough contract — the route's own values are covered in `route.test.ts`).
2. **The new pagination test never exercised the id tiebreak or `scanTruncated` it was nominally testing.** Added: a same-millisecond tiebreak test (four rows, `createdAt` intentionally identical), a `scanTruncated:true` round-trip test, an empty-page-past-the-end assertion, and a test that a `before` param with no matching `beforeId` is treated as no cursor at all — matching the route's own documented fail-safe.

Second (real, but explicitly out-of-scope per #58's own done-means) finding, filed as follow-up **#59**: `runAndSurfaceInvariantChecks` still only ever reads page one — the check runner's 100-invariant ceiling (`DEFAULT_LIMIT` in the route) is unchanged by this PR. #58's done-means explicitly separated "the client wrapper matches the route" from "wiring a real multi-page consumer," so this PR doesn't attempt it; #59 tracks it honestly rather than leaving it a silent gap.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 968 passing + 10 skipped (was 964 + 10 on the #57 branch; +4 new tests: second-page fetch, tiebreak, scanTruncated round-trip, no-beforeId-fallback)
- [x] Adversarial (troublemaker) subagent review completed; all findings addressed (test-quality gaps fixed in this PR; the one out-of-scope caller-wiring gap filed as #59)

Closes #58


---
_Generated by [Claude Code](https://claude.ai/code/session_0114f5xu9TLhHrMmr62xgcj6)_