### PR TITLE
fix(mermaid): stop a failed retry from replacing a real answer

### DIFF
--- a/src/lib/ai/__tests__/mermaidGuard.test.ts
+++ b/src/lib/ai/__tests__/mermaidGuard.test.ts
@@ -170,4 +170,20 @@ describe('ensureRenderableMermaid', () => {
     expect(result).toBe(degradeMermaidToProse(original))
     expect(retry).toHaveBeenCalledTimes(1)
   })
+
+  // A 200 response with blank/missing content is not something a caller can
+  // throw on (the request itself succeeded) — the guard must not trust it as
+  // a deliberate plain-prose answer, or it silently discards the original.
+  it.each([
+    ['empty string', ''],
+    ['whitespace only', '   \n  '],
+    ['null', null],
+    ['undefined', undefined],
+  ])('a retry resolving to %s degrades the original instead of returning it', async (_label, value) => {
+    const retry = vi.fn(async () => value as unknown as string)
+    const original = fenced(INVALID)
+    const result = await ensureRenderableMermaid(original, retry)
+    expect(result).toBe(degradeMermaidToProse(original))
+    expect(retry).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/lib/ai/__tests__/resolverContinueThreadFailure.test.ts
+++ b/src/lib/ai/__tests__/resolverContinueThreadFailure.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation } from '@/lib/annotations/types'
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+vi.mock('@/lib/audit/auditLogger', () => ({
+  logResolutionAudit: vi.fn().mockResolvedValue('audit-1'),
+}))
+
+function makeAnnotation(): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:1:10',
+    type: 'flag',
+    status: 'resolved',
+    transcript: 'Original question',
+    anchor: { from: 1, to: 5, scope: 'sentence', text: 'Some text' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 100,
+    resolvedAt: 200,
+    verbosity: 'normal',
+  }
+}
+
+function makeEditorState(): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Some text here.')]),
+  ])
+  return EditorState.create({ schema, doc })
+}
+
+async function loadResolver() {
+  vi.resetModules()
+  return import('@/lib/ai/resolver')
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('continueThread requestFailed signal', () => {
+  it('flags requestFailed when /api/resolve responds non-ok', async () => {
+    const resolver = await loadResolver()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'boom', json: async () => ({}) }),
+    )
+
+    const message = await resolver.continueThread(makeAnnotation(), 'follow-up', makeEditorState())
+
+    expect(message.requestFailed).toBe(true)
+    expect(message.content).toContain('Error:')
+  })
+
+  it('flags requestFailed when the fetch itself rejects', async () => {
+    const resolver = await loadResolver()
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+    const message = await resolver.continueThread(makeAnnotation(), 'follow-up', makeEditorState())
+
+    expect(message.requestFailed).toBe(true)
+    expect(message.content).toContain('network down')
+  })
+
+  it('leaves requestFailed unset on a successful reply, including one that reads like an error', async () => {
+    const resolver = await loadResolver()
+    // A model is free to answer with prose beginning "Error:" — content alone
+    // cannot distinguish a real answer from the catch block's placeholder,
+    // which is exactly why the flag exists.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        statusText: 'OK',
+        json: async () => ({ content: 'Error: is the wrong word here.', responseId: 'resp-1' }),
+      }),
+    )
+
+    const message = await resolver.continueThread(makeAnnotation(), 'follow-up', makeEditorState())
+
+    expect(message.requestFailed).toBeUndefined()
+    expect(message.content).toBe('Error: is the wrong word here.')
+  })
+})

--- a/src/lib/ai/mermaidGuard.ts
+++ b/src/lib/ai/mermaidGuard.ts
@@ -65,6 +65,11 @@ export function degradeMermaidToProse(content: string): string {
  *   returns replacement content): a retry whose fence validates — or that
  *   has no fence at all (plain-prose fallback) — wins; anything else
  *   degrades the ORIGINAL content's fence to a plain code block.
+ *
+ * Callback contract: `retry` MUST throw when its underlying request failed.
+ * A returned fence-less string is trusted as a deliberate plain-prose answer,
+ * so returning an error-shaped string instead of throwing silently replaces
+ * the original answer with it.
  */
 export async function ensureRenderableMermaid(
   content: string,

--- a/src/lib/ai/mermaidGuard.ts
+++ b/src/lib/ai/mermaidGuard.ts
@@ -63,13 +63,16 @@ export function degradeMermaidToProse(content: string): string {
  * - fence validates → content as-is;
  * - otherwise retry ONCE (the callback receives the parse error text and
  *   returns replacement content): a retry whose fence validates — or that
- *   has no fence at all (plain-prose fallback) — wins; anything else
- *   degrades the ORIGINAL content's fence to a plain code block.
+ *   has non-blank fence-less text (plain-prose fallback) — wins; anything
+ *   else degrades the ORIGINAL content's fence to a plain code block.
  *
  * Callback contract: `retry` MUST throw when its underlying request failed.
  * A returned fence-less string is trusted as a deliberate plain-prose answer,
  * so returning an error-shaped string instead of throwing silently replaces
- * the original answer with it.
+ * the original answer with it. As a second line of defense (a 200 response
+ * with blank/missing content is not a "request failed" a caller can throw
+ * on), a retry that is not a non-blank string is treated the same as a
+ * thrown retry rather than trusted.
  */
 export async function ensureRenderableMermaid(
   content: string,
@@ -85,6 +88,9 @@ export async function ensureRenderableMermaid(
   try {
     retried = await retry(result.error)
   } catch {
+    return degradeMermaidToProse(content)
+  }
+  if (typeof retried !== 'string' || retried.trim() === '') {
     return degradeMermaidToProse(content)
   }
 

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -667,6 +667,7 @@ ${annotation.type === 'edit'
       content: `Error: ${err instanceof Error ? err.message : 'Thread continuation failed'}. Please try again.`,
       suggestedEdit: null,
       timestamp: Date.now(),
+      requestFailed: true,
     }
   }
 }

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -52,6 +52,13 @@ export interface ConversationMessage {
   auditId?: string
   /** Set when the compliance audit-log write failed, so the UI can flag incomplete coverage */
   auditFailed?: boolean
+  /**
+   * Set when the underlying request failed and `content` is a synthesized error
+   * string rather than a model reply. Callers that branch on the answer (rather
+   * than just displaying it) must check this — the error text is otherwise
+   * indistinguishable from a real one-line answer.
+   */
+  requestFailed?: boolean
 }
 
 export interface Annotation {

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -53,10 +53,13 @@ export interface ConversationMessage {
   /** Set when the compliance audit-log write failed, so the UI can flag incomplete coverage */
   auditFailed?: boolean
   /**
-   * Set when the underlying request failed and `content` is a synthesized error
-   * string rather than a model reply. Callers that branch on the answer (rather
-   * than just displaying it) must check this — the error text is otherwise
-   * indistinguishable from a real one-line answer.
+   * Set by `continueThread` (src/lib/ai/resolver.ts) when its `/api/resolve`
+   * request failed and `content` is a synthesized error string rather than a
+   * model reply — the error text is otherwise indistinguishable from a real
+   * one-line answer. NOT currently set by every function that can return an
+   * error-shaped message (e.g. `streamResolveAnnotation`'s own catch, or
+   * `simplifyThread`, which returns a bare string with no way to flag this at
+   * all) — a caller consuming one of those must not assume the same coverage.
    */
   requestFailed?: boolean
 }

--- a/src/lib/voice/__tests__/pipeline.capture.test.ts
+++ b/src/lib/voice/__tests__/pipeline.capture.test.ts
@@ -108,6 +108,8 @@ interface FetchStubOptions {
   streamText?: string
   /** Respond non-ok to ONLY the mermaid-guard's correction retry. */
   failMermaidRetry?: boolean
+  /** Respond 200 with blank content to ONLY the mermaid-guard's correction retry. */
+  blankMermaidRetry?: boolean
 }
 
 function makeFetchStub(options: FetchStubOptions = {}) {
@@ -137,11 +139,20 @@ function makeFetchStub(options: FetchStubOptions = {}) {
       const userContent = (body?.messages ?? [])
         .map((m: { content: string }) => m.content)
         .join('\n')
-      if (
-        options.failMermaidRetry &&
-        userContent.includes('The mermaid diagram failed to parse')
-      ) {
+      // Only the mermaid-guard's non-streamed correction retry carries this
+      // phrase as its LAST message — check the last message specifically so
+      // a later, unrelated request whose history merely contains a prior
+      // correction can't be mistaken for the retry itself.
+      const isMermaidRetry =
+        !body?.stream &&
+        String((body?.messages ?? []).at(-1)?.content ?? '').includes(
+          'The mermaid diagram failed to parse',
+        )
+      if (options.failMermaidRetry && isMermaidRetry) {
         return { ok: false, status: 500, statusText: 'retry boom', json: async () => ({}) }
+      }
+      if (options.blankMermaidRetry && isMermaidRetry) {
+        return jsonResponse({ content: '', responseId: 'test-resp-1' })
       }
       // MADS branch shapes — mirrored from tests/cascade-review.spec.ts
       let content: string
@@ -573,6 +584,12 @@ describe('(g) mermaid guard on resolution content', () => {
         ),
     )
     expect(retries).toHaveLength(1)
+    // The correction prompt must carry the actual broken diagram source —
+    // otherwise the model is asked to fix a diagram it has never seen.
+    const retryMessages = retries[0].body?.messages ?? []
+    expect(
+      retryMessages.some((m: { content: string }) => m.content.includes('grph BROKEN')),
+    ).toBe(true)
 
     const content = getAnnotation(id).resolution?.content ?? ''
     expect(content).not.toContain('```mermaid')
@@ -603,6 +620,27 @@ describe('(g) mermaid guard on resolution content', () => {
     expect(content).toContain('Here is the flow:')
     expect(content).toContain('One caption.')
     // Degraded, not raw: the broken source survives as a plain code block.
+    expect(content).not.toContain('```mermaid')
+    expect(content).toContain('```\ngrph BROKEN\n```')
+  })
+
+  it('a retry that resolves 200 with blank content degrades the ORIGINAL answer instead of returning blank', async () => {
+    const INVALID_DIAGRAM = 'Here is the flow:\n\n```mermaid\ngrph BROKEN\n```\n\nOne caption.'
+    // A blank-but-ok retry is not something the caller can throw on — the
+    // guard itself must refuse to trust it as a deliberate plain-prose reply.
+    const { stub } = makeFetchStub({ streamText: INVALID_DIAGRAM, blankMermaidRetry: true })
+    vi.stubGlobal('fetch', stub)
+
+    const id = captureAndResolveInBackground('dig', 'diagram this', FROM, TO, {
+      suggestedType: 'dig',
+      skipClassify: true,
+    })!
+    await waitFor(() => getAnnotation(id).status === 'resolved')
+
+    const content = getAnnotation(id).resolution?.content ?? ''
+    expect(content).toBeTruthy()
+    expect(content).toContain('Here is the flow:')
+    expect(content).toContain('One caption.')
     expect(content).not.toContain('```mermaid')
     expect(content).toContain('```\ngrph BROKEN\n```')
   })

--- a/src/lib/voice/__tests__/pipeline.capture.test.ts
+++ b/src/lib/voice/__tests__/pipeline.capture.test.ts
@@ -106,6 +106,8 @@ interface FetchStubOptions {
   resolveGate?: Promise<void>
   /** Content for streamed (SSE) resolutions. */
   streamText?: string
+  /** Respond non-ok to ONLY the mermaid-guard's correction retry. */
+  failMermaidRetry?: boolean
 }
 
 function makeFetchStub(options: FetchStubOptions = {}) {
@@ -135,6 +137,12 @@ function makeFetchStub(options: FetchStubOptions = {}) {
       const userContent = (body?.messages ?? [])
         .map((m: { content: string }) => m.content)
         .join('\n')
+      if (
+        options.failMermaidRetry &&
+        userContent.includes('The mermaid diagram failed to parse')
+      ) {
+        return { ok: false, status: 500, statusText: 'retry boom', json: async () => ({}) }
+      }
       // MADS branch shapes — mirrored from tests/cascade-review.spec.ts
       let content: string
       if (userContent.includes('Find every edge case')) {
@@ -573,6 +581,30 @@ describe('(g) mermaid guard on resolution content', () => {
     // Presentation-layer message carries the degraded content too.
     const lastAgent = [...getAnnotation(id).conversation].reverse().find((m) => m.role === 'agent')
     expect(lastAgent?.content).toBe(content)
+  })
+
+  it('a retry whose own /api/resolve call fails degrades the ORIGINAL answer instead of replacing it with the error string', async () => {
+    const INVALID_DIAGRAM = 'Here is the flow:\n\n```mermaid\ngrph BROKEN\n```\n\nOne caption.'
+    // continueThread reports a failed /api/resolve as an error-shaped message
+    // rather than throwing. That message carries no mermaid fence, so before
+    // the requestFailed signal existed the guard read it as a deliberate
+    // plain-prose retry and returned it as the final answer.
+    const { stub } = makeFetchStub({ streamText: INVALID_DIAGRAM, failMermaidRetry: true })
+    vi.stubGlobal('fetch', stub)
+
+    const id = captureAndResolveInBackground('dig', 'diagram this', FROM, TO, {
+      suggestedType: 'dig',
+      skipClassify: true,
+    })!
+    await waitFor(() => getAnnotation(id).status === 'resolved')
+
+    const content = getAnnotation(id).resolution?.content ?? ''
+    expect(content).not.toContain('Thread continuation failed')
+    expect(content).toContain('Here is the flow:')
+    expect(content).toContain('One caption.')
+    // Degraded, not raw: the broken source survives as a plain code block.
+    expect(content).not.toContain('```mermaid')
+    expect(content).toContain('```\ngrph BROKEN\n```')
   })
 
   it('content without a fence never touches the guard (no retry calls)', async () => {

--- a/src/lib/voice/pipeline.ts
+++ b/src/lib/voice/pipeline.ts
@@ -314,6 +314,12 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
           async (parseError) => {
             const correction = `The mermaid diagram failed to parse: ${parseError}. Reply with either a corrected single \`\`\`mermaid block or plain prose.`
             const message = await continueThread(current, correction, view.state)
+            // continueThread reports a failed /api/resolve call as an
+            // error-shaped message rather than throwing. Returning it would
+            // read as a fence-less "plain prose" retry and replace the real
+            // answer with the error text — throw so the guard degrades the
+            // ORIGINAL content instead.
+            if (message.requestFailed) throw new Error(message.content)
             return message.content
           },
         )

--- a/src/lib/voice/pipeline.ts
+++ b/src/lib/voice/pipeline.ts
@@ -312,8 +312,15 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
         resolution.content = await ensureRenderableMermaid(
           resolution.content,
           async (parseError) => {
-            const correction = `The mermaid diagram failed to parse: ${parseError}. Reply with either a corrected single \`\`\`mermaid block or plain prose.`
-            const message = await continueThread(current, correction, view.state)
+            // The stale `current` snapshot's conversation predates the
+            // streamed answer (it only holds the empty placeholder message
+            // added above) — continueThread would ask the model to correct
+            // a diagram it has never seen. Read the live annotation and
+            // inline the broken source directly into the correction prompt.
+            const fresh = annotationStore.getById(id) ?? current
+            const brokenSource = extractMermaidFence(resolution.content)?.code ?? ''
+            const correction = `The mermaid diagram failed to parse: ${parseError}.\n\nHere is the diagram source:\n\`\`\`\n${brokenSource}\n\`\`\`\n\nReply with either a corrected single \`\`\`mermaid block or plain prose.`
+            const message = await continueThread(fresh, correction, view.state)
             // continueThread reports a failed /api/resolve call as an
             // error-shaped message rather than throwing. Returning it would
             // read as a fence-less "plain prose" retry and replace the real


### PR DESCRIPTION
## Summary

`ensureRenderableMermaid` (`src/lib/ai/mermaidGuard.ts`) retries once when a ```` ```mermaid ```` fence fails to parse, and trusts a fence-less retry as a deliberate "the model chose plain prose" answer. Its only real caller (`src/lib/voice/pipeline.ts`'s mermaid guard) retries via `continueThread` (`src/lib/ai/resolver.ts`), which does **not** throw when its own `/api/resolve` call fails — its outer `catch` returns a message whose `content` is the plain string `"Error: Thread continuation failed: ... Please try again."`. That string has no fence either, so the guard returned it as the final answer, **silently discarding the ORIGINAL, imperfect-but-real answer** that had failed only its diagram validation. This is stricter than the guard's own documented contract ("the guard must never block or lose an answer").

## Fix

- `ConversationMessage` (`src/lib/annotations/types.ts`) gains an optional `requestFailed?: boolean`, mirroring the existing `auditFailed` pattern. Set in `continueThread`'s outer catch.
- `pipeline.ts`'s mermaid retry callback throws when `message.requestFailed` is set, so the guard's pre-existing `try/catch` around `retry()` degrades the ORIGINAL content — the path that was already correct for a thrown retry.
- No signature change to `continueThread` (deliberate — avoids conflicting with #85, which independently adds a 4th parameter to the same function).

## Adversarial review — NO-MERGE, two HIGH findings, both fixed before push

Ran a troublemaker review before pushing. First pass returned **NO-MERGE**: the fix above closes the reported symptom but not the whole defect class named in #86.

1. **HIGH — a retry resolving 200 with blank/null/undefined content was still trusted as deliberate plain prose.** Not every failure throws: a provider empty completion, an OpenAI refusal (`message.content: null`), or an Anthropic extended-thinking response (`content[0]` is a `thinking` block, `.text` is `undefined`) all return `ok: true` with unusable content — no caller can throw on a "successful" empty response. Reproduced concretely (dumped `resolution.content` for `''`/`null`/`undefined` retries: all three destroyed the real answer, and `null`/`undefined` additionally crashed `episodeIngestion.ts`'s `buildEpisodeBody` and wrote `null`/`undefined` into the persisted annotation store). **Fixed in the guard itself** (not just the caller): a non-string or blank-after-trim retry is now treated the same as a thrown retry.
2. **HIGH — the retry never actually saw the broken diagram.** The callback closed over a pre-stream annotation snapshot (`current`), whose conversation held only the empty streaming placeholder — the broken mermaid source was never included in the correction prompt. The model was asked to fix a diagram it had never seen, so a short fence-less "I don't have the diagram" reply was the *normal* outcome, not an edge case — and the guard trusted it as the final answer. **Fixed** by reading the live annotation from the store and inlining the broken source directly into the correction prompt.

Both are now covered by regression tests confirmed to fail against the pre-fix code (verified locally by reverting each fix independently and re-running).

**Descoped, not folded in:** review surfaced a related but distinct, worse-blast-radius bug — `simplifyThread` has no failure signal at all, and its sole caller (`ResolutionActions.tsx`'s "Simplify" button) unconditionally overwrites the entire persisted conversation with the request's return value, so a failed request permanently destroys the whole thread with no HITL gate. Different function, not touched by this diff — filed as **#88**.

## Verification

- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 1020 passing + 10 skipped (was 1015 + 10 on `main`)

Closes #86

---
_Generated by [Claude Code](https://claude.ai/code/session_016vQeLFumPV29fcKp9hzpBT)_