### PR TITLE
fix(stores): bound annotationStore's persisted array size

### DIFF
--- a/src/stores/__tests__/annotationStore.persistence.test.ts
+++ b/src/stores/__tests__/annotationStore.persistence.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Annotation } from '@/lib/annotations/types'
+
+class MemoryStorage {
+  protected store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  clear() {
+    this.store.clear()
+  }
+}
+
+/** Every setItem call throws QuotaExceededError — simulates a truly exhausted quota. */
+class AlwaysQuotaStorage extends MemoryStorage {
+  setItem(): void {
+    const err = new Error('QuotaExceededError')
+    err.name = 'QuotaExceededError'
+    throw err
+  }
+}
+
+/**
+ * The first setItem call for `failingKey` throws QuotaExceededError;
+ * subsequent calls (and calls for any other key — e.g. a sibling store's own
+ * localStorage writes triggered as an import side effect) succeed normally.
+ */
+class FailOnceStorage extends MemoryStorage {
+  private failed = false
+
+  constructor(private readonly failingKey: string) {
+    super()
+  }
+
+  setItem(key: string, value: string) {
+    if (key === this.failingKey && !this.failed) {
+      this.failed = true
+      const err = new Error('QuotaExceededError')
+      err.name = 'QuotaExceededError'
+      throw err
+    }
+    super.setItem(key, value)
+  }
+}
+
+function makeAnnotation(id: string): Annotation {
+  return {
+    id,
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:0:10',
+    type: 'flag',
+    status: 'resolved',
+    transcript: `annotation ${id}`,
+    anchor: { from: 0, to: 10, scope: 'phrase', text: 'x' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: Date.now(),
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+async function loadStore() {
+  vi.resetModules()
+  return import('@/stores/annotationStore')
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('annotationStore persistence bounds (#64)', () => {
+  it('caps the persisted annotations array even as the in-memory array keeps growing past the cap', async () => {
+    const storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+    const { useAnnotationStore } = await loadStore()
+
+    const TOTAL = 520
+    for (let i = 0; i < TOTAL; i++) {
+      useAnnotationStore.getState().add(makeAnnotation(`ann-${i}`))
+    }
+
+    // In-memory state is not trimmed — only what gets written to localStorage is.
+    expect(useAnnotationStore.getState().annotations).toHaveLength(TOTAL)
+
+    const raw = storage.getItem('intent-ide-annotations')
+    expect(raw).not.toBeNull()
+    const persisted = JSON.parse(raw as string)
+    const persistedAnnotations = persisted.state.annotations as Annotation[]
+
+    expect(persistedAnnotations.length).toBe(500)
+    // Oldest entries are evicted first; newest are kept.
+    expect(persistedAnnotations[0].id).toBe(`ann-${TOTAL - 500}`)
+    expect(persistedAnnotations[persistedAnnotations.length - 1].id).toBe(`ann-${TOTAL - 1}`)
+  })
+
+  it('does not crash the store when localStorage.setItem always throws QuotaExceededError', async () => {
+    vi.stubGlobal('localStorage', new AlwaysQuotaStorage())
+    const { useAnnotationStore } = await loadStore()
+
+    expect(() => useAnnotationStore.getState().add(makeAnnotation('ann-1'))).not.toThrow()
+    // In-memory state still reflects the update even though persistence silently failed.
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+  })
+
+  it('emergency-prunes to the newest EMERGENCY_ANNOTATIONS entries and retries once when the first write hits QuotaExceededError', async () => {
+    const storage = new FailOnceStorage('intent-ide-annotations')
+    vi.stubGlobal('localStorage', storage)
+    const { useAnnotationStore } = await loadStore()
+
+    // A single write carrying well over the emergency cap (100), so a
+    // regression that drops the `.slice(-EMERGENCY_ANNOTATIONS)` prune would
+    // leave the full, unpruned array on the (successful) retry instead —
+    // this assertion catches that, unlike asserting length <= 100 against a
+    // seed of 1 (which passes trivially either way).
+    const SEED = 150
+    const seeded = Array.from({ length: SEED }, (_, i) => makeAnnotation(`ann-${i}`))
+    expect(() => useAnnotationStore.setState({ annotations: seeded })).not.toThrow()
+
+    const raw = storage.getItem('intent-ide-annotations')
+    expect(raw).not.toBeNull()
+    const persisted = JSON.parse(raw as string)
+    const persistedAnnotations = persisted.state.annotations as Annotation[]
+
+    expect(persistedAnnotations).toHaveLength(100)
+    // Newest 100 of the 150 are kept — the oldest 50 are dropped by the prune.
+    expect(persistedAnnotations[0].id).toBe(`ann-${SEED - 100}`)
+    expect(persistedAnnotations[persistedAnnotations.length - 1].id).toBe(`ann-${SEED - 1}`)
+  })
+
+  it('clears activeAnnotationId on rehydrate if the cap evicted the annotation it pointed at', async () => {
+    const storage = new MemoryStorage()
+    // Simulate an already-persisted store from a prior session where
+    // activeAnnotationId survived pointing at an annotation that a later
+    // write's cap evicted.
+    storage.setItem(
+      'intent-ide-annotations',
+      JSON.stringify({
+        state: {
+          annotations: [makeAnnotation('ann-kept')],
+          activeAnnotationId: 'ann-evicted',
+        },
+        version: 0,
+      })
+    )
+    vi.stubGlobal('localStorage', storage)
+    const { useAnnotationStore } = await loadStore()
+
+    expect(useAnnotationStore.getState().activeAnnotationId).toBeNull()
+    expect(useAnnotationStore.getState().annotations.map((a) => a.id)).toEqual(['ann-kept'])
+  })
+
+  it('preserves activeAnnotationId on rehydrate when it still points at a live annotation', async () => {
+    const storage = new MemoryStorage()
+    storage.setItem(
+      'intent-ide-annotations',
+      JSON.stringify({
+        state: {
+          annotations: [makeAnnotation('ann-kept')],
+          activeAnnotationId: 'ann-kept',
+        },
+        version: 0,
+      })
+    )
+    vi.stubGlobal('localStorage', storage)
+    const { useAnnotationStore } = await loadStore()
+
+    expect(useAnnotationStore.getState().activeAnnotationId).toBe('ann-kept')
+  })
+})

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -53,6 +53,14 @@ export function finalizeInterruptedAnnotations(annotations: Annotation[]): Annot
   })
 }
 
+// Sibling stores (invariantFlagStore's MAX_SURFACED, changesStore's
+// MAX_PERSISTED_ENTRIES) already cap their persisted arrays; this store had
+// neither a cap nor quota-error handling, so a long-lived session's
+// unbounded `annotations` array could eventually blow the localStorage
+// quota (see #64). 500 matches changesStore's reference cap.
+const MAX_PERSISTED_ANNOTATIONS = 500
+const EMERGENCY_ANNOTATIONS = 100
+
 interface AnnotationState {
   annotations: Annotation[]
   activeAnnotationId: string | null
@@ -110,11 +118,51 @@ export const useAnnotationStore = create<AnnotationState>()(
     }),
     {
       name: 'intent-ide-annotations',
+      partialize: (state) => ({
+        annotations: state.annotations.slice(-MAX_PERSISTED_ANNOTATIONS),
+        activeAnnotationId: state.activeAnnotationId,
+      }),
+      storage: {
+        getItem: (name: string) => {
+          try {
+            const raw = localStorage.getItem(name)
+            return raw ? JSON.parse(raw) : null
+          } catch {
+            return null
+          }
+        },
+        setItem: (name: string, value: unknown) => {
+          try {
+            localStorage.setItem(name, JSON.stringify(value))
+          } catch {
+            // Quota exceeded — emergency prune and retry.
+            // Zustand persist v4 wraps in { state: {...}, version: N }.
+            try {
+              const parsed = JSON.parse(JSON.stringify(value)) as Record<string, unknown>
+              const inner = (parsed.state ?? parsed) as Record<string, unknown>
+              inner.annotations = ((inner.annotations as unknown[]) ?? []).slice(-EMERGENCY_ANNOTATIONS)
+              localStorage.setItem(name, JSON.stringify(parsed))
+            } catch {
+              // Silently fail — in-memory state is still valid.
+            }
+          }
+        },
+        removeItem: (name: string) => localStorage.removeItem(name),
+      },
       onRehydrateStorage: () => (state) => {
         if (state) {
           state.annotations = finalizeInterruptedAnnotations(
             migrateAnnotations(state.annotations)
           )
+          // The persisted cap above can evict the annotation activeAnnotationId
+          // pointed at (only possible once >MAX_PERSISTED_ANNOTATIONS accumulate,
+          // which the uncapped store could never hit before now).
+          if (
+            state.activeAnnotationId &&
+            !state.annotations.some((a) => a.id === state.activeAnnotationId)
+          ) {
+            state.activeAnnotationId = null
+          }
         }
       },
     }


### PR DESCRIPTION
## What

`useAnnotationStore` (`src/stores/annotationStore.ts`) was a plain `persist()` zustand store with no size cap on its `annotations` array — every `add()` call grew it unboundedly in `localStorage`, for the lifetime of the app, with no fallback if `localStorage.setItem` threw `QuotaExceededError`. Its siblings are already hardened for exactly this: `invariantFlagStore.ts` caps at `MAX_SURFACED = 1000` via `.slice(-MAX_SURFACED)` on every write; `changesStore.ts` caps via `partialize` (entries at 500, changeSets at 100) plus a custom `storage` wrapper that catches a quota error and retries with an emergency-pruned payload.

- New `MAX_PERSISTED_ANNOTATIONS = 500` (matching `changesStore`'s reference cap) applied via `partialize` — bounds what gets written to `localStorage` on every persist. The in-memory `annotations` array is deliberately left unbounded during the live session (same tradeoff `changesStore.ts` already makes); only the persisted copy is capped.
- New custom `storage` wrapper (mirrors `changesStore.ts`'s pattern) whose `setItem` catches a thrown quota error, re-parses the payload, prunes `annotations` to the newest `EMERGENCY_ANNOTATIONS = 100`, and retries once. A second failure is silently swallowed — in-memory state stays valid either way.
- `onRehydrateStorage` now also clears `activeAnnotationId` if the persisted cap evicted the annotation it pointed at. This is a new (if minor) failure mode the cap introduces — nothing was ever evicted before, so this could never happen pre-fix.

## Process note: adversarial review found a real test-quality gap, fixed before this push

A troublemaker subagent review of the first commit found the emergency-prune regression test was vacuous: it seeded exactly **one** annotation and asserted `length <= 100`, which passes trivially regardless of whether the prune logic does anything at all. Proven by mutation testing (the review's own repro, which I re-ran myself): deleting the `.slice(-EMERGENCY_ANNOTATIONS)` line left all 3 tests green.

Fixed by seeding 150 annotations in a single write that exceeds the emergency cap, and asserting both the exact resulting length (100) and that the *newest* 100 survived (not the oldest). Re-verified concretely: reverted just the source fix and confirmed the new test fails (`expected length of 100 but got 150`) before restoring it.

The review also flagged the new `activeAnnotationId` dangling-reference risk (see above) — fixed with a rehydrate guard + two regression tests (evicted-reference cleared, live-reference preserved), rather than left as a known gap.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 964 passing + 10 skipped (was 959 + 10 baseline; +5 new)
- [x] Adversarial (troublemaker) subagent review completed; the one real finding (vacuous prune test) fixed and independently re-verified by mutation testing; the LOW `activeAnnotationId` finding also fixed rather than left open

Closes #64

---
_Generated by [Claude Code](https://claude.ai/code/session_01V38UFVX9j6ChAmB2Ygzt2m)_