### PR TITLE
fix(resolver): guard maybeCompactContext against concurrent compaction races

### DIFF
--- a/src/lib/ai/__tests__/resolverCompactionConcurrency.test.ts
+++ b/src/lib/ai/__tests__/resolverCompactionConcurrency.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '@/stores/sessionStore'
+import { maybeCompactContext } from '../resolver'
+
+// #71: maybeCompactContext() had no concurrency guard. Two callers
+// (resolveAnnotation / streamResolveAnnotation / continueThread invoked in
+// quick succession) that both observe annotationHistory above threshold each
+// fired their own /api/resolve compaction request and raced on the final
+// session.updateContext() write — last writer wins, silently discarding the
+// other compaction's result and its LLM spend. This asserts concurrent
+// callers now share a single in-flight compaction instead.
+
+const LARGE_HISTORY = 'x'.repeat(64000 * 4) // estimatedTokens === COMPACTION_THRESHOLD_TOKENS
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useSessionStore.getState().reset()
+})
+
+describe('maybeCompactContext concurrency guard', () => {
+  it('fires exactly one /api/resolve compaction call for two overlapping invocations', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: LARGE_HISTORY })
+
+    const gate = deferred<void>()
+    let fetchCalls = 0
+    const fetchMock = vi.fn(async () => {
+      fetchCalls += 1
+      await gate.promise
+      return {
+        ok: true,
+        json: async () => ({ content: 'compacted summary' }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    // Two callers race in without either having resolved yet.
+    const first = maybeCompactContext()
+    const second = maybeCompactContext()
+
+    // Let both callers reach their fetch() call before releasing the response.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(fetchCalls).toBe(1)
+
+    gate.resolve()
+    await Promise.all([first, second])
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(useSessionStore.getState().context.annotationHistory).toBe(
+      '[Compacted session summary]\ncompacted summary',
+    )
+  })
+
+  it('allows a new compaction after the in-flight one settles', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: LARGE_HISTORY })
+
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ content: 'first summary' }),
+    })) as unknown as typeof fetch
+    vi.stubGlobal('fetch', fetchMock)
+
+    await maybeCompactContext()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // Grow history back above threshold and compact again — this must fire
+    // its own request, not silently no-op because a stale guard never cleared.
+    useSessionStore.getState().updateContext({ annotationHistory: LARGE_HISTORY })
+    await maybeCompactContext()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -653,12 +653,23 @@ const CHARS_PER_TOKEN = 4
 // keeps sub-agent calls cheap rather than a hard fraction of the window.
 const COMPACTION_THRESHOLD_TOKENS = 64000
 
+// Module-level in-flight guard: resolveAnnotation/streamResolveAnnotation/
+// continueThread can all call maybeCompactContext() in quick succession
+// (rapid double-click, two annotations resolving at once). Without this,
+// each concurrent caller independently observes history above threshold,
+// fires its own compaction request, and races on the final updateContext()
+// write — last writer wins, silently discarding the other compaction's
+// result (and the LLM spend that produced it). Callers that arrive while a
+// compaction is already running await that SAME promise instead of firing
+// their own.
+let compactionInFlight: Promise<void> | null = null
+
 /**
  * Check if the session context is getting too large and compact it.
  * Per agent-orchestration.mdc Section 3: trigger summarization when
  * context exceeds 50% of the model's maximum context window.
  */
-async function maybeCompactContext(): Promise<void> {
+export async function maybeCompactContext(): Promise<void> {
   const session = useSessionStore.getState()
   const history = session.context.annotationHistory
 
@@ -668,6 +679,20 @@ async function maybeCompactContext(): Promise<void> {
 
   if (estimatedTokens < COMPACTION_THRESHOLD_TOKENS) return
 
+  if (compactionInFlight) return compactionInFlight
+
+  compactionInFlight = performCompaction(session, history)
+  try {
+    await compactionInFlight
+  } finally {
+    compactionInFlight = null
+  }
+}
+
+async function performCompaction(
+  session: ReturnType<typeof useSessionStore.getState>,
+  history: string,
+): Promise<void> {
   const config = useSettingsStore.getState().llmConfig
 
   const prompt = CONTEXT_COMPRESSION_PROMPT.replace('{{history}}', history)


### PR DESCRIPTION
## Summary

`maybeCompactContext()` in `src/lib/ai/resolver.ts` had no guard against concurrent invocations. `resolveAnnotation`/`streamResolveAnnotation` (and, once PR #69 lands, `continueThread`) can all call it in quick succession — two annotations resolving at once, a rapid double-click. Each concurrent caller independently observed `annotationHistory` above the compaction threshold, fired its own `/api/resolve` compaction request, and raced on the final `session.updateContext(...)` write: last writer wins, silently discarding the other compaction's result and the LLM spend that produced it.

This is separate from — and not fixed by — #68/PR #69's read-after-write-ordering fix, which only ensures a *single* call re-reads the store correctly after its *own* compaction. It does nothing about two calls compacting concurrently.

## Fix

A module-level `compactionInFlight: Promise<void> | null` guard: the compaction body was extracted into `performCompaction()`, and `maybeCompactContext()` now checks/sets `compactionInFlight` synchronously (no `await` between the check and the set, so this is a true atomic claim, not a race-prone check-then-act) before firing it. A caller that arrives while a compaction is already running awaits that *same* promise instead of firing its own. `finally { compactionInFlight = null }` lets a later, independent compaction fire normally once the in-flight one settles.

`maybeCompactContext` was changed from module-private to `export` so it can be unit-tested directly, matching this codebase's existing pattern of exporting internal functions for test seams (e.g. `resolveEditRange`/`applySingleEdit`).

## Test coverage

New `src/lib/ai/__tests__/resolverCompactionConcurrency.test.ts`:
1. Two overlapping `maybeCompactContext()` calls (via a gated fetch mock that doesn't resolve until both callers have had a chance to reach it) → exactly one `/api/resolve` call fires, both callers observe the compacted result.
2. A second, independent compaction after the first settles → fires its own request (the guard self-clears, it doesn't permanently latch).

Verified non-vacuous three ways: reverted the whole fix (test fails — `maybeCompactContext is not a function`, since it wasn't exported before); kept the export but manually neutered just the guard body (test 1 fails — 2 fetch calls instead of 1); confirmed both pass against the real fix.

## Adversarial review

Ran a troublemaker review before pushing. Verdict: sound, no blocking findings.
- Confirmed empirically (not just by inspection) that the check-then-set has no `await` in between, so the guard is genuinely atomic.
- Confirmed `performCompaction`'s `session.updateContext(...)` call lands on live zustand state regardless of which caller's `session` snapshot invoked it — `updateContext` is a functional `set((s) => ...)` updater closed over zustand's internal `set`, not over a stale local snapshot (same pattern `appendToHistory` already uses).
- Confirmed the fix doesn't widen the pre-existing (not introduced by this diff) window where a compaction's blind `updateContext` overwrite could clobber a concurrent `appendToHistory` write — merging N racing callers into 1 doesn't lengthen that window or change its odds, since it already exists for any single in-flight compaction today.
- One minor, explicitly non-blocking note: `performCompaction`'s setup before its own `try` (config/prompt/model selection) is currently all non-throwing given the real implementations, so a synchronous throw there rejecting the shared promise for all piggybacking callers at once is theoretical, not a change to hold up the merge for.
- Confirmed the diff stays scoped to only `resolver.ts` + the new test file — no changes to the pre-existing stale-`sessionContext`-across-`await` issue (#68/PR #69's territory) or audit-logging (#70/#72).

The review also surfaced one pre-existing, adjacent gap worth tracking (not a regression from this PR, and not fixed here to keep this change scoped to the concurrency race it was filed for): a compaction's `updateContext` overwrite can, in principle, clobber a concurrent `appendToHistory` write from an unrelated resolution finishing mid-compaction. Filing as a follow-up `task:` issue with a `discovered-from` ref rather than leaving it as an unaddressed note.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 982 passing + 10 skipped

Closes #71

---
_Generated by [Claude Code](https://claude.ai/code/session_01VAWx3ryR1X5cztY2QdMFYf)_