### PR TITLE
fix(invariants): page runAndSurfaceInvariantChecks past listInvariants' first page

### DIFF
--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -220,6 +220,87 @@ describe('runAndSurfaceInvariantChecks', () => {
     expect(next.doc.textBetween(cascade.from, cascade.to)).toBe(cascade.targetText)
   })
 
+  it('pages past listInvariants()\'s first page to catch a violation living on an older page (#59)', async () => {
+    // Simulates a document with > 100 live invariants: the fixture's real
+    // conflicting invariant sits on the SECOND page, past the route's
+    // DEFAULT_LIMIT of 100 — proving the runner doesn't stop at page one.
+    const page1 = Array.from({ length: 100 }, (_, i) =>
+      invariantRecord({
+        id: `inv-filler-${i}`,
+        // No numeric token in the statement, so `checkInvariants` skips these
+        // before ever touching the document — they exist only to fill page 1.
+        statement: `some unrelated policy note number ${i}`,
+        blockIds: JSON.stringify([]),
+      }),
+    )
+    const page2 = [invariantRecord()] // the real DECLARE_TEXT/CONFLICT_TEXT fixture
+
+    const calls: string[] = []
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        calls.push(url)
+        const isFirstPage = !url.includes('before=')
+        return {
+          ok: true,
+          status: 200,
+          json: async () =>
+            isFirstPage
+              ? {
+                  invariants: page1,
+                  nextCursor: '2026-08-17T00:00:00.000Z',
+                  nextCursorId: 'inv-filler-99',
+                  scanTruncated: false,
+                }
+              : { invariants: page2, nextCursor: null, nextCursorId: null, scanTruncated: false },
+        } as Response
+      }),
+    )
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1]).toContain('before=')
+    expect(calls[1]).toContain('beforeId=inv-filler-99')
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+  })
+
+  it('aborts the page walk (and flags nothing) when the active document changes between pages', async () => {
+    const page1 = [invariantRecord({ id: 'inv-filler-0', statement: 'no figures here', blockIds: '[]' })]
+    let call = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        call++
+        if (call === 1) {
+          useDocumentStore.setState({ activeDocumentId: 'doc-B' })
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              invariants: page1,
+              nextCursor: '2026-08-17T00:00:00.000Z',
+              nextCursorId: 'inv-filler-0',
+              scanTruncated: false,
+            }),
+          } as Response
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ invariants: [invariantRecord()], nextCursor: null, nextCursorId: null, scanTruncated: false }),
+        } as Response
+      }),
+    )
+    const state = EditorState.create({ schema, doc: DOC })
+
+    await runAndSurfaceInvariantChecks('doc-A', state)
+
+    expect(call).toBe(1) // the second page is never fetched once the doc has switched
+    expect(useAnnotationStore.getState().annotations).toHaveLength(0)
+  })
+
   it('produces no flag for an invariant already resolved (#35: dismissing a flag stops it being checked)', async () => {
     // Simulates what GET /api/invariants returns once a "Nevermind" resolve
     // has landed: the live row for this fact now has status 'resolved', not

--- a/src/lib/invariants/__tests__/invariantCascade.test.ts
+++ b/src/lib/invariants/__tests__/invariantCascade.test.ts
@@ -227,9 +227,17 @@ describe('runAndSurfaceInvariantChecks', () => {
     const page1 = Array.from({ length: 100 }, (_, i) =>
       invariantRecord({
         id: `inv-filler-${i}`,
-        // No numeric token in the statement, so `checkInvariants` skips these
-        // before ever touching the document — they exist only to fill page 1.
-        statement: `some unrelated policy note number ${i}`,
+        // Digit-free by construction (the distinguishing index lives only in
+        // `id`, never in the statement text) — `extractChangedTokens` finds
+        // no numeric token, so `checkInvariants` skips these before ever
+        // touching the document. They exist only to fill page 1; a statement
+        // with an embedded 2+-digit index (e.g. "note number 42") would still
+        // usually be safe here too, but only because "unrelated"/"policy"/
+        // "note" happen to win `checkInvariants`' specificity-based required-
+        // term selection and never appear in either fixture block — a
+        // coincidence of that heuristic, not a guarantee. Keeping the index
+        // out of the statement removes that coincidence entirely.
+        statement: 'some unrelated policy note with no figures at all',
         blockIds: JSON.stringify([]),
       }),
     )

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -7,7 +7,7 @@ import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
 import { useInvariantFlagStore } from '@/stores/invariantFlagStore'
 import { generateId } from '@/lib/utils/id'
-import { listInvariants, resolveInvariant } from './captureInvariant'
+import { listInvariants, resolveInvariant, type Invariant, type ListInvariantsCursor } from './captureInvariant'
 import { checkInvariants, type InvariantViolation } from './invariantCheckRunner'
 import { checkEntailmentInvariants, type EntailmentCheckDeps } from './entailmentCheck'
 import { useSettingsStore } from '@/stores/settingsStore'
@@ -172,6 +172,57 @@ function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): 
   return null
 }
 
+// Defensive bound on how many pages `listAllInvariants` will walk. Not a
+// real limit in practice: `GET /api/invariants` computes the live set from a
+// scan of at most SUPERSEDE_SCAN_CAP (2000) rows regardless of cursor, so at
+// the route's own DEFAULT_LIMIT (100) a genuinely-exhaustive walk of that
+// scan window never exceeds 20 pages — this only guards against an
+// unforeseen cursor bug looping forever.
+const MAX_INVARIANT_PAGES = 25
+
+/**
+ * Walks every page of a document's live invariants (#59 — the check runner
+ * previously read only `GET /api/invariants`'s first page, silently
+ * excluding older declared facts once a document passed the route's
+ * DEFAULT_LIMIT of 100). Returns `null` if the active document changed
+ * during the walk, so the caller can abort exactly as it already does for
+ * the single-page case, rather than tagging a flag with the wrong
+ * document's id.
+ *
+ * A `scanTruncated` page means the route's own scan window was cut off
+ * before reaching the end of this document's raw rows — this is a
+ * pre-existing, disclosed limit of the route itself (see its doc-comment),
+ * not something a caller can page around, so it is only logged here, not
+ * treated as an error.
+ */
+async function listAllInvariants(documentId: string): Promise<Invariant[] | null> {
+  const invariants: Invariant[] = []
+  let cursor: ListInvariantsCursor | undefined
+  let scanTruncated = false
+
+  for (let page = 0; page < MAX_INVARIANT_PAGES; page++) {
+    const result = await listInvariants(documentId, cursor)
+    if (useDocumentStore.getState().activeDocumentId !== documentId) return null
+
+    invariants.push(...result.invariants)
+    scanTruncated = scanTruncated || result.scanTruncated
+    if (!result.nextCursor || !result.nextCursorId) {
+      if (scanTruncated) {
+        console.warn(
+          `[invariants] Check runner's page walk for document ${documentId} stopped within a truncated scan window — older invariants may be unreachable this run.`,
+        )
+      }
+      return invariants
+    }
+    cursor = { before: result.nextCursor, beforeId: result.nextCursorId }
+  }
+
+  console.warn(
+    `[invariants] Check runner hit its ${MAX_INVARIANT_PAGES}-page safety bound for document ${documentId} — stopping early.`,
+  )
+  return invariants
+}
+
 /**
  * Runs the deterministic doc-CI lane for a document against its current
  * editor state and appends one resolved 'flag' annotation per violated
@@ -180,10 +231,10 @@ function primaryAnchor(doc: EditorState['doc'], violation: InvariantViolation): 
  *
  * Two guards keep this from becoming an unbounded nuisance:
  * - Doc-switch race: `state` is read from a caller-captured EditorView after
- *   an async round-trip (`listInvariants`); if the active document changed
- *   in the meantime, `state` and `documentId` would disagree — abort rather
- *   than tag a flag with the wrong document's id (same guard as the sibling
- *   `directEditCascade.ts`).
+ *   an async round-trip (now potentially several, via `listAllInvariants`);
+ *   if the active document changed in the meantime, `state` and
+ *   `documentId` would disagree — abort rather than tag a flag with the
+ *   wrong document's id (same guard as the sibling `directEditCascade.ts`).
  * - Re-flag dedup: the check re-runs on every apply, so without a dedup an
  *   unresolved conflict would re-surface as a brand-new annotation on every
  *   future apply anywhere in the document, forever. Dedup state lives in its
@@ -210,8 +261,8 @@ export async function runAndSurfaceInvariantChecks(
   try {
     if (useDocumentStore.getState().activeDocumentId !== documentId) return
 
-    const { invariants } = await listInvariants(documentId)
-    if (useDocumentStore.getState().activeDocumentId !== documentId) return
+    const invariants = await listAllInvariants(documentId)
+    if (invariants === null) return // active document changed mid-page-walk
 
     const violations: InvariantViolation[] = checkInvariants(state.doc, invariants)
 

--- a/src/lib/invariants/invariantCascade.ts
+++ b/src/lib/invariants/invariantCascade.ts
@@ -194,6 +194,14 @@ const MAX_INVARIANT_PAGES = 25
  * pre-existing, disclosed limit of the route itself (see its doc-comment),
  * not something a caller can page around, so it is only logged here, not
  * treated as an error.
+ *
+ * Disclosed carry-forward limitation: each page is its own GET, computing
+ * the live (supersede-resolved) set fresh from the DB at that moment. If a
+ * "Nevermind" resolve for a row already returned on an earlier page lands
+ * mid-walk, that row's now-stale `active` copy stays in the accumulated
+ * result — a real but narrow widening of a race that already existed
+ * (single-request) pre-#59; multiple sequential requests widen the window
+ * rather than introduce it.
  */
 async function listAllInvariants(documentId: string): Promise<Invariant[] | null> {
   const invariants: Invariant[] = []
@@ -218,7 +226,8 @@ async function listAllInvariants(documentId: string): Promise<Invariant[] | null
   }
 
   console.warn(
-    `[invariants] Check runner hit its ${MAX_INVARIANT_PAGES}-page safety bound for document ${documentId} — stopping early.`,
+    `[invariants] Check runner hit its ${MAX_INVARIANT_PAGES}-page safety bound for document ${documentId} — stopping early.` +
+      (scanTruncated ? ' The route’s own scan window was also truncated within those pages.' : ''),
   )
   return invariants
 }


### PR DESCRIPTION
## Summary

Stacked on #60 (still open, green, awaiting operator merge — this PR consumes the cursor-returning `listInvariants()` shape it wires up rather than duplicating it).

`runAndSurfaceInvariantChecks` (`invariantCascade.ts`) called `listInvariants(documentId)` exactly once and read only `{ invariants }` — the first page (server default 100 rows). Since `GET /api/invariants` defaults to `DEFAULT_LIMIT = 100`, any document with more than 100 live invariants had its deterministic/entailment doc-CI check runner silently evaluate new edits against only the newest 100 declared facts — older declared facts stopped being regression-tested with no error or indication to the user.

- New `listAllInvariants(documentId)` helper walks every page via the `{before, beforeId}` cursor until `nextCursor`/`nextCursorId` come back null, accumulating all live invariants before `checkInvariants` runs.
- Re-checks the existing "active document changed" guard after **every** page fetch (not just once) — aborts (returns `null`) exactly as the single-page case already did, rather than risking tagging a flag with the wrong document's id.
- Defensive `MAX_INVARIANT_PAGES = 25` bound against an unforeseen cursor bug looping forever — not a real limit in practice, since the route's own `SUPERSEDE_SCAN_CAP` (2000 rows) already bounds a genuinely-exhaustive walk to ~20 pages at the route's `DEFAULT_LIMIT` (100).
- `scanTruncated` (the route's own pre-existing, disclosed scan-window limit) and the page-bound case are both `console.warn`-disclosed, matching this codebase's existing convention for this kind of limit (e.g. `SUPERSEDE_SCAN_CAP`'s own disclosure).
- New regression test seeding 100 filler invariants (page 1) + the real conflicting fixture (page 2), asserting the runner still fetches page 2 and still surfaces the violation. New test asserting the page walk aborts cleanly if the active document changes between pages.

## Process note: adversarial review found real gaps, fixed before this push

A troublemaker subagent review of the first commit found:

1. **Test-comment inaccuracy:** the filler invariants' "why this can't false-positive" comment claimed they had no numeric token, but statements like `"note number 42"` do carry one — they only failed to match `checkInvariants` by a coincidence of its term-specificity heuristic ("unrelated" winning the required-term slice), not for the stated reason. Fixed by making the fillers genuinely digit-free (index lives only in `id`, never in the statement text), so the safety property is now true by construction, not by heuristic luck. Verified concretely: reverted just the source fix and confirmed the new pagination test fails (`expected [...] to have a length of 2 but got 1`) before restoring it.
2. **Dropped disclosure:** if both the page-bound AND `scanTruncated` triggered in the same run, only the page-bound warning fired — the `scanTruncated` fact was silently absorbed. Fixed to include both in that case.
3. **Widened race, now disclosed:** each page is its own GET recomputing the live set fresh — if a "Nevermind" resolve for an already-fetched row lands mid-walk, its stale `active` copy can survive in the accumulated result. This race already existed pre-fix (single request); multiple sequential requests widen the window rather than introduce it. Documented in the function's doc-comment rather than silently left implicit.

**Deliberately NOT fixed here (filed as follow-up #62):** the review's strongest finding — a document that has accumulated conflicts against page-2+ invariants for months can now surface all of them at once, as a synchronous burst of toasts + annotations with no batching, which collides with CLAUDE.md's Flow State / Event Segmentation requirement that AI notifications be buffered to natural reading breakpoints. That gap pre-dates this PR (it already existed for ≤100 invariants, just capped lower) and fixing it is a real feature (batching/throttling the doc-CI surfacing loop), not a pagination bug — out of #59's own done-means, so it's tracked honestly rather than silently left in this diff.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 970 passing + 10 skipped (was 968 + 10 on the #60 branch; +2 new tests)
- [x] Adversarial (troublemaker) subagent review completed; all findings addressed or filed as an honest follow-up (#62)
- [x] Confirmed the new pagination test actually exercises the fix — reverted the source to pre-fix and watched it fail, then restored it

Closes #59

---
_Generated by [Claude Code](https://claude.ai/code/session_013Pi5KB5fq2QgsZNKnu7xQW)_