### PR TITLE
fix(resolver): flag auditFailed on a real audit-write failure at all four call sites

### DIFF
--- a/src/lib/ai/__tests__/resolverAuditFailedGuard.test.ts
+++ b/src/lib/ai/__tests__/resolverAuditFailedGuard.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation, Resolution } from '@/lib/annotations/types'
+
+// logAuditEvent's own try/catch swallows every real write failure and
+// resolves null — it never rejects. Mocking logResolutionAudit at the
+// module boundary lets each scenario drive both the real failure mode
+// (resolves null) and the defensive-backstop mode (throws) independently
+// of what the underlying auditLogger implementation can actually produce.
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logResolutionAudit: vi.fn(),
+}))
+
+// MADS is attempted unconditionally at the top of both resolveAnnotation and
+// streamResolveAnnotation; mocking it lets a single test target either the
+// MADS branch (non-null return) or the single-agent branch (null return)
+// without depending on the real debate pipeline.
+vi.mock('@/lib/ai/mads', () => ({
+  runMADS: vi.fn(),
+}))
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:1:10',
+    type: 'flag',
+    status: 'resolved',
+    transcript: 'Original question',
+    anchor: { from: 1, to: 5, scope: 'sentence', text: 'Some text' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 100,
+    resolvedAt: 200,
+    verbosity: 'normal',
+    ...overrides,
+  }
+}
+
+function makeEditorState(): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Some text here.')]),
+  ])
+  return EditorState.create({ schema, doc })
+}
+
+async function loadModules() {
+  vi.resetModules()
+  const auditLogger = await import('@/lib/audit/auditLogger')
+  const mads = await import('@/lib/ai/mads')
+  const resolver = await import('@/lib/ai/resolver')
+  return { auditLogger, mads, resolver }
+}
+
+function stubFetchJson(content: string, responseId = 'resp-1') {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      json: async () => ({ content, responseId }),
+    }),
+  )
+}
+
+// The real streamResolveAnnotation parses an SSE body via response.body.getReader();
+// a minimal single-chunk reader stub is enough to drive it to a resolved Resolution.
+function stubFetchSSE(content: string, responseId = 'resp-1') {
+  const sseBody = `data: ${JSON.stringify({ responseId })}\n\ndata: ${JSON.stringify({ text: content })}\n\n`
+  const bytes = new TextEncoder().encode(sseBody)
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      body: {
+        getReader() {
+          let delivered = false
+          return {
+            read: async () => {
+              if (delivered) return { done: true, value: undefined }
+              delivered = true
+              return { done: false, value: bytes }
+            },
+          }
+        },
+      },
+    }),
+  )
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+const noopOnChunk = () => {}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+type Mods = Awaited<ReturnType<typeof loadModules>>
+
+const madsResolution: Resolution = {
+  type: 'edit',
+  content: 'MADS reply',
+  suggestedEdit: null,
+  actions: [],
+}
+
+const scenarios: Array<{
+  name: string
+  run: (mods: Mods, annotation: Annotation) => Promise<Resolution>
+}> = [
+  {
+    name: 'resolveAnnotation MADS branch',
+    run: async (mods, annotation) => {
+      vi.mocked(mods.mads.runMADS).mockResolvedValue({
+        resolution: { ...madsResolution },
+        uncertaintyFlags: [],
+        debateLog: '',
+        usedMADS: true,
+      })
+      return mods.resolver.resolveAnnotation(annotation, makeEditorState())
+    },
+  },
+  {
+    name: 'resolveAnnotation single-agent branch',
+    run: async (mods, annotation) => {
+      vi.mocked(mods.mads.runMADS).mockResolvedValue(null)
+      stubFetchJson('single-agent reply')
+      return mods.resolver.resolveAnnotation(annotation, makeEditorState())
+    },
+  },
+  {
+    name: 'streamResolveAnnotation MADS branch',
+    run: async (mods, annotation) => {
+      vi.mocked(mods.mads.runMADS).mockResolvedValue({
+        resolution: { ...madsResolution },
+        uncertaintyFlags: [],
+        debateLog: '',
+        usedMADS: true,
+      })
+      return mods.resolver.streamResolveAnnotation(annotation, makeEditorState(), noopOnChunk)
+    },
+  },
+  {
+    name: 'streamResolveAnnotation single-agent branch',
+    run: async (mods, annotation) => {
+      vi.mocked(mods.mads.runMADS).mockResolvedValue(null)
+      stubFetchSSE('single-agent stream reply')
+      return mods.resolver.streamResolveAnnotation(annotation, makeEditorState(), noopOnChunk)
+    },
+  },
+]
+
+describe('resolver audit-failed guard (issue #72)', () => {
+  for (const scenario of scenarios) {
+    it(`${scenario.name}: flags auditFailed when the audit write resolves null (the real failure signal)`, async () => {
+      const mods = await loadModules()
+      // logAuditEvent never rejects on a real write failure — it resolves null.
+      // A test that only exercised .mockRejectedValue would assert a mode the
+      // real implementation can't produce and miss this actual failure path.
+      vi.mocked(mods.auditLogger.logResolutionAudit).mockResolvedValue(null)
+
+      const resolution = await scenario.run(mods, makeAnnotation())
+      await flushMicrotasks()
+
+      expect(resolution.auditFailed).toBe(true)
+      expect(resolution.auditId).toBeUndefined()
+    })
+
+    it(`${scenario.name}: flags auditFailed as a defensive backstop if logResolutionAudit unexpectedly throws`, async () => {
+      const mods = await loadModules()
+      vi.mocked(mods.auditLogger.logResolutionAudit).mockRejectedValue(new Error('unexpected throw'))
+
+      const resolution = await scenario.run(mods, makeAnnotation())
+      await flushMicrotasks()
+
+      expect(resolution.auditFailed).toBe(true)
+      expect(resolution.auditId).toBeUndefined()
+    })
+
+    it(`${scenario.name}: sets auditId (not auditFailed) on a successful write`, async () => {
+      const mods = await loadModules()
+      vi.mocked(mods.auditLogger.logResolutionAudit).mockResolvedValue('audit-1')
+
+      const resolution = await scenario.run(mods, makeAnnotation())
+      await flushMicrotasks()
+
+      expect(resolution.auditId).toBe('audit-1')
+      expect(resolution.auditFailed).toBeUndefined()
+    })
+  }
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -164,9 +164,12 @@ export async function resolveAnnotation(
         if (auditId) {
           madsResult.resolution.auditId = auditId
           useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+        } else {
+          // logAuditEvent never rejects — a real write failure resolves null, not a throw
+          madsResult.resolution.auditFailed = true
         }
       }).catch((e) => {
-        // EU AI Act ledger write failed — surface incomplete coverage, don't drop silently
+        // Defensive backstop for a throw before logResolutionAudit's own try/catch
         console.error('Audit log failed (MADS)', e)
         madsResult.resolution.auditFailed = true
       })
@@ -267,9 +270,12 @@ ${annotation.type === 'edit'
       if (auditId) {
         resolution.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+      } else {
+        // logAuditEvent never rejects — a real write failure resolves null, not a throw
+        resolution.auditFailed = true
       }
     }).catch((e) => {
-      // EU AI Act ledger write failed — surface incomplete coverage, don't drop silently
+      // Defensive backstop for a throw before logResolutionAudit's own try/catch
       console.error('Audit log failed (single-agent)', e)
       resolution.auditFailed = true
     })
@@ -326,7 +332,14 @@ export async function streamResolveAnnotation(
         if (auditId) {
           madsResult.resolution.auditId = auditId
           useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+        } else {
+          // logAuditEvent never rejects — a real write failure resolves null, not a throw
+          madsResult.resolution.auditFailed = true
         }
+      }).catch((e) => {
+        // Defensive backstop for a throw before logResolutionAudit's own try/catch
+        console.error('Audit log failed (streaming MADS)', e)
+        madsResult.resolution.auditFailed = true
       })
       if (madsResult.uncertaintyFlags.length > 0) {
         madsResult.resolution.uncertaintyFlags = madsResult.uncertaintyFlags
@@ -469,9 +482,12 @@ ${annotation.type === 'edit'
       if (auditId) {
         resolution.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
+      } else {
+        // logAuditEvent never rejects — a real write failure resolves null, not a throw
+        resolution.auditFailed = true
       }
     }).catch((e) => {
-      // EU AI Act ledger write failed — surface incomplete coverage, don't drop silently
+      // Defensive backstop for a throw before logResolutionAudit's own try/catch
       console.error('Audit log failed (single-agent)', e)
       resolution.auditFailed = true
     })


### PR DESCRIPTION
## Summary

`logAuditEvent` (`src/lib/audit/auditLogger.ts:77-100`) is documented as "Fire-and-forget safe: errors are logged but never thrown" — its internal `try/catch` swallows every real failure (network error, non-2xx response) and resolves to `null`. It never rejects. `logResolutionAudit` adds no additional rejection path on top of it.

`src/lib/ai/resolver.ts` had four call sites that fire `logResolutionAudit(...).then((auditId) => { if (auditId) { ...set auditId... } }).catch((e) => { ...set auditFailed = true... })`. Because the promise never actually rejects on a real failure, the `.catch()` block was dead code for the failure mode it exists to handle: on a genuine audit-write failure, `auditId` resolves `null`, the `if (auditId)` guard is false, and **neither** `auditId` **nor** `auditFailed` got set — the resolution silently reported no audit trouble at all.

Fixed the same `else { resolution.auditFailed = true }` branch at all four sites, using PR #73's `continueThread` fix (closing #70) as the reference pattern:
- `resolveAnnotation`'s MADS branch
- `resolveAnnotation`'s single-agent branch
- `streamResolveAnnotation`'s MADS branch
- `streamResolveAnnotation`'s single-agent branch

## Found in review, fixed in the same diff

The streaming MADS branch (`streamResolveAnnotation`) was missing a `.catch()` entirely — a thrown audit call there was previously an unhandled rejection that never set `auditFailed` either. Added the same defensive-backstop `.catch()` used at the other three sites.

## Test coverage

New `src/lib/ai/__tests__/resolverAuditFailedGuard.test.ts` — parameterized across all 4 call sites × 3 scenarios (audit write resolves `null` → `auditFailed`; audit write throws → `auditFailed` via the defensive backstop; audit write succeeds → `auditId` set, no false positive). `runMADS` is mocked to independently target the MADS vs. single-agent branch of each function; `streamResolveAnnotation`'s single-agent scenario stubs a minimal single-chunk SSE `ReadableStream` to drive the real parsing path.

Verified non-vacuous: reverted `resolver.ts` to pre-fix and confirmed 5/12 tests fail against it (the four null-resolution scenarios plus the missing-`.catch()` unhandled-rejection case); restored the fix and confirmed all 12 pass.

## Adversarial review

Ran a troublemaker review before pushing. Verdict: **MERGE** — confirmed all four sites correctly patched (grepped `logResolutionAudit` call sites repo-wide: exactly 4, all in this file, all patched; other `logAuditEvent`/`logOverrideAudit` call sites elsewhere are different, out-of-scope sites, correctly untouched), confirmed the vitest module alias resolves `@/lib/ai/mads` and resolver.ts's relative `./mads` to the same file so the mock takes effect, and independently reproduced the non-vacuous test result (5/12 failing pre-fix) itself.

The review also surfaced a real, broader gap this diff does **not** close: `resolution.auditFailed` has no UI consumer anywhere in the codebase, and the fire-and-forget `.then()/.catch()` mutates the `resolution` object in place after the function has already returned it — since callers store that object via a plain `{...a, ...patch}` spread in `annotationStore.update()`, that later mutation bypasses Zustand's `set()`, so it never reaches React subscribers or the persisted snapshot. `docs/compliance.md`'s claim that a failed audit write is "flagged in the UI" is therefore currently false, independent of this fix. Both issues pre-date this diff and are outside its scope (a single-call-site correctness fix vs. a UI + store-architecture change) — filed as its own scoped follow-up: closes-adjacent to but not fixed by this PR.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 992 passing + 10 skipped (was 980 + 10; +1 new test file, 12 tests)

## Descoped (filed as a follow-up, not folded into this PR)

`resolution.auditFailed`/`auditId` are set correctly by this fix but are structurally undeliverable to the user or persisted store today — filed as a new `task:` issue with a `discovered-from` ref rather than left as a silent gap or a TODO in this diff.

Closes #72


---
_Generated by [Claude Code](https://claude.ai/code/session_01FjYh5GHGwwY4TFrzXg27ZB)_