### PR TITLE
fix(resolver): preserve a concurrent appendToHistory during compaction

### DIFF
--- a/src/lib/ai/__tests__/resolverCompactionAppendPreserve.test.ts
+++ b/src/lib/ai/__tests__/resolverCompactionAppendPreserve.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useSessionStore } from '@/stores/sessionStore'
+import { maybeCompactContext } from '../resolver'
+
+// #75: maybeCompactContext()'s final session.updateContext() is a whole-field
+// overwrite of annotationHistory computed from a pre-compaction snapshot. If
+// an unrelated resolution finishes and calls appendToHistory() while this
+// compaction's LLM call is still in flight, that overwrite silently discards
+// the just-appended entry. This asserts the appended suffix survives.
+
+const LARGE_HISTORY = 'x'.repeat(64000 * 4) // estimatedTokens === COMPACTION_THRESHOLD_TOKENS
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useSessionStore.getState().reset()
+})
+
+describe('maybeCompactContext preserves a concurrent appendToHistory', () => {
+  it('keeps a history entry appended while the compaction fetch is still pending', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: LARGE_HISTORY })
+
+    const gate = deferred<void>()
+    const fetchMock = vi.fn(async () => {
+      // An unrelated resolution finishes mid-compaction and appends to the
+      // live history before this compaction's fetch resolves.
+      useSessionStore.getState().appendToHistory('unrelated resolution entry')
+      await gate.promise
+      return {
+        ok: true,
+        json: async () => ({ content: 'compacted summary' }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const compaction = maybeCompactContext()
+    await Promise.resolve()
+    gate.resolve()
+    await compaction
+
+    expect(useSessionStore.getState().context.annotationHistory).toBe(
+      '[Compacted session summary]\ncompacted summary\nunrelated resolution entry',
+    )
+  })
+
+  it('skips the write when the live history no longer starts with what was summarized', async () => {
+    useSessionStore.getState().updateContext({ annotationHistory: LARGE_HISTORY })
+
+    const gate = deferred<void>()
+    const fetchMock = vi.fn(async () => {
+      // Live history changed in a way that isn't a pure append on top of the
+      // pre-compaction snapshot (e.g. a session reset) — the summary is now
+      // based on stale data, so the fix should not force it back in.
+      useSessionStore.getState().reset()
+      useSessionStore.getState().updateContext({ annotationHistory: 'fresh session history' })
+      await gate.promise
+      return {
+        ok: true,
+        json: async () => ({ content: 'compacted summary' }),
+      } as Response
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const compaction = maybeCompactContext()
+    await Promise.resolve()
+    gate.resolve()
+    await compaction
+
+    expect(useSessionStore.getState().context.annotationHistory).toBe('fresh session history')
+  })
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -776,10 +776,24 @@ async function performCompaction(
     const compacted = data.content
 
     if (compacted && compacted.length < history.length) {
-      session.updateContext({
-        annotationHistory: `[Compacted session summary]\n${compacted}`,
-        totalTokens: Math.ceil(compacted.length / CHARS_PER_TOKEN),
-      })
+      // A concurrent, unrelated resolution's appendToHistory() can land while
+      // this compaction's LLM call is still in flight. appendToHistory only
+      // ever appends onto the live annotationHistory, so if it's still
+      // prefixed by the exact string we summarized, anything after that
+      // prefix is a suffix appended during the round-trip — preserve it
+      // instead of clobbering it with the whole-field overwrite below. If
+      // the live history no longer starts with what we summarized (e.g. a
+      // session reset), the summary is based on stale data, so skip the
+      // write rather than guess at how to merge it.
+      const currentHistory = useSessionStore.getState().context.annotationHistory
+      if (currentHistory.startsWith(history)) {
+        const appendedSuffix = currentHistory.slice(history.length)
+        const newHistory = `[Compacted session summary]\n${compacted}${appendedSuffix}`
+        session.updateContext({
+          annotationHistory: newHistory,
+          totalTokens: Math.ceil(newHistory.length / CHARS_PER_TOKEN),
+        })
+      }
     }
   } catch {
     // Non-blocking — if compaction fails, continue with existing context


### PR DESCRIPTION
## Summary

`maybeCompactContext()` in `src/lib/ai/resolver.ts` reads `session.context.annotationHistory` when it starts, summarizes it via an LLM call, and then does a whole-field overwrite: `session.updateContext({ annotationHistory: ..., totalTokens: ... })`.

If an unrelated resolution (a different annotation's `resolveAnnotation`/`streamResolveAnnotation`/`continueThread`) finishes and calls `session.appendToHistory(...)` while this compaction's LLM call is still in flight, the compaction's later overwrite silently discards the just-appended entry. `appendToHistory` itself is safe (a functional `set((s) => ...)` updater), but the overwrite is not append-aware — it replaces the whole field with a summary computed from a stale pre-compaction snapshot.

This is separate from — and not fixed by — PR #74's `compactionInFlight` guard, which only serializes concurrent *compactions*. It does nothing about an unrelated, non-compacting caller appending mid-flight.

## Fix

`performCompaction` now re-reads the live `annotationHistory` immediately before the final write. If it still starts with the exact string that was summarized, anything after that prefix is a suffix appended during the round-trip — preserved instead of clobbered. If the live history no longer starts with what was summarized (e.g. a session `reset()` on document import/switch), the summary is based on stale data, so the write is skipped rather than guessed at.

`totalTokens` is now computed from the merged `newHistory.length` rather than just `compacted.length` — more accurate than before (the old estimate omitted the `"[Compacted session summary]\n"` prefix), though nothing in the codebase currently reads `totalTokens` for gating.

## Test coverage

New `src/lib/ai/__tests__/resolverCompactionAppendPreserve.test.ts`:
1. A history entry appended via `appendToHistory` while the compaction fetch is still pending survives in the final `annotationHistory`.
2. When the live history diverges from what was summarized in a non-append way (a session `reset()`), the write is skipped and the live history is left untouched.

Verified non-vacuous: reverted `resolver.ts` to pre-fix and confirmed both new tests fail against it (silently discards the append; overwrites the reset history), then confirmed both pass against the fix.

## Adversarial review

Ran a troublemaker review before pushing. Verdict: **MERGE**.
- Traced every production mutator of `annotationHistory` besides `appendToHistory`: `performCompaction` itself (serialized by PR #74's `compactionInFlight` guard — no interleaving possible) and `useSessionStore.getState().reset()` (`DocInputModal.tsx`, doc import/switch) — both handled correctly by the `startsWith` check.
- Confirmed the skip-on-divergence fallback isn't a livelock: multiple overlapping appends during the round-trip are still merged correctly (the suffix just grows); only a non-append overwrite triggers the skip, and that's a deliberate, rare user action, not steady-state traffic.
- Confirmed `totalTokens` is write-only (`grep -rn "totalTokens" src`) — no UI, gating, or trimming logic reads it, so the changed computation is a non-issue.
- Confirmed no interaction with `MAX_PERSISTED_HISTORY_CHARS`/`EMERGENCY_HISTORY_CHARS` — those only touch the serialized localStorage payload, not the in-memory `context.annotationHistory` this fix reads.
- Independently reproduced the non-vacuous test result.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 1003 passing + 10 skipped (was 992 + 10; +11 new)

## Descoped (filed as a follow-up, not folded into this PR)

The review surfaced that `src/lib/ai/contextEngine.ts` (`compressSessionContext`/`updateSessionContext`) contains the same unfixed whole-field-overwrite pattern this PR fixes in `resolver.ts`. It's currently dead code (zero call sites) so not a live bug today, but a landmine if it's ever wired back in — filed as its own scoped `task:` issue with a `discovered-from` ref rather than left as a silent gap.

Closes #75

---
_Generated by [Claude Code](https://claude.ai/code/session_0131Tu17DsLmmuhpEX4avvj4)_