### PR TITLE
fix(resolver): log an audit record for continueThread follow-ups

### DIFF
--- a/src/lib/ai/__tests__/resolverContinueThreadAudit.test.ts
+++ b/src/lib/ai/__tests__/resolverContinueThreadAudit.test.ts
@@ -108,13 +108,32 @@ describe('continueThread audit logging', () => {
     expect(changeSet?.auditRecordIds).toContain('audit-99')
   })
 
-  it('flags auditFailed on the returned message when the audit write rejects, without dropping the reply', async () => {
+  it('flags auditFailed when the audit write resolves null — the real failure signal, since logResolutionAudit never rejects on a write failure', async () => {
     const { auditLogger, resolver } = await loadModules()
-    vi.mocked(auditLogger.logResolutionAudit).mockRejectedValue(new Error('audit endpoint down'))
+    // logAuditEvent's own try/catch swallows every real failure and resolves null;
+    // it never rejects. A test that only exercised .catch() would assert a mode the
+    // real implementation can't produce and miss this actual failure path.
+    vi.mocked(auditLogger.logResolutionAudit).mockResolvedValue(null)
     stubFetch('Follow-up agent reply')
 
     const annotation = makeAnnotation()
     const message = await resolver.continueThread(annotation, 'Another follow-up', makeEditorState())
+
+    expect(message.content).toBe('Follow-up agent reply')
+
+    await flushMicrotasks()
+
+    expect(message.auditFailed).toBe(true)
+    expect(message.auditId).toBeUndefined()
+  })
+
+  it('flags auditFailed as a defensive backstop if logResolutionAudit unexpectedly throws', async () => {
+    const { auditLogger, resolver } = await loadModules()
+    vi.mocked(auditLogger.logResolutionAudit).mockRejectedValue(new Error('unexpected throw'))
+    stubFetch('Follow-up agent reply')
+
+    const annotation = makeAnnotation()
+    const message = await resolver.continueThread(annotation, 'Yet another follow-up', makeEditorState())
 
     expect(message.content).toBe('Follow-up agent reply')
 

--- a/src/lib/ai/__tests__/resolverContinueThreadAudit.test.ts
+++ b/src/lib/ai/__tests__/resolverContinueThreadAudit.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation } from '@/lib/annotations/types'
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logResolutionAudit: vi.fn(),
+}))
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:1:10',
+    type: 'flag',
+    status: 'resolved',
+    transcript: 'Original question',
+    anchor: { from: 1, to: 5, scope: 'sentence', text: 'Some text' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 100,
+    resolvedAt: 200,
+    verbosity: 'normal',
+    ...overrides,
+  }
+}
+
+function makeEditorState(): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Some text here.')]),
+  ])
+  return EditorState.create({ schema, doc })
+}
+
+async function loadModules() {
+  vi.resetModules()
+  const auditLogger = await import('@/lib/audit/auditLogger')
+  const resolver = await import('@/lib/ai/resolver')
+  const changesStore = await import('@/stores/changesStore')
+  return { auditLogger, resolver, changesStore }
+}
+
+function stubFetch(content: string, responseId = 'resp-1') {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      json: async () => ({ content, responseId }),
+    }),
+  )
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('continueThread audit logging', () => {
+  it('writes an audit record for a follow-up thread message and links it to the annotation', async () => {
+    const { auditLogger, resolver, changesStore } = await loadModules()
+    vi.mocked(auditLogger.logResolutionAudit).mockResolvedValue('audit-99')
+    stubFetch('Follow-up agent reply')
+
+    const annotation = makeAnnotation()
+    const message = await resolver.continueThread(annotation, 'What about edge cases?', makeEditorState())
+
+    expect(message.content).toBe('Follow-up agent reply')
+    expect(auditLogger.logResolutionAudit).toHaveBeenCalledTimes(1)
+    expect(auditLogger.logResolutionAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        annotationType: 'flag',
+        transcript: 'What about edge cases?',
+        responseId: 'resp-1',
+        usedMADS: false,
+      }),
+    )
+
+    await flushMicrotasks()
+
+    expect(message.auditId).toBe('audit-99')
+    expect(message.auditFailed).toBeUndefined()
+
+    const changeSet = changesStore.useChangesStore.getState().getChangeSetByAnnotationId(annotation.id)
+    expect(changeSet?.auditRecordIds).toContain('audit-99')
+  })
+
+  it('flags auditFailed on the returned message when the audit write rejects, without dropping the reply', async () => {
+    const { auditLogger, resolver } = await loadModules()
+    vi.mocked(auditLogger.logResolutionAudit).mockRejectedValue(new Error('audit endpoint down'))
+    stubFetch('Follow-up agent reply')
+
+    const annotation = makeAnnotation()
+    const message = await resolver.continueThread(annotation, 'Another follow-up', makeEditorState())
+
+    expect(message.content).toBe('Follow-up agent reply')
+
+    await flushMicrotasks()
+
+    expect(message.auditFailed).toBe(true)
+    expect(message.auditId).toBeUndefined()
+  })
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -574,19 +574,42 @@ ${annotation.type === 'edit'
 
     const data = await response.json()
     const content = data.content
+    const responseId = data.responseId ?? crypto.randomUUID()
 
     // Update session context
     useSessionStore.getState().appendToHistory(
       `[${annotation.type}] Follow-up: "${followUp.slice(0, 50)}..." → Agent responded.`
     )
 
-    return {
+    const message: ConversationMessage = {
       id: generateId(),
       role: 'agent',
       content,
       suggestedEdit: annotation.type === 'edit' ? parseSuggestedEdit(content, annotation) : null,
       timestamp: Date.now(),
     }
+
+    // Audit log for follow-up thread messages (non-blocking, same pattern as the other call sites)
+    logResolutionAudit({
+      annotationType: annotation.type,
+      transcript: followUp,
+      modelName: config.provider,
+      modelVersion: config.model,
+      promptVersion: 'RESOLVER_v1',
+      responseId,
+      usedMADS: false,
+    }).then((auditId) => {
+      if (auditId) {
+        message.auditId = auditId
+        useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+      }
+    }).catch((e) => {
+      // EU AI Act ledger write failed — surface incomplete coverage, don't drop silently
+      console.error('Audit log failed (continueThread)', e)
+      message.auditFailed = true
+    })
+
+    return message
   } catch (err) {
     return {
       id: generateId(),

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -602,9 +602,13 @@ ${annotation.type === 'edit'
       if (auditId) {
         message.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+      } else {
+        // logResolutionAudit resolves null (never rejects) on a write failure —
+        // this is the real failure signal, not the .catch() below.
+        message.auditFailed = true
       }
     }).catch((e) => {
-      // EU AI Act ledger write failed — surface incomplete coverage, don't drop silently
+      // Defensive backstop for a throw before logResolutionAudit's own try/catch.
       console.error('Audit log failed (continueThread)', e)
       message.auditFailed = true
     })

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -48,6 +48,10 @@ export interface ConversationMessage {
   content: string
   suggestedEdit: SuggestedEdit | null
   timestamp: number
+  /** Audit trail ID for EU AI Act compliance (set after async logging) */
+  auditId?: string
+  /** Set when the compliance audit-log write failed, so the UI can flag incomplete coverage */
+  auditFailed?: boolean
 }
 
 export interface Annotation {


### PR DESCRIPTION
## Summary

`continueThread` in `src/lib/ai/resolver.ts` was the only one of the three resolver entry points that never called `logResolutionAudit` — follow-up thread messages (a user asking a clarifying question after the initial resolution) were invisible to the EU AI Act Article 12 audit ledger.

- Added `auditId?: string` / `auditFailed?: boolean` to the `ConversationMessage` interface (`src/lib/annotations/types.ts`), mirroring `Resolution`'s existing fields.
- `continueThread` now builds its return value as a `const message` object, fires `logResolutionAudit(...)` non-blocking, sets `message.auditId` and links the record to the annotation's change set via `useChangesStore().linkAuditToAnnotation(...)` on success — the same pattern already used by `resolveAnnotation`/`streamResolveAnnotation`.

## Review found a real bug in that same "same pattern" — fixed in a second commit

Adversarial review of the first commit caught that `logResolutionAudit` never actually rejects: `logAuditEvent`'s own `try/catch` swallows every real write failure and resolves `null`. The pre-existing `.then((auditId) => { if (auditId) {...} }).catch(...)` pattern I copied means a genuine audit-write failure resolves `auditId = null`, the `if (auditId)` guard is false, and **neither** `auditId` nor `auditFailed` gets set on the message — silently reproducing the exact ledger gap this PR exists to close.

Fixed by adding an `else { message.auditFailed = true }` branch for the null-result case, keeping `.catch()` only as a defensive backstop for a throw before `logResolutionAudit`'s own internal try/catch. The regression test that only exercised `.mockRejectedValue(...)` (a mode the real implementation can't produce) was replaced with one that exercises the actual null-resolution failure path, plus a separate test for the defensive-backstop throw case.

The same latent bug exists at the three pre-existing call sites (`resolveAnnotation`/`streamResolveAnnotation`, MADS and single-agent branches) — out of scope here since fixing it would widen a single-call-site fix into a four-call-site refactor. Filed as #72.

## Test coverage

New `src/lib/ai/__tests__/resolverContinueThreadAudit.test.ts`, three tests:
1. Audit write succeeds → `auditId` set on the returned message, and the change set for the annotation has the record linked.
2. Audit write resolves `null` (the real failure signal) → `auditFailed` set to `true`.
3. Audit write unexpectedly throws (defensive backstop) → `auditFailed` set to `true`.

Verified non-vacuous both times: reverted `resolver.ts` to each pre-fix version in turn and confirmed the corresponding new test fails against it, then confirmed it passes against the fix.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 983 passing + 10 skipped (was 982 + 10; +1 new test file, 3 tests)

Closes #70


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4qgGe7b8dacM2p9m8nry7)_