### PR TITLE
fix(annotations): document and lock in the audit-linkage race

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -71,16 +71,27 @@ scheme prevents their after-the-fact modification — but they are asserted by t
 time, not cryptographically signed by an independent authority. They are attribution records, not
 non-repudiable signatures.
 
-**Linkage to the audit ledger — including the failure path.** Versions of kind `apply` carry the
-ids of the audit records covering the underlying AI inference, a direct join to the Article 12
-audit ledger (`AuditLog`, written via the append-only `src/app/api/audit/route.ts` /
-`src/lib/audit/auditLogger.ts`). When an audit write fails at inference time, `resolver.ts` routes
-the `auditFailed` flag through `useAnnotationStore`'s `updateResolutionAuditStatus`/`updateMessage`
-actions (not a bare object mutation — a subscriber-notifying, persisted store write) and the UI
-surfaces it: a warning callout on the resolution card and on the conversation message it belongs
-to (`AnnotationCard.tsx`, `ConversationThread.tsx`), plus a toast at apply/decision time
-(`ResolutionActions.tsx`) when the linked version would otherwise carry **zero** audit ids or the
-human-oversight override record has nowhere to link to. The gap is surfaced, not papered over.
+**Linkage to the audit ledger — including the failure and race paths.** Versions of kind `apply`
+carry the ids of the audit records covering the underlying AI inference, a direct join to the
+Article 12 audit ledger (`AuditLog`, written via the append-only `src/app/api/audit/route.ts` /
+`src/lib/audit/auditLogger.ts`). The audit write is fire-and-forget (the apply path never awaits
+it, by design), so a version's audit linkage is a snapshot taken at apply time
+(`resolveApplyAuditIds` in `src/lib/annotations/applyAuditLinkage.ts`), not a guarantee the write
+ever completes first. Two distinct cases both leave a version with **zero** audit ids: the write
+fails — `resolver.ts` routes the `auditFailed` flag through `useAnnotationStore`'s
+`updateResolutionAuditStatus`/`updateMessage` actions and the UI surfaces it (a warning callout on
+the resolution card and on the conversation message it belongs to in `AnnotationCard.tsx` /
+`ConversationThread.tsx`, plus a toast in `ResolutionActions.tsx` — at apply time when the linked
+version would otherwise carry zero audit ids, or at decision time when a human-oversight override
+record has nowhere to link to) — or the write simply hasn't settled yet when the user applies,
+which has no UI signal and is indistinguishable from "will never succeed" at apply time. Neither
+case is backfilled if a pending write later
+succeeds — `DocCommit` is append-only, and there is no code path that attaches a late-arriving
+audit id to an already-created version. Both gaps are surfaced, not papered over; the race case is
+tracked as accepted-and-documented rather than closed, since closing it fully (awaiting the write
+before apply, or backfilling `auditIds` after the fact) would either add apply-path latency or
+require its own design pass on what, if anything, may mutate on an append-only record — see
+issue #83.
 
 **Retention.** Audit records carry a `dataRetentionDays` default of 2555 days (7 years);
 compliance-relevant document versions (`'import' | 'apply' | 'restore'`) are retained indefinitely

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -30,6 +30,7 @@ import { showAffectedMode } from '@/lib/annotations/showAffected'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { refreshAnchorAfterApply, refreshedAnchorForMultiRegionApply } from '@/lib/annotations/anchoring'
 import { createCommit } from '@/lib/history/commits'
+import { resolveApplyAuditIds } from '@/lib/annotations/applyAuditLinkage'
 import { recordInvariant, shouldCaptureInvariant } from '@/lib/invariants/captureInvariant'
 import { resolveInvariantFlagOnDismiss, runAndSurfaceInvariantChecks } from '@/lib/invariants/invariantCascade'
 import { classifyCheckKind } from '@/lib/invariants/invariantCheckRunner'
@@ -131,12 +132,12 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
   const recordApplyCommit = (blockIdsTouched: string[]) => {
     const currentView = useEditorStore.getState().view
     if (!currentView) return
-    const auditIds =
-      changeSet && changeSet.auditRecordIds.length > 0
-        ? changeSet.auditRecordIds
-        : annotation.resolution?.auditId
-          ? [annotation.resolution.auditId]
-          : []
+    // If the audit write hasn't settled yet (still in flight, neither
+    // auditId nor auditFailed set), this version is committed with zero
+    // audit ids and is never backfilled if the write later succeeds — a
+    // narrower, documented sibling of the auditFailed gap (see
+    // docs/compliance.md and #83).
+    const auditIds = resolveApplyAuditIds(changeSet?.auditRecordIds, annotation.resolution?.auditId)
     // Warn rather than silently apply with a zero-audit-links version — see
     // #77. Only fires when the write is KNOWN to have failed (auditFailed),
     // not merely still in flight (which would false-positive on a fast click).

--- a/src/lib/annotations/__tests__/applyAuditLinkage.pure.test.ts
+++ b/src/lib/annotations/__tests__/applyAuditLinkage.pure.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApplyAuditIds } from '../applyAuditLinkage'
+
+describe('resolveApplyAuditIds', () => {
+  it('prefers the change set audit record ids when present', () => {
+    expect(resolveApplyAuditIds(['audit-1', 'audit-2'], 'audit-3')).toEqual(['audit-1', 'audit-2'])
+  })
+
+  it('falls back to the resolution audit id when the change set has none yet', () => {
+    expect(resolveApplyAuditIds([], 'audit-3')).toEqual(['audit-3'])
+    expect(resolveApplyAuditIds(undefined, 'audit-3')).toEqual(['audit-3'])
+  })
+
+  it('a settled resolution.auditId (write succeeded before apply) is captured', () => {
+    expect(resolveApplyAuditIds(undefined, 'audit-late-but-settled')).toEqual(['audit-late-but-settled'])
+  })
+
+  it('a KNOWN-FAILED write and a STILL-IN-FLIGHT write both yield zero ids — documented gap, #83', () => {
+    // resolution.auditId is undefined in both cases (a failed write never gets
+    // one; a pending write hasn't received one yet) — this function has no
+    // input that could distinguish them, so both collapse to the same empty
+    // result. That collapse is the exact race #83 names: applying fast enough
+    // that the fire-and-forget logResolutionAudit promise hasn't resolved
+    // either way produces the same zero-audit-id version as an outright
+    // failure, and neither is backfilled once/if the write later succeeds.
+    // Locked in as documented behavior (docs/compliance.md), not a bug.
+    expect(resolveApplyAuditIds(undefined, undefined)).toEqual([])
+  })
+})

--- a/src/lib/annotations/applyAuditLinkage.ts
+++ b/src/lib/annotations/applyAuditLinkage.ts
@@ -1,0 +1,20 @@
+/**
+ * Which audit-ledger record ids a version commit should carry at apply time.
+ *
+ * `logResolutionAudit` (see `src/lib/ai/resolver.ts`) is fire-and-forget: the
+ * apply path never awaits it, so at the moment a version commit is created
+ * the write may be pending, failed, or already settled with an id. This
+ * function is pure so that "pending write -> zero ids at apply time" (the
+ * documented gap in `docs/compliance.md`) is a locked-in, tested outcome
+ * rather than an accident of call order. A write that settles AFTER the
+ * version already exists is not backfilled — see compliance.md.
+ */
+export function resolveApplyAuditIds(
+  changeSetAuditRecordIds: string[] | undefined,
+  resolutionAuditId: string | undefined,
+): string[] {
+  if (changeSetAuditRecordIds && changeSetAuditRecordIds.length > 0) {
+    return changeSetAuditRecordIds
+  }
+  return resolutionAuditId ? [resolutionAuditId] : []
+}


### PR DESCRIPTION
## Summary

`recordApplyCommit` in `src/components/Annotations/ResolutionActions.tsx` snapshots the `DocCommit` version's `auditIds` synchronously at apply time, from either the change set's `auditRecordIds` or `annotation.resolution?.auditId`. The audit-ledger write (`logResolutionAudit`) is fire-and-forget and never awaited before apply, by design (see the existing "never blocks the apply path" comment on `recordApplyCommit`).

PR #81 (closing #77) added a toast for the *known-failed* case (`auditFailed === true`). Issue #83 named a narrower, distinct race: if the user applies fast enough that the audit write hasn't settled **at all** yet (neither `auditId` nor `auditFailed` set), the resulting version commit still gets zero audit ids — permanently, since `DocCommit` is append-only and nothing ever backfills a late-arriving audit id onto an already-created version. There is no UI signal for this case (it's indistinguishable from "will never succeed" at the moment of apply).

## Approach

The issue offered three options. This PR takes **option 3 — accept and document**, for two concrete reasons:
1. **Option 1 (await the write before apply)** would contradict the codebase's explicit, already-stated design: `recordApplyCommit` is deliberately fire-and-forget so the apply path is never blocked on a network write.
2. **Option 2 (backfill a late-arriving auditId)** would require patching an already-created `DocCommit`, which is intentionally append-only per `docs/compliance.md` — the issue itself says this "needs its own design pass," which is out of scope for a P3 fix.

### Changes

- Extracted the inline audit-id-selection ternary out of `recordApplyCommit` into a pure, tested function: `resolveApplyAuditIds` (`src/lib/annotations/applyAuditLinkage.ts`). Behavior is unchanged — verified against `origin/main`'s original inline expression.
- Added `src/lib/annotations/__tests__/applyAuditLinkage.pure.test.ts`, covering the change-set-present, change-set-empty-but-resolution-settled, and both-empty (the #83 race) cases. The last test's comment is explicit that the function's inputs can't distinguish "known-failed" from "still-in-flight" — both collapse to `[]` by construction, and that collapse *is* the documented gap.
- Extended the "Linkage to the audit ledger" section of `docs/compliance.md` to describe the race explicitly (previously it only described the known-failure case), citing #83 as the tracking issue for why it isn't closed further.

The pre-existing `auditFailed` toast in `recordApplyCommit` (apply time) and the separate decision-time toast in `handleAction` (human-oversight override has nowhere to link to) are both untouched — only the id-selection logic was extracted.

## Adversarial review

Ran a troublemaker review before pushing. First pass returned **NO-MERGE**: it caught that my `compliance.md` rewrite had silently dropped the decision-time toast's description (the pre-existing "...or the human-oversight override record has nowhere to link to" clause), which would have been a real documentation regression in a PR whose whole point is documentation accuracy. Fixed by restoring that clause alongside the new race-path text. Second pass confirmed: extraction fidelity verified against `origin/main`, test coverage is honest (no overclaiming), no other `createCommit(kind: 'apply', ...)` call site exists elsewhere in the codebase, and the newer Document Invariant Ledger capture logic added below this block keys off the commit hash, not `auditIds`, so there's no interaction with this race.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 1015 passing + 10 skipped (was 1014 + 10 on `main`; +1 net test file)

Closes #83

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJLKgB8a3E47npqS9nEXsu)_