### PR TITLE
fix(annotations): surface resolution.auditFailed in the UI and reach the store

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -74,9 +74,13 @@ non-repudiable signatures.
 **Linkage to the audit ledger — including the failure path.** Versions of kind `apply` carry the
 ids of the audit records covering the underlying AI inference, a direct join to the Article 12
 audit ledger (`AuditLog`, written via the append-only `src/app/api/audit/route.ts` /
-`src/lib/audit/auditLogger.ts`). When an audit write fails at inference time, the resolution is
-flagged in the UI (`auditFailed`) and the linked version records **zero** audit ids — the gap is
-surfaced, not papered over.
+`src/lib/audit/auditLogger.ts`). When an audit write fails at inference time, `resolver.ts` routes
+the `auditFailed` flag through `useAnnotationStore`'s `updateResolutionAuditStatus`/`updateMessage`
+actions (not a bare object mutation — a subscriber-notifying, persisted store write) and the UI
+surfaces it: a warning callout on the resolution card and on the conversation message it belongs
+to (`AnnotationCard.tsx`, `ConversationThread.tsx`), plus a toast at apply/decision time
+(`ResolutionActions.tsx`) when the linked version would otherwise carry **zero** audit ids or the
+human-oversight override record has nowhere to link to. The gap is surfaced, not papered over.
 
 **Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years);
 compliance-relevant document versions (`'import' | 'apply' | 'restore'`) are retained indefinitely

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -445,6 +445,16 @@ export function AnnotationCard({
         </div>
       )}
 
+      {/* Audit-write failure warning (EU AI Act Art. 12 gap — see #77) */}
+      {showDetail && !held && annotation.resolution?.auditFailed && (
+        <div className="mt-3 mx-1 p-2 border border-red-300 bg-red-50 rounded-xl flex items-center gap-2">
+          <span className="text-red-600 text-xs font-bold shrink-0">⚠</span>
+          <p className="text-xs text-red-800">
+            Audit record for this resolution failed to save — this change has no linked compliance record.
+          </p>
+        </div>
+      )}
+
       {/* Inline provocation callout (when MADS raised an unresolved objection; hidden while held) */}
       {showDetail && !held && annotation.resolution?.provocation && (
         <div className="mt-3 mx-1 p-3 border border-amber-300 bg-amber-50 rounded-xl shadow-sm">

--- a/src/components/Annotations/ConversationThread.tsx
+++ b/src/components/Annotations/ConversationThread.tsx
@@ -118,6 +118,11 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
               <span className="text-[10px] font-mono text-muted">
                 {formatTimestamp(message.timestamp)}
               </span>
+              {message.auditFailed && (
+                <p className="mt-1 text-[10px] text-red-700 flex items-center gap-1">
+                  <span className="font-bold">⚠</span> Audit record failed to save for this response
+                </p>
+              )}
 
               {message.suggestedEdit && (
                 <>

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -125,6 +125,15 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         : annotation.resolution?.auditId
           ? [annotation.resolution.auditId]
           : []
+    // Warn rather than silently apply with a zero-audit-links version — see
+    // #77. Only fires when the write is KNOWN to have failed (auditFailed),
+    // not merely still in flight (which would false-positive on a fast click).
+    if (auditIds.length === 0 && annotation.resolution?.auditFailed) {
+      useToastStore.getState().addToast(
+        'Audit record for this resolution failed to save — applying anyway, but this version has no linked compliance record.',
+        'error'
+      )
+    }
     const transcript = annotation.transcript.trim()
     const message = !transcript
       ? 'AI change applied'
@@ -419,6 +428,14 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     const approvalAction = handlerToApprovalAction(handler)
     if (auditId && approvalAction) {
       recordHumanDecision(auditId, approvalAction)
+    } else if (!auditId && approvalAction && annotation.resolution?.auditFailed) {
+      // Known failure (not just "write still in flight") — the human-oversight
+      // override record has nowhere to link to. Warn instead of skipping
+      // silently — see #77.
+      useToastStore.getState().addToast(
+        'This decision could not be recorded — the audit trail for this resolution failed to save.',
+        'error'
+      )
     }
 
     switch (handler) {

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -41,6 +41,18 @@ interface ResolutionActionsProps {
   annotation: Annotation
 }
 
+// Handlers whose case body only opens SemanticCommitModal (setPendingHandler
+// + openCommitModal) — no decision has actually happened yet at the point
+// handleAction runs. 'add-to-doc' is conditionally modal-gated: only when
+// there's a suggestedEdit to review (see its case body below); with no
+// suggestedEdit it decides immediately in the same synchronous call.
+const ALWAYS_MODAL_GATED_HANDLERS = new Set(['apply-edit', 'act-on-thought', 'change-from-answer'])
+
+function opensCommitModal(handler: string, hasSuggestedEdit: boolean): boolean {
+  if (ALWAYS_MODAL_GATED_HANDLERS.has(handler)) return true
+  return handler === 'add-to-doc' && hasSuggestedEdit
+}
+
 export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   const updateAnnotation = useAnnotationStore((s) => s.update)
   const view = useEditorStore((s) => s.view)
@@ -426,12 +438,17 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
     // Log human oversight decision if we have an audit trail (non-blocking)
     const auditId = annotation.resolution?.auditId
     const approvalAction = handlerToApprovalAction(handler)
+    const modalGated = opensCommitModal(handler, Boolean(annotation.resolution?.suggestedEdit) && Boolean(view))
     if (auditId && approvalAction) {
       recordHumanDecision(auditId, approvalAction)
-    } else if (!auditId && approvalAction && annotation.resolution?.auditFailed) {
+    } else if (!auditId && approvalAction && annotation.resolution?.auditFailed && !modalGated) {
       // Known failure (not just "write still in flight") — the human-oversight
       // override record has nowhere to link to. Warn instead of skipping
-      // silently — see #77.
+      // silently — see #77. Skipped for handlers that only open the commit
+      // modal here (no decision has happened yet): recordApplyCommit's own
+      // toast covers those once the user actually confirms, so this doesn't
+      // fire early for a decision that hasn't happened, or double up with
+      // that toast on confirm.
       useToastStore.getState().addToast(
         'This decision could not be recorded — the audit trail for this resolution failed to save.',
         'error'

--- a/src/components/Annotations/__tests__/resolutionActions.opensCommitModal.pure.test.ts
+++ b/src/components/Annotations/__tests__/resolutionActions.opensCommitModal.pure.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+
+// opensCommitModal is not exported from ResolutionActions.tsx (importing a
+// .tsx into a node-environment .test.ts here would pull in the whole store/
+// plugin import graph — see agentMarkdown.pure.test.ts for the established
+// precedent of testing such logic via a source-faithful re-implementation
+// instead). Any change to the source logic will produce a mismatch that
+// surfaces both here and in the component's behavior.
+const ALWAYS_MODAL_GATED_HANDLERS = new Set(['apply-edit', 'act-on-thought', 'change-from-answer'])
+
+function opensCommitModal(handler: string, hasSuggestedEdit: boolean): boolean {
+  if (ALWAYS_MODAL_GATED_HANDLERS.has(handler)) return true
+  return handler === 'add-to-doc' && hasSuggestedEdit
+}
+
+// Regression for #77's adversarial-review HIGH finding: handleAction's
+// audit-failure toast fired for apply-edit/act-on-thought/change-from-answer
+// even though those handlers only open SemanticCommitModal — no decision has
+// happened yet — producing a "this decision could not be recorded" toast for
+// a decision that might never happen (the user could still cancel), and a
+// duplicate, differently-worded toast from recordApplyCommit on confirm.
+describe('opensCommitModal (#77 handleAction toast-gating fix)', () => {
+  it('is modal-gated for apply-edit/act-on-thought/change-from-answer regardless of edit/view state', () => {
+    for (const handler of ['apply-edit', 'act-on-thought', 'change-from-answer']) {
+      expect(opensCommitModal(handler, true)).toBe(true)
+      expect(opensCommitModal(handler, false)).toBe(true)
+    }
+  })
+
+  it('add-to-doc is modal-gated only when there is a suggested edit to review', () => {
+    expect(opensCommitModal('add-to-doc', true)).toBe(true)
+    // No suggestedEdit: add-to-doc decides immediately (inserts as a new
+    // paragraph) — a real, un-gated decision that should still be warned
+    // about on a known audit-write failure.
+    expect(opensCommitModal('add-to-doc', false)).toBe(false)
+  })
+
+  it('is never modal-gated for handlers that always decide synchronously', () => {
+    for (const handler of ['dismiss', 'park', 'tweak', 'explore', 'explore-deeper', 'research']) {
+      expect(opensCommitModal(handler, true)).toBe(false)
+      expect(opensCommitModal(handler, false)).toBe(false)
+    }
+  })
+})

--- a/src/lib/ai/__tests__/resolverAuditFailedStoreSync.test.ts
+++ b/src/lib/ai/__tests__/resolverAuditFailedStoreSync.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation } from '@/lib/annotations/types'
+
+// #77: `auditFailed` was set correctly on the Resolution/ConversationMessage
+// object (fixed by #72/PR76), but the mutation never reached the reactive
+// store — no subscriber was notified and the persisted localStorage snapshot
+// never picked it up. These tests drive both possible orderings between "the
+// resolution/message gets stored" and "the audit write settles", since the
+// store-sync call is a no-op if the annotation isn't in the store yet (the
+// direct object mutation is what carries the flag across in that ordering).
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logResolutionAudit: vi.fn(),
+}))
+
+vi.mock('@/lib/ai/mads', () => ({
+  runMADS: vi.fn(),
+}))
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:1:10',
+    type: 'flag',
+    status: 'resolving',
+    transcript: 'Original question',
+    anchor: { from: 1, to: 5, scope: 'sentence', text: 'Some text' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 100,
+    resolvedAt: null,
+    verbosity: 'normal',
+    ...overrides,
+  }
+}
+
+function makeEditorState(): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Some text here.')]),
+  ])
+  return EditorState.create({ schema, doc })
+}
+
+async function loadModules() {
+  vi.resetModules()
+  const auditLogger = await import('@/lib/audit/auditLogger')
+  const mads = await import('@/lib/ai/mads')
+  const resolver = await import('@/lib/ai/resolver')
+  const annotationStoreMod = await import('@/stores/annotationStore')
+  return { auditLogger, mads, resolver, annotationStoreMod }
+}
+
+function stubFetchJson(content: string, responseId = 'resp-1') {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      json: async () => ({ content, responseId }),
+    }),
+  )
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('resolveAnnotation → annotationStore audit-status sync (#77)', () => {
+  it('reaches the store when the resolution was already stored before the audit write settles (ordering A)', async () => {
+    const { auditLogger, mads, resolver, annotationStoreMod } = await loadModules()
+    vi.mocked(mads.runMADS).mockResolvedValue(null)
+    stubFetchJson('single-agent reply')
+
+    let resolveAudit!: (v: string | null) => void
+    vi.mocked(auditLogger.logResolutionAudit).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolveAudit = resolve
+      }),
+    )
+
+    const annotation = makeAnnotation()
+    const resolution = await resolver.resolveAnnotation(annotation, makeEditorState())
+
+    // The caller (pipeline.ts / AnnotationCard.tsx) stores the resolution
+    // synchronously once resolveAnnotation resolves — before the still-pending
+    // fire-and-forget audit write has any chance to settle.
+    const store = annotationStoreMod.useAnnotationStore
+    store.getState().add(annotation)
+    store.getState().update(annotation.id, { status: 'resolved', resolution, resolvedAt: Date.now() })
+
+    // logAuditEvent never rejects on a real write failure — it resolves null.
+    resolveAudit(null)
+    await flushMicrotasks()
+
+    const stored = store.getState().getById(annotation.id)
+    expect(stored?.resolution?.auditFailed).toBe(true)
+    expect(stored?.resolution?.auditId).toBeUndefined()
+    // A NEW resolution object — proof that `set()` fired (subscriber/persist
+    // notified), not just that the original object was mutated in place.
+    expect(stored?.resolution).not.toBe(resolution)
+
+    // Outlives a simulated rehydration: read what actually landed in
+    // localStorage and confirm the flag survived the persist round-trip.
+    const raw = (globalThis.localStorage as unknown as MemoryStorage).getItem('intent-ide-annotations')
+    expect(raw).not.toBeNull()
+    const persisted = JSON.parse(raw as string)
+    const persistedAnnotation = persisted.state.annotations.find((a: Annotation) => a.id === annotation.id)
+    expect(persistedAnnotation.resolution.auditFailed).toBe(true)
+  })
+
+  it('preserves the flag on the resolution object when the audit write settles before the resolution is ever stored (ordering B)', async () => {
+    const { auditLogger, mads, resolver, annotationStoreMod } = await loadModules()
+    vi.mocked(mads.runMADS).mockResolvedValue(null)
+    stubFetchJson('single-agent reply')
+
+    let resolveAudit!: (v: string | null) => void
+    vi.mocked(auditLogger.logResolutionAudit).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolveAudit = resolve
+      }),
+    )
+
+    const annotation = makeAnnotation()
+    const resolution = await resolver.resolveAnnotation(annotation, makeEditorState())
+
+    // Resolve the audit write and let its .then() run BEFORE the annotation
+    // is stored anywhere — updateResolutionAuditStatus is a guaranteed no-op
+    // here (nothing in the store yet), so this only passes if the direct
+    // object mutation in resolver.ts is still in place as a fallback.
+    resolveAudit(null)
+    await flushMicrotasks()
+
+    const store = annotationStoreMod.useAnnotationStore
+    store.getState().add(annotation)
+    store.getState().update(annotation.id, { status: 'resolved', resolution, resolvedAt: Date.now() })
+
+    const stored = store.getState().getById(annotation.id)
+    expect(stored?.resolution?.auditFailed).toBe(true)
+  })
+
+  it('does not stomp a newer resolution (e.g. a badge-override re-resolve) with a stale audit outcome', async () => {
+    const { auditLogger, mads, resolver, annotationStoreMod } = await loadModules()
+    vi.mocked(mads.runMADS).mockResolvedValue(null)
+    stubFetchJson('first reply')
+
+    let resolveAudit!: (v: string | null) => void
+    vi.mocked(auditLogger.logResolutionAudit).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolveAudit = resolve
+      }),
+    )
+
+    const annotation = makeAnnotation()
+    const staleResolution = await resolver.resolveAnnotation(annotation, makeEditorState())
+
+    const store = annotationStoreMod.useAnnotationStore
+    store.getState().add(annotation)
+    store.getState().update(annotation.id, { status: 'resolved', resolution: staleResolution, resolvedAt: Date.now() })
+
+    // A newer resolution (e.g. a badge-override re-run) replaces it before
+    // the first resolution's audit write settles.
+    const freshResolution = { ...staleResolution, content: 'fresh reply' }
+    store.getState().update(annotation.id, { resolution: freshResolution })
+
+    resolveAudit(null)
+    await flushMicrotasks()
+
+    const stored = store.getState().getById(annotation.id)
+    // The stale write's outcome must not land on the fresh resolution.
+    expect(stored?.resolution).toBe(freshResolution)
+    expect(stored?.resolution?.auditFailed).toBeUndefined()
+  })
+})
+
+describe('continueThread → annotationStore audit-status sync (#77)', () => {
+  it('reaches the store when the message was already stored before the audit write settles (ordering A)', async () => {
+    const { auditLogger, resolver, annotationStoreMod } = await loadModules()
+    stubFetchJson('follow-up reply')
+
+    let resolveAudit!: (v: string | null) => void
+    vi.mocked(auditLogger.logResolutionAudit).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolveAudit = resolve
+      }),
+    )
+
+    const annotation = makeAnnotation()
+    const store = annotationStoreMod.useAnnotationStore
+    store.getState().add(annotation)
+
+    const message = await resolver.continueThread(annotation, 'What about edge cases?', makeEditorState())
+    store.getState().addMessage(annotation.id, message)
+
+    resolveAudit(null)
+    await flushMicrotasks()
+
+    const stored = store.getState().getById(annotation.id)
+    const storedMessage = stored?.conversation.find((m) => m.id === message.id)
+    expect(storedMessage?.auditFailed).toBe(true)
+
+    const raw = (globalThis.localStorage as unknown as MemoryStorage).getItem('intent-ide-annotations')
+    const persisted = JSON.parse(raw as string)
+    const persistedAnnotation = persisted.state.annotations.find((a: Annotation) => a.id === annotation.id)
+    expect(persistedAnnotation.conversation.find((m: { id: string }) => m.id === message.id).auditFailed).toBe(true)
+  })
+
+  it('preserves the flag on the message object when the audit write settles before the message is ever stored (ordering B)', async () => {
+    const { auditLogger, resolver, annotationStoreMod } = await loadModules()
+    stubFetchJson('follow-up reply')
+
+    let resolveAudit!: (v: string | null) => void
+    vi.mocked(auditLogger.logResolutionAudit).mockReturnValue(
+      new Promise<string | null>((resolve) => {
+        resolveAudit = resolve
+      }),
+    )
+
+    const annotation = makeAnnotation()
+    const message = await resolver.continueThread(annotation, 'What about edge cases?', makeEditorState())
+
+    resolveAudit(null)
+    await flushMicrotasks()
+
+    const store = annotationStoreMod.useAnnotationStore
+    store.getState().add(annotation)
+    store.getState().addMessage(annotation.id, message)
+
+    const stored = store.getState().getById(annotation.id)
+    const storedMessage = stored?.conversation.find((m) => m.id === message.id)
+    expect(storedMessage?.auditFailed).toBe(true)
+  })
+})

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -48,6 +48,34 @@ function resolveAdaptiveVerbosity(annotation: Annotation): Verbosity {
   return annotation.verbosity || getDefaultVerbosity(annotation.anchor.scope, annotation.type)
 }
 
+/**
+ * Apply an audit-write outcome to a Resolution. Mutates `resolution` in place
+ * (so the field survives if this settles before the resolution is ever
+ * stored) and also pushes the outcome through the store (so a subscriber
+ * still gets notified, and the persisted snapshot still gets written, if the
+ * resolution was already stored by the time this settles). See #77.
+ */
+function syncResolutionAuditOutcome(annotationId: string, resolution: Resolution, auditId: string | null) {
+  if (auditId) {
+    resolution.auditId = auditId
+    useAnnotationStore.getState().updateResolutionAuditStatus(annotationId, resolution, { auditId })
+  } else {
+    resolution.auditFailed = true
+    useAnnotationStore.getState().updateResolutionAuditStatus(annotationId, resolution, { auditFailed: true })
+  }
+}
+
+/** Same outcome-sync contract as {@link syncResolutionAuditOutcome}, for a ConversationMessage. */
+function syncMessageAuditOutcome(annotationId: string, message: ConversationMessage, auditId: string | null) {
+  if (auditId) {
+    message.auditId = auditId
+    useAnnotationStore.getState().updateMessage(annotationId, message.id, { auditId })
+  } else {
+    message.auditFailed = true
+    useAnnotationStore.getState().updateMessage(annotationId, message.id, { auditFailed: true })
+  }
+}
+
 function buildReviewProgress(currentAnnotationId: string): string {
   const annotations = useAnnotationStore.getState().annotations
   const total = annotations.length
@@ -165,17 +193,15 @@ export async function resolveAnnotation(
         responseId: crypto.randomUUID(),
         usedMADS: true,
       }).then((auditId) => {
+        // logAuditEvent never rejects — a real write failure resolves null, not a throw
+        syncResolutionAuditOutcome(annotation.id, madsResult.resolution, auditId)
         if (auditId) {
-          madsResult.resolution.auditId = auditId
           useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
-        } else {
-          // logAuditEvent never rejects — a real write failure resolves null, not a throw
-          madsResult.resolution.auditFailed = true
         }
       }).catch((e) => {
         // Defensive backstop for a throw before logResolutionAudit's own try/catch
         console.error('Audit log failed (MADS)', e)
-        madsResult.resolution.auditFailed = true
+        syncResolutionAuditOutcome(annotation.id, madsResult.resolution, null)
       })
       // Pass MADS uncertainty flags for visualization (Claude fallback)
       if (madsResult.uncertaintyFlags.length > 0) {
@@ -271,17 +297,15 @@ ${annotation.type === 'edit'
       responseId,
       usedMADS: false,
     }).then((auditId) => {
+      // logAuditEvent never rejects — a real write failure resolves null, not a throw
+      syncResolutionAuditOutcome(annotation.id, resolution, auditId)
       if (auditId) {
-        resolution.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
-      } else {
-        // logAuditEvent never rejects — a real write failure resolves null, not a throw
-        resolution.auditFailed = true
       }
     }).catch((e) => {
       // Defensive backstop for a throw before logResolutionAudit's own try/catch
       console.error('Audit log failed (single-agent)', e)
-      resolution.auditFailed = true
+      syncResolutionAuditOutcome(annotation.id, resolution, null)
     })
 
     // Attach multi-region cascade edits (best-effort)
@@ -335,17 +359,15 @@ export async function streamResolveAnnotation(
         responseId: crypto.randomUUID(),
         usedMADS: true,
       }).then((auditId) => {
+        // logAuditEvent never rejects — a real write failure resolves null, not a throw
+        syncResolutionAuditOutcome(annotation.id, madsResult.resolution, auditId)
         if (auditId) {
-          madsResult.resolution.auditId = auditId
           useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
-        } else {
-          // logAuditEvent never rejects — a real write failure resolves null, not a throw
-          madsResult.resolution.auditFailed = true
         }
       }).catch((e) => {
         // Defensive backstop for a throw before logResolutionAudit's own try/catch
         console.error('Audit log failed (streaming MADS)', e)
-        madsResult.resolution.auditFailed = true
+        syncResolutionAuditOutcome(annotation.id, madsResult.resolution, null)
       })
       if (madsResult.uncertaintyFlags.length > 0) {
         madsResult.resolution.uncertaintyFlags = madsResult.uncertaintyFlags
@@ -485,17 +507,15 @@ ${annotation.type === 'edit'
       responseId,
       usedMADS: false,
     }).then((auditId) => {
+      // logAuditEvent never rejects — a real write failure resolves null, not a throw
+      syncResolutionAuditOutcome(annotation.id, resolution, auditId)
       if (auditId) {
-        resolution.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
-      } else {
-        // logAuditEvent never rejects — a real write failure resolves null, not a throw
-        resolution.auditFailed = true
       }
     }).catch((e) => {
       // Defensive backstop for a throw before logResolutionAudit's own try/catch
       console.error('Audit log failed (single-agent)', e)
-      resolution.auditFailed = true
+      syncResolutionAuditOutcome(annotation.id, resolution, null)
     })
 
     // Attach multi-region cascade edits (best-effort)
@@ -627,18 +647,16 @@ ${annotation.type === 'edit'
       responseId,
       usedMADS: false,
     }).then((auditId) => {
+      // logResolutionAudit resolves null (never rejects) on a write failure —
+      // this is the real failure signal, not the .catch() below.
+      syncMessageAuditOutcome(annotation.id, message, auditId)
       if (auditId) {
-        message.auditId = auditId
         useChangesStore.getState().linkAuditToAnnotation(annotation, auditId)
-      } else {
-        // logResolutionAudit resolves null (never rejects) on a write failure —
-        // this is the real failure signal, not the .catch() below.
-        message.auditFailed = true
       }
     }).catch((e) => {
       // Defensive backstop for a throw before logResolutionAudit's own try/catch.
       console.error('Audit log failed (continueThread)', e)
-      message.auditFailed = true
+      syncMessageAuditOutcome(annotation.id, message, null)
     })
 
     return message

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -66,6 +66,20 @@ interface AnnotationState {
   activeAnnotationId: string | null
   add: (annotation: Annotation) => void
   update: (id: string, patch: Partial<Annotation>) => void
+  /**
+   * Patches `resolution.auditId`/`auditFailed` after an async audit write
+   * settles, but only if `resolution` (by reference) is still the annotation's
+   * current resolution — a re-resolve (badge override, re-run) that replaced
+   * it in the meantime is left untouched rather than stomped by a stale
+   * audit-write outcome. See #77: this is the notification half of the fix;
+   * the caller (resolver.ts) also mutates `resolution` in place so the field
+   * survives even if this fires before the resolution has been stored at all.
+   */
+  updateResolutionAuditStatus: (
+    id: string,
+    resolution: Resolution,
+    patch: Pick<Resolution, 'auditId'> | Pick<Resolution, 'auditFailed'>
+  ) => void
   remove: (id: string) => void
   setActive: (id: string | null) => void
   addMessage: (id: string, message: ConversationMessage) => void
@@ -85,6 +99,14 @@ export const useAnnotationStore = create<AnnotationState>()(
         set((s) => ({
           annotations: s.annotations.map((a) =>
             a.id === id ? { ...a, ...patch } : a
+          ),
+        })),
+      updateResolutionAuditStatus: (id, resolution, patch) =>
+        set((s) => ({
+          annotations: s.annotations.map((a) =>
+            a.id === id && a.resolution === resolution
+              ? { ...a, resolution: { ...a.resolution, ...patch } }
+              : a
           ),
         })),
       remove: (id) =>


### PR DESCRIPTION
## Summary

`docs/compliance.md` claimed a failed audit-log write is "flagged in the UI (`auditFailed`)". That claim was false in two compounding ways:

1. **No UI consumer.** Nothing anywhere read `resolution.auditFailed` or `ConversationMessage.auditFailed` to render a warning. `ResolutionActions.tsx`'s apply-commit path silently defaulted to `auditIds: []` and its `recordHumanDecision` call was silently skipped when `auditId` was undefined — a failed audit write on the "flag it" path produced a permanent version-history commit with zero audit links and zero user-facing signal.
2. **The flag couldn't reliably reach the reactive store.** `resolver.ts`'s five audit-write completion callbacks (`resolveAnnotation` MADS + single-agent, `streamResolveAnnotation` MADS + single-agent, `continueThread`) all did a bare in-place mutation like `resolution.auditFailed = true` on an object that may already be sitting in `useAnnotationStore`'s state. That mutation never calls `set()`, so no subscriber re-renders, and since the store uses `persist` (localStorage, which only writes on `set()`), the flag was silently lost on reload.

## Fix

- **`src/stores/annotationStore.ts`:** new `updateResolutionAuditStatus(id, resolutionRef, patch)` action — patches `annotation.resolution` via `set()` **only if** `a.resolution === resolutionRef` (referential match), so a resolution replaced by a newer re-resolve (e.g. a badge-type override) can't be stomped by a stale audit-write outcome landing late.
- **`src/lib/ai/resolver.ts`:** two small helpers, `syncResolutionAuditOutcome` and `syncMessageAuditOutcome`, replace the bare mutations at all five call sites. Each still mutates the object in place (so the flag survives if the audit write settles *before* the object is ever stored — the store call would otherwise no-op) **and** routes the outcome through the store (so a subscriber is notified and the persisted snapshot is written when the object is already stored).
- **UI consumers:** a warning callout on the resolution card (`AnnotationCard.tsx`) and an inline warning on the conversation message it belongs to (`ConversationThread.tsx`).
- **`ResolutionActions.tsx`:** warns instead of silently defaulting/skipping at the two sites the issue named — zero audit ids on the resulting version, and a skipped `recordHumanDecision` call — but only for handlers that decide synchronously. See "Adversarial review" below for why that gating exists.
- **`docs/compliance.md`:** corrected to describe the actual mechanism.

## Test coverage

- `src/lib/ai/__tests__/resolverAuditFailedStoreSync.test.ts` — drives both possible orderings (resolution/message stored before vs. after the audit write settles) for `resolveAnnotation` and `continueThread`, plus a case proving a newer resolution isn't stomped by a stale outcome, plus a persistence round-trip check reading raw localStorage.
- `src/components/Annotations/__tests__/resolutionActions.opensCommitModal.pure.test.ts` — pure-function regression test for the toast-gating fix below.

## Adversarial review

Ran a troublemaker review before pushing. First verdict: **NO-MERGE**, one HIGH:

> The new `handleAction` toast fired for `apply-edit`/`act-on-thought`/`change-from-answer` the instant the user clicked "Apply" — but those handlers only open `SemanticCommitModal`; no decision has happened yet. If the user then cancelled, a "this decision could not be recorded" toast had already fired for a decision that never happened. If they confirmed, `recordApplyCommit` fired a second, differently-worded toast for the same underlying condition.

Fixed by gating the `handleAction` toast off for handlers that route through the commit modal (`opensCommitModal` helper) — it still fires for handlers that decide synchronously (`dismiss`, `park`, `add-to-doc` with no `suggestedEdit`). Verified: core mechanism (reference-chain correctness of the `updateResolutionAuditStatus` guard, no field-clobbering race with `attachCascadeEdits`, test harness legitimacy) was independently traced and confirmed correct by the same review.

The review also surfaced two out-of-scope findings, filed as their own follow-ups rather than folded in or left as silent gaps (see below).

## Descoped (filed as follow-ups)

- The mermaid-diagram correction retry in `src/lib/voice/pipeline.ts` calls `continueThread` but discards the returned message (only `.content` is used) — its `syncMessageAuditOutcome` call is a guaranteed no-op, so a failed audit write on that specific sub-thread has no UI signal anywhere. Filed as its own scoped `task:` issue.
- Applying an edit before its audit write has settled at all (neither succeeded nor failed yet) still produces a permanent zero-audit-id version commit, even if the write goes on to succeed a moment later — this PR's `auditFailed` guard correctly avoids a false-positive toast for that case, but doesn't close the underlying race. Filed as its own scoped `task:` issue.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 1011 passing + 10 skipped (was 1003 + 10; +8 new)
- `npm run build` — clean

Closes #77

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsD2h5Jt3sHezDXDvQwjB8)_