### PR TITLE
fix(resolver): re-read session context after compaction, compact in continueThread

### DIFF
--- a/src/lib/ai/__tests__/resolverCompaction.test.ts
+++ b/src/lib/ai/__tests__/resolverCompaction.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import { useSessionStore } from '@/stores/sessionStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+import type { Annotation } from '@/lib/annotations/types'
+import { resolveAnnotation, continueThread, streamResolveAnnotation } from '../resolver'
+
+/**
+ * Regression coverage for #68: maybeCompactContext() mutates the session
+ * store in place, but a `sessionContext` local captured BEFORE the await
+ * still points at the pre-compaction object — so even when compaction runs
+ * successfully, the call that triggered it sent the stale, uncompacted
+ * history anyway. continueThread never called maybeCompactContext() at all.
+ *
+ * A naive "compaction ran successfully" assertion would miss both bugs (the
+ * store does end up compacted — just too late for the in-flight call, and
+ * continueThread simply never checks). These tests assert on what the
+ * *same, triggering* /api/resolve call actually sent.
+ */
+
+const COMPACTED_SUMMARY = 'Reviewer has focused on budget figures across three sections.'
+const STALE_MARKER = 'STALE_UNCOMPACTED_MARKER'
+
+// Comfortably above COMPACTION_THRESHOLD_TOKENS (64_000 tokens * 4 chars/token).
+function bigHistory(): string {
+  return `${STALE_MARKER}\n` + 'x'.repeat(300_000)
+}
+
+function doc() {
+  return schema.node('doc', null, [
+    schema.node('paragraph', null, [schema.text('The total budget is $50,000 for the pilot program.')]),
+  ])
+}
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-A',
+    locationGroupKey: 'loc-1',
+    type: 'ask',
+    status: 'resolving',
+    transcript: 'what does this mean',
+    anchor: { from: 1, to: 10, scope: 'sentence', text: 'The total' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: Date.now(),
+    resolvedAt: null,
+    verbosity: 'normal',
+    ...overrides,
+  }
+}
+
+function jsonResponse(data: unknown) {
+  return { ok: true, status: 200, statusText: 'OK', json: async () => data }
+}
+
+/** SSE-shaped response for the `stream: true` branch streamResolveAnnotation actually parses. */
+function sseResponse(text: string) {
+  const encoder = new TextEncoder()
+  const body = `data: ${JSON.stringify({ responseId: 'test-resp-1' })}\n\ndata: ${JSON.stringify({ text })}\n\n`
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(body))
+        controller.close()
+      },
+    }),
+    json: async () => ({}),
+  }
+}
+
+/**
+ * Records every /api/resolve call's system-message content, keyed by whether
+ * it's the compaction call. Handles BOTH response shapes streamResolveAnnotation
+ * and resolveAnnotation/continueThread actually use — a plain json() stub alone
+ * would never exercise streamResolveAnnotation's SSE-reader branch (it throws
+ * "No response body for stream" without a real ReadableStream body).
+ */
+function makeFetchStub() {
+  const resolveSystemMessages: string[] = []
+  let compactionCalls = 0
+
+  const stub = vi.fn(async (input: unknown, init?: { body?: string }) => {
+    const url = typeof input === 'string' ? input : String((input as { url?: string })?.url ?? input)
+    const body = init?.body ? JSON.parse(init.body) : null
+
+    if (url.includes('/api/audit')) {
+      return jsonResponse({ auditId: 'audit-test-1' })
+    }
+    if (url.includes('/api/resolve')) {
+      const messages = body?.messages ?? []
+      const isCompactionCall =
+        messages.length === 1 && String(messages[0]?.content ?? '').includes('Compress the following review session')
+
+      if (isCompactionCall) {
+        compactionCalls++
+        return jsonResponse({ content: COMPACTED_SUMMARY })
+      }
+
+      // The real resolution/continuation call — system message is messages[0].
+      resolveSystemMessages.push(String(messages[0]?.content ?? ''))
+      if (body?.stream) {
+        return sseResponse('Agent reply.')
+      }
+      return jsonResponse({ content: 'Agent reply.', responseId: 'test-resp-1', logprobs: null })
+    }
+    return jsonResponse({})
+  })
+
+  return { stub, resolveSystemMessages, getCompactionCalls: () => compactionCalls }
+}
+
+beforeEach(() => {
+  useSessionStore.getState().reset()
+  useSettingsStore.getState().setLLMConfig({ provider: 'claude', model: 'claude-sonnet-4-6', apiKey: 'test-key' })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('resolveAnnotation re-reads session context after compaction', () => {
+  it('the SAME call that triggers compaction sends the compacted history, not the stale pre-compaction one', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: bigHistory() })
+
+    const { stub, resolveSystemMessages, getCompactionCalls } = makeFetchStub()
+    vi.stubGlobal('fetch', stub)
+
+    const state = EditorState.create({ schema, doc: doc() })
+    const annotation = makeAnnotation()
+
+    await resolveAnnotation(annotation, state)
+
+    expect(getCompactionCalls()).toBe(1)
+    expect(resolveSystemMessages).toHaveLength(1)
+    expect(resolveSystemMessages[0]).toContain(COMPACTED_SUMMARY)
+    expect(resolveSystemMessages[0]).not.toContain(STALE_MARKER)
+
+    // The store itself is compacted too (that part already worked pre-fix).
+    expect(useSessionStore.getState().context.annotationHistory).toContain(COMPACTED_SUMMARY)
+  })
+
+  it('below the compaction threshold, no compaction call fires and history passes through unchanged', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: 'short prior context' })
+
+    const { stub, resolveSystemMessages, getCompactionCalls } = makeFetchStub()
+    vi.stubGlobal('fetch', stub)
+
+    const state = EditorState.create({ schema, doc: doc() })
+    await resolveAnnotation(makeAnnotation(), state)
+
+    expect(getCompactionCalls()).toBe(0)
+    expect(resolveSystemMessages).toHaveLength(1)
+    expect(resolveSystemMessages[0]).toContain('short prior context')
+  })
+})
+
+describe('streamResolveAnnotation re-reads session context after compaction (the actually-reachable production path)', () => {
+  // resolveAnnotation above has no production callers (AnnotationCard.tsx and
+  // voice/pipeline.ts both call streamResolveAnnotation) — this suite is the
+  // one that must catch the bug on the path the shipped UI actually uses.
+  it('the SAME streamed call that triggers compaction sends the compacted history, not the stale pre-compaction one', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: bigHistory() })
+
+    const { stub, resolveSystemMessages, getCompactionCalls } = makeFetchStub()
+    vi.stubGlobal('fetch', stub)
+
+    const state = EditorState.create({ schema, doc: doc() })
+    const annotation = makeAnnotation()
+    const chunks: string[] = []
+
+    const resolution = await streamResolveAnnotation(annotation, state, (c) => chunks.push(c))
+
+    expect(getCompactionCalls()).toBe(1)
+    expect(resolveSystemMessages).toHaveLength(1)
+    expect(resolveSystemMessages[0]).toContain(COMPACTED_SUMMARY)
+    expect(resolveSystemMessages[0]).not.toContain(STALE_MARKER)
+
+    // The SSE plumbing itself worked (sanity check the stub is really exercised).
+    expect(resolution.content).toBe('Agent reply.')
+    expect(chunks.length).toBeGreaterThan(0)
+
+    expect(useSessionStore.getState().context.annotationHistory).toContain(COMPACTED_SUMMARY)
+  })
+})
+
+describe('continueThread compacts session context before sending it', () => {
+  it('a large annotationHistory triggers compaction, and the follow-up call sends the compacted version', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: bigHistory() })
+
+    const { stub, resolveSystemMessages, getCompactionCalls } = makeFetchStub()
+    vi.stubGlobal('fetch', stub)
+
+    const state = EditorState.create({ schema, doc: doc() })
+    const annotation = makeAnnotation({ type: 'ask', status: 'resolved' })
+
+    await continueThread(annotation, 'and what about the second half?', state)
+
+    // Before the fix, continueThread never called maybeCompactContext() at
+    // all — this assertion is the one a naive "it returns a message" test
+    // would never catch.
+    expect(getCompactionCalls()).toBe(1)
+    expect(resolveSystemMessages).toHaveLength(1)
+    expect(resolveSystemMessages[0]).toContain(COMPACTED_SUMMARY)
+    expect(resolveSystemMessages[0]).not.toContain(STALE_MARKER)
+  })
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -137,10 +137,14 @@ export async function resolveAnnotation(
   editorState: EditorState,
 ): Promise<Resolution> {
   const config = useSettingsStore.getState().llmConfig
-  const sessionContext = useSessionStore.getState().context
 
   // Context compaction: if session history is large, compress before proceeding
   await maybeCompactContext()
+
+  // Re-read after compaction — compaction mutates the store in place, and a
+  // reference captured before the await would still point at the pre-compaction
+  // (uncompacted) history.
+  const sessionContext = useSessionStore.getState().context
 
   // Build context
   const localBlock = getBlockText(editorState, annotation.anchor.from)
@@ -302,9 +306,11 @@ export async function streamResolveAnnotation(
   onChunk: (partialContent: string) => void,
 ): Promise<Resolution> {
   const config = useSettingsStore.getState().llmConfig
-  const sessionContext = useSessionStore.getState().context
 
   await maybeCompactContext()
+
+  // Re-read after compaction — see resolveAnnotation's identical comment.
+  const sessionContext = useSessionStore.getState().context
 
   const localBlock = getBlockText(editorState, annotation.anchor.from)
   const sectionText = getSectionText(editorState, annotation.anchor.from)
@@ -498,6 +504,12 @@ export async function continueThread(
   editorState: EditorState,
 ): Promise<ConversationMessage> {
   const config = useSettingsStore.getState().llmConfig
+
+  // Context compaction: unlike the other two call sites, follow-up threads can
+  // grow annotationHistory indefinitely with no compaction check otherwise ever
+  // firing on this path.
+  await maybeCompactContext()
+
   const sessionContext = useSessionStore.getState().context
 
   // Build context


### PR DESCRIPTION
## Summary

`src/lib/ai/resolver.ts` had two related gaps in the context-compaction path (`maybeCompactContext()`) that meant it didn't actually bound the prompt sent to the LLM the way the code assumed:

1. **Stale reference across the `await`.** `resolveAnnotation` and `streamResolveAnnotation` both captured `const sessionContext = useSessionStore.getState().context` **before** `await maybeCompactContext()`. Compaction mutates the store in place, but the already-captured local still pointed at the pre-compaction object — so even when compaction successfully ran and shrank history, the very call that triggered it sent the *original*, uncompacted `annotationHistory` to the LLM anyway. Fixed by re-reading `useSessionStore.getState().context` after the `await` in both functions.
2. **`continueThread` never called `maybeCompactContext()` at all.** Follow-up threads could grow `annotationHistory` indefinitely with no compaction check ever firing on that path. Fixed by adding the call before it reads `sessionContext.annotationHistory`.

## Test coverage

New `src/lib/ai/__tests__/resolverCompaction.test.ts`, with a fetch stub that distinguishes the compaction call from the real resolve/continuation call and asserts the **same, triggering** call sends the compacted (not stale) history.

Adversarial review of an earlier version of this PR caught that the initial test suite only covered `resolveAnnotation`, which has **zero production callers** — `AnnotationCard.tsx` and `voice/pipeline.ts` both call `streamResolveAnnotation`. Coverage now targets `streamResolveAnnotation` directly via a stubbed SSE `ReadableStream` response (the shape it actually parses), which is the path that matters. `resolveAnnotation` and `continueThread` are covered too.

Verified non-vacuous: checked out the pre-fix `resolver.ts` and confirmed all three "same call" assertions fail against it; restored the fix and confirmed all 4 tests pass.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 984 passing + 10 skipped (was 983 + 10; +1 new test file, 4 tests)

## Descoped (filed as follow-ups, not folded into this PR)

Adversarial review surfaced two pre-existing, unrelated gaps while reviewing this diff:
- `continueThread` never writes an audit record at all (unlike `resolveAnnotation`/`streamResolveAnnotation`) — follow-up thread messages get no EU AI Act audit row.
- `maybeCompactContext()` has no concurrency guard — two calls racing above the threshold can both fire a compaction request and then race on `session.updateContext(...)` (last-writer-wins).

Both filed as their own scoped `task:` issues with `discovered-from` refs rather than left as TODOs in this diff.

Closes #68

---
_Generated by [Claude Code](https://claude.ai/code/session_013xCwecb7KV2b3gZN6ebwrh)_