### PR TITLE
fix(stores): cap sessionStore's persisted annotationHistory

### DIFF
--- a/src/stores/__tests__/sessionStore.persistence.test.ts
+++ b/src/stores/__tests__/sessionStore.persistence.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+class MemoryStorage {
+  protected store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  clear() {
+    this.store.clear()
+  }
+}
+
+/** Every setItem call throws QuotaExceededError — simulates a truly exhausted quota. */
+class AlwaysQuotaStorage extends MemoryStorage {
+  setItem(): void {
+    const err = new Error('QuotaExceededError')
+    err.name = 'QuotaExceededError'
+    throw err
+  }
+}
+
+/**
+ * The first setItem call for `failingKey` throws QuotaExceededError;
+ * subsequent calls (and calls for any other key) succeed normally.
+ */
+class FailOnceStorage extends MemoryStorage {
+  private failed = false
+
+  constructor(private readonly failingKey: string) {
+    super()
+  }
+
+  setItem(key: string, value: string) {
+    if (key === this.failingKey && !this.failed) {
+      this.failed = true
+      const err = new Error('QuotaExceededError')
+      err.name = 'QuotaExceededError'
+      throw err
+    }
+    super.setItem(key, value)
+  }
+}
+
+async function loadStore() {
+  vi.resetModules()
+  return import('@/stores/sessionStore')
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('sessionStore persistence bounds (#66)', () => {
+  it('caps the persisted annotationHistory even as the in-memory string keeps growing past the cap', async () => {
+    const storage = new MemoryStorage()
+    vi.stubGlobal('localStorage', storage)
+    const { useSessionStore } = await loadStore()
+
+    // One entry well past MAX_PERSISTED_HISTORY_CHARS (400_000), so a
+    // regression that drops the `.slice()` cap leaves the full string
+    // persisted instead.
+    const bigEntry = 'x'.repeat(500_000)
+    useSessionStore.getState().appendToHistory(bigEntry)
+
+    // In-memory state is not trimmed — only what gets written to localStorage is.
+    expect(useSessionStore.getState().context.annotationHistory).toHaveLength(bigEntry.length)
+
+    const raw = storage.getItem('intent-ide-session')
+    expect(raw).not.toBeNull()
+    const persisted = JSON.parse(raw as string)
+    const persistedHistory = persisted.state.context.annotationHistory as string
+
+    expect(persistedHistory.length).toBe(400_000)
+    // Oldest characters are evicted first; newest (tail) survive.
+    expect(persistedHistory).toBe(bigEntry.slice(-400_000))
+  })
+
+  it('does not crash the store when localStorage.setItem always throws QuotaExceededError', async () => {
+    vi.stubGlobal('localStorage', new AlwaysQuotaStorage())
+    const { useSessionStore } = await loadStore()
+
+    expect(() => useSessionStore.getState().appendToHistory('entry')).not.toThrow()
+    // In-memory state still reflects the update even though persistence silently failed.
+    expect(useSessionStore.getState().context.annotationHistory).toBe('entry')
+  })
+
+  it('emergency-prunes annotationHistory to EMERGENCY_HISTORY_CHARS and retries once when the first write hits QuotaExceededError', async () => {
+    const storage = new FailOnceStorage('intent-ide-session')
+    vi.stubGlobal('localStorage', storage)
+    const { useSessionStore } = await loadStore()
+
+    // A single write carrying well over the emergency cap (80_000), so a
+    // regression that drops the emergency prune would leave the full,
+    // unpruned string on the (successful) retry instead.
+    const seeded = 'y'.repeat(150_000)
+    expect(() =>
+      useSessionStore.setState((s) => ({ context: { ...s.context, annotationHistory: seeded } }))
+    ).not.toThrow()
+
+    const raw = storage.getItem('intent-ide-session')
+    expect(raw).not.toBeNull()
+    const persisted = JSON.parse(raw as string)
+    const persistedHistory = persisted.state.context.annotationHistory as string
+
+    expect(persistedHistory.length).toBe(80_000)
+    expect(persistedHistory).toBe(seeded.slice(-80_000))
+  })
+})

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -24,6 +24,18 @@ const initialContext: SessionContext = {
   totalTokens: 0,
 }
 
+// resolver.ts's maybeCompactContext() is the normal path: it summarizes
+// annotationHistory via an LLM call once it estimates ~64k tokens (~256k
+// chars at CHARS_PER_TOKEN=4). But that call can fail (bad key, network
+// error, non-ok response) and is swallowed silently, leaving history to grow
+// unbounded — the same unbounded-persisted-string risk sibling stores
+// (changesStore's partialize caps, annotationStore's MAX_PERSISTED_ANNOTATIONS,
+// see #64) were already hardened against. These are the hard backstop for
+// when the soft LLM path fails, sized comfortably above the ~256k-char soft
+// trigger so normal compaction is always the one that fires first.
+const MAX_PERSISTED_HISTORY_CHARS = 400_000
+const EMERGENCY_HISTORY_CHARS = 80_000
+
 export const useSessionStore = create<SessionState>()(
   persist(
     (set) => ({
@@ -41,6 +53,46 @@ export const useSessionStore = create<SessionState>()(
         })),
       reset: () => set({ context: { ...initialContext } }),
     }),
-    { name: 'intent-ide-session' }
+    {
+      name: 'intent-ide-session',
+      partialize: (state) => ({
+        context: {
+          ...state.context,
+          annotationHistory: state.context.annotationHistory.slice(-MAX_PERSISTED_HISTORY_CHARS),
+        },
+      }),
+      storage: {
+        getItem: (name: string) => {
+          try {
+            const raw = localStorage.getItem(name)
+            return raw ? JSON.parse(raw) : null
+          } catch {
+            return null
+          }
+        },
+        setItem: (name: string, value: unknown) => {
+          try {
+            localStorage.setItem(name, JSON.stringify(value))
+          } catch {
+            // Quota exceeded — emergency prune and retry.
+            // Zustand persist v4 wraps in { state: {...}, version: N }.
+            try {
+              const parsed = JSON.parse(JSON.stringify(value)) as Record<string, unknown>
+              const inner = (parsed.state ?? parsed) as { context?: SessionContext }
+              if (inner.context) {
+                inner.context = {
+                  ...inner.context,
+                  annotationHistory: (inner.context.annotationHistory ?? '').slice(-EMERGENCY_HISTORY_CHARS),
+                }
+              }
+              localStorage.setItem(name, JSON.stringify(parsed))
+            } catch {
+              // Silently fail — in-memory state is still valid.
+            }
+          }
+        },
+        removeItem: (name: string) => localStorage.removeItem(name),
+      },
+    }
   )
 )


### PR DESCRIPTION
## What

`useSessionStore` (`src/stores/sessionStore.ts`) was a plain `persist()` zustand store with no hard cap on `context.annotationHistory` — every `appendToHistory()` call (`resolver.ts` lines 245/449/579, `mads.ts` line 444) grows it by concatenation, with no `QuotaExceededError` handling on the persisted write. Its siblings are already hardened for exactly this: `changesStore.ts`'s `partialize` + emergency-prune wrapper, and `annotationStore.ts` as of PR #65 (closing #64).

The only prior mitigation was `resolver.ts`'s `maybeCompactContext()` — a soft LLM-based summarization that triggers at an estimated 64,000 tokens (~256,000 chars at `CHARS_PER_TOKEN=4`) but silently no-ops on any fetch failure (bad key, network error, non-`ok` response, all swallowed), leaving `annotationHistory` to grow unbounded if that path ever breaks.

## Fix

- New `MAX_PERSISTED_HISTORY_CHARS = 400_000` applied via `partialize` — slices `context.annotationHistory` to its newest 400k characters before every localStorage write. Sized comfortably above the ~256k-char soft compaction trigger so normal compaction is the one that fires first in the common case; this is the hard backstop for when it doesn't. In-memory state stays unbounded during the live session, matching the same tradeoff `annotationStore.ts`/`changesStore.ts` already make.
- New `EMERGENCY_HISTORY_CHARS = 80_000` — a custom `storage.setItem` wrapper (mirrors `annotationStore.ts`'s pattern) whose `setItem` catches a thrown quota error, re-parses the zustand-wrapped payload, prunes `annotationHistory` to its newest 80k chars, and retries once. A second failure is silently swallowed — in-memory state stays valid either way.
- No `onRehydrateStorage` guard was added: unlike `annotationStore.ts`'s `activeAnnotationId`, nothing else in `sessionStore`'s state cross-references `annotationHistory` in a way a truncation could dangle.

## Adversarial review

A troublemaker subagent reviewed the diff before push. Verdict: **MERGE** — no correctness issues in the new code. It confirmed the slice direction keeps the newest (tail) content, matching `appendToHistory`'s append-at-end semantics; confirmed `partialize` doesn't drop `documentSummary`/`userPatterns`/`totalTokens`; and confirmed the new tests are non-vacuous (they seed 500k/150k-char payloads well past both caps and assert exact tail-slice equality, not just a loose bound).

It also surfaced a real, pre-existing, unrelated bug in `resolver.ts` that undercuts this fix's stated rationale in practice — `sessionContext` is captured *before* `await maybeCompactContext()` runs but read *after*, so the stale reference means the resolution call that triggered compaction never actually benefits from it; and `continueThread` never calls `maybeCompactContext()` at all, so in-memory history can still grow unbounded through follow-up threads independent of this fix. Filed as a fast-follow (see below) rather than folded into this PR, since this PR's stated goal (bound the localStorage write) is met and tested regardless.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 978 passing + 10 skipped (was 975 baseline on this checkout; +3 new)
- [x] Adversarial (troublemaker) subagent review completed — verdict MERGE, no findings required a fix

Closes #66

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xq8fFQRaQFTzFL2TouY4QQ)_