### PR TITLE
Fix three P0 review-UI rendering defects (title/pill overlap, hidden map markers, whole-paragraph diff)

### DIFF
--- a/src/components/Annotations/AnnotationMap.tsx
+++ b/src/components/Annotations/AnnotationMap.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { markUserActivated } from '@/lib/voice/pipeline'
+import { clusterMarkers } from '@/lib/annotations/clusterMarkers'
 import { ANNOTATION_COLORS } from '@/lib/annotations/types'
 
 export function AnnotationMap() {
@@ -13,6 +14,7 @@ export function AnnotationMap() {
   const setActive = useAnnotationStore((s) => s.setActive)
   const view = useEditorStore((s) => s.view)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
+  const [openClusterIndex, setOpenClusterIndex] = useState<number | null>(null)
   const visibleAnnotations = useMemo(
     () => annotations.filter((annotation) => annotation.documentId === activeDocumentId),
     [activeDocumentId, annotations]
@@ -20,7 +22,6 @@ export function AnnotationMap() {
 
   const docLength = view?.state.doc.content.size ?? 1
 
-  // Group annotations by rough position (within 5% of doc length)
   const markers = useMemo(() => {
     return visibleAnnotations.map((a) => ({
       id: a.id,
@@ -31,10 +32,21 @@ export function AnnotationMap() {
     }))
   }, [visibleAnnotations, docLength, activeId])
 
-  const handleClick = (id: string) => {
+  // Markers within 5% of doc length of each other collapse into one cluster
+  // with a count badge, so co-located annotations stay reachable instead of
+  // rendering at pixel-identical positions where only the topmost is clickable.
+  const clusters = useMemo(() => clusterMarkers(markers), [markers])
+
+  // A stale index after the cluster list reshapes would open the wrong popover.
+  useEffect(() => {
+    setOpenClusterIndex(null)
+  }, [clusters.length, activeDocumentId])
+
+  const handleSelect = (id: string) => {
     // Map-marker selection is user attention — clear the capture mark.
     markUserActivated(id)
     setActive(id)
+    setOpenClusterIndex(null)
     if (view) {
       const ann = visibleAnnotations.find((a) => a.id === id)
       if (ann) {
@@ -66,22 +78,65 @@ export function AnnotationMap() {
       {/* Vertical track */}
       <div className="absolute left-1/2 top-2 bottom-2 w-px bg-border -translate-x-1/2" />
 
-      {/* Markers */}
-      {markers.map((m) => (
-        <button
-          key={m.id}
-          onClick={() => handleClick(m.id)}
-          title={m.label}
-          className={`absolute left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm transition-transform hover:scale-150 ${
-            m.isActive ? 'scale-150 ring-2 ring-offset-1' : ''
-          }`}
-          style={{
-            top: `${Math.max(2, Math.min(98, m.position * 100))}%`,
-            backgroundColor: ANNOTATION_COLORS[m.type],
-            '--tw-ring-color': m.isActive ? ANNOTATION_COLORS[m.type] : undefined,
-          } as React.CSSProperties}
-        />
-      ))}
+      {/* Markers — one dot per cluster */}
+      {clusters.map((cluster, index) => {
+        const top = `${Math.max(2, Math.min(98, cluster.position * 100))}%`
+        const hasActive = cluster.members.some((m) => m.isActive)
+
+        if (cluster.members.length === 1) {
+          const m = cluster.members[0]
+          return (
+            <button
+              key={m.id}
+              onClick={() => handleSelect(m.id)}
+              title={m.label}
+              className={`absolute left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm transition-transform hover:scale-150 ${
+                m.isActive ? 'scale-150 ring-2 ring-offset-1' : ''
+              }`}
+              style={{
+                top,
+                backgroundColor: ANNOTATION_COLORS[m.type],
+                '--tw-ring-color': m.isActive ? ANNOTATION_COLORS[m.type] : undefined,
+              } as React.CSSProperties}
+            />
+          )
+        }
+
+        const isOpen = openClusterIndex === index
+        return (
+          <div key={cluster.members[0].id} className="absolute left-1/2 -translate-x-1/2" style={{ top }}>
+            <button
+              onClick={() => setOpenClusterIndex(isOpen ? null : index)}
+              aria-expanded={isOpen}
+              title={`${cluster.members.length} annotations here`}
+              className={`flex h-5 w-5 items-center justify-center rounded-full border-2 border-white bg-ink text-[10px] font-mono font-semibold text-white shadow-sm transition-transform hover:scale-125 ${
+                hasActive || isOpen ? 'scale-125 ring-2 ring-offset-1 ring-ink/40' : ''
+              }`}
+            >
+              {cluster.members.length}
+            </button>
+            {isOpen && (
+              <div className="absolute left-6 top-0 z-20 w-44 rounded-xl border border-border/70 bg-white py-1 shadow-lg">
+                {cluster.members.map((m) => (
+                  <button
+                    key={m.id}
+                    onClick={() => handleSelect(m.id)}
+                    className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors hover:bg-warm ${
+                      m.isActive ? 'font-semibold' : ''
+                    }`}
+                  >
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: ANNOTATION_COLORS[m.type] }}
+                    />
+                    <span className="min-w-0 truncate">{m.label}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
 
       {/* Legend */}
       <div className="absolute bottom-0 left-0 right-0 flex justify-center gap-3 py-2 bg-white/80">

--- a/src/components/Changes/ChangesPanel.tsx
+++ b/src/components/Changes/ChangesPanel.tsx
@@ -74,7 +74,10 @@ export function ChangesPanel() {
             const expanded = expandedIds.has(changeSet.id)
             return (
               <div key={changeSet.id} className="px-4 py-4">
-                <div className="flex items-start justify-between gap-3">
+                {/* flex-wrap + basis-40: when the title and the pill cluster cannot
+                    share the row, the cluster drops to its own line instead of
+                    being painted over by the overflowing title. */}
+                <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
                   <button
                     onClick={() => {
                       setExpandedIds((prev) => {
@@ -84,20 +87,22 @@ export function ChangesPanel() {
                         return next
                       })
                     }}
-                    className="min-w-0 flex-1 text-left"
+                    className="min-w-0 flex-1 basis-40 text-left"
                   >
-                    <div className="flex items-center gap-2">
-                      <span className={`px-2 py-0.5 rounded text-[10px] font-mono ${STATUS_STYLES[changeSet.status]}`}>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className={`shrink-0 px-2 py-0.5 rounded text-[10px] font-mono ${STATUS_STYLES[changeSet.status]}`}>
                         {changeSet.status}
                       </span>
-                      <span className="text-sm font-medium text-ink">{changeSet.title}</span>
+                      <span className="min-w-0 truncate text-sm font-medium text-ink" title={changeSet.title}>
+                        {changeSet.title}
+                      </span>
                     </div>
                     <p className="mt-1 text-xs text-muted-foreground">
                       {changeSet.annotationIds.length} annotations, {changeSet.entries.length} applied changes, {changeSet.auditRecordIds.length} audit events
                     </p>
                   </button>
 
-                  <div className="flex flex-wrap justify-end gap-1">
+                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
                     {STATUS_OPTIONS.map((status) => (
                       <button
                         key={status}

--- a/src/components/Changes/DiffView.tsx
+++ b/src/components/Changes/DiffView.tsx
@@ -1,53 +1,67 @@
 'use client'
 
+import { useMemo } from 'react'
+import { computeWordDiff, type DiffChunk } from '@/lib/changes/diffEngine'
+
 interface DiffViewProps {
   before: string
   after: string
 }
 
-function NumberedLines({ text, prefix, lineClass, prefixClass }: {
-  text: string
-  prefix: string
-  lineClass: string
-  prefixClass: string
-}) {
-  const lines = text.split('\n')
+/**
+ * Word-level diff of a change slice. Unchanged runs render as plain text;
+ * only changed words carry the add/remove treatment, so a one-word edit
+ * reads as one marked word instead of a full repaint of both slices.
+ *
+ * No line-number gutter: the slices are document fragments, so any numbers
+ * here would be slice-relative and imply document positions they don't have.
+ */
+export function DiffView({ before, after }: DiffViewProps) {
+  const chunks = useMemo(() => computeWordDiff(before, after), [before, after])
+
   return (
-    <div className="font-mono text-xs">
-      {lines.map((line, i) => (
-        <div key={i} className={`flex gap-2 px-2.5 py-0.5 ${lineClass}`}>
-          <span className="text-muted-foreground/30 select-none w-5 text-right shrink-0">{i + 1}</span>
-          <span className={`${prefixClass} shrink-0 select-none`}>{prefix}</span>
-          <span className={prefixClass}>{line || ' '}</span>
-        </div>
-      ))}
+    <div className="rounded-xl border border-border/70 overflow-hidden bg-white">
+      {before && (
+        <DiffSide
+          chunks={chunks}
+          side="before"
+          className={`bg-red-50/60 ${after ? 'border-b border-border/50' : ''}`}
+        />
+      )}
+      {after && <DiffSide chunks={chunks} side="after" className="bg-emerald-50/60" />}
     </div>
   )
 }
 
-export function DiffView({ before, after }: DiffViewProps) {
+function DiffSide({ chunks, side, className }: {
+  chunks: DiffChunk[]
+  side: 'before' | 'after'
+  className: string
+}) {
+  const marker = side === 'before' ? '-' : '+'
+  const markerClass = side === 'before' ? 'text-red-500/70' : 'text-emerald-600/70'
+  const visible = chunks.filter((c) => c.type !== (side === 'before' ? 'insert' : 'delete'))
+
   return (
-    <div className="rounded-xl border border-border/70 overflow-hidden bg-white">
-      {before && (
-        <div className="bg-red-50/60 border-b border-border/50">
-          <NumberedLines
-            text={before}
-            prefix="-"
-            lineClass=""
-            prefixClass="text-red-500/70"
-          />
-        </div>
-      )}
-      {after && (
-        <div className="bg-emerald-50/60">
-          <NumberedLines
-            text={after}
-            prefix="+"
-            lineClass=""
-            prefixClass="text-emerald-600/70"
-          />
-        </div>
-      )}
+    <div className={`flex gap-2 px-2.5 py-1.5 font-mono text-xs ${className}`}>
+      <span aria-hidden="true" className={`select-none shrink-0 ${markerClass}`}>
+        {marker}
+      </span>
+      <p className="min-w-0 whitespace-pre-wrap break-words text-ink/80">
+        {visible.map((chunk, index) =>
+          chunk.type === 'equal' ? (
+            <span key={index}>{chunk.text}</span>
+          ) : chunk.type === 'delete' ? (
+            <del key={index} className="rounded-sm bg-red-200/80 px-0.5 text-red-900 no-underline">
+              {chunk.text}
+            </del>
+          ) : (
+            <ins key={index} className="rounded-sm bg-emerald-200/80 px-0.5 text-emerald-900 no-underline">
+              {chunk.text}
+            </ins>
+          )
+        )}
+      </p>
     </div>
   )
 }

--- a/src/lib/annotations/__tests__/clusterMarkers.pure.test.ts
+++ b/src/lib/annotations/__tests__/clusterMarkers.pure.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { clusterMarkers, type MapMarker } from '../clusterMarkers'
+
+function marker(id: string, position: number, type: MapMarker['type'] = 'ask'): MapMarker {
+  return { id, type, position, label: id, isActive: false }
+}
+
+describe('clusterMarkers', () => {
+  it('keeps well-separated markers as singleton clusters', () => {
+    const input = [marker('a', 0.1), marker('b', 0.4), marker('c', 0.9)]
+    const clusters = clusterMarkers(input)
+    expect(clusters).toHaveLength(3)
+    expect(clusters.every((c) => c.members.length === 1)).toBe(true)
+    expect(clusters.map((c) => c.members[0].id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('merges markers at the exact same position into one cluster', () => {
+    const input = [marker('a', 0.25), marker('b', 0.25)]
+    const clusters = clusterMarkers(input)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].members.map((m) => m.id).sort()).toEqual(['a', 'b'])
+    expect(clusters[0].position).toBeCloseTo(0.25)
+  })
+
+  it('merges markers within the gap threshold and splits beyond it', () => {
+    const input = [marker('a', 0.1), marker('b', 0.13), marker('c', 0.2)]
+    const clusters = clusterMarkers(input, 0.05)
+    expect(clusters).toHaveLength(2)
+    expect(clusters[0].members.map((m) => m.id)).toEqual(['a', 'b'])
+    expect(clusters[1].members.map((m) => m.id)).toEqual(['c'])
+  })
+
+  it('preserves every marker: cluster sizes always sum to the input count', () => {
+    const input = [
+      marker('a', 0.02),
+      marker('b', 0.02),
+      marker('c', 0.05),
+      marker('d', 0.3),
+      marker('e', 0.31, 'edit'),
+      marker('f', 0.72, 'flag'),
+      marker('g', 0.99, 'dig'),
+    ]
+    const clusters = clusterMarkers(input)
+    const total = clusters.reduce((sum, c) => sum + c.members.length, 0)
+    expect(total).toBe(input.length)
+    const ids = clusters.flatMap((c) => c.members.map((m) => m.id)).sort()
+    expect(ids).toEqual(['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+  })
+
+  it('returns no clusters for no markers', () => {
+    expect(clusterMarkers([])).toEqual([])
+  })
+})

--- a/src/lib/annotations/clusterMarkers.ts
+++ b/src/lib/annotations/clusterMarkers.ts
@@ -1,0 +1,54 @@
+import type { AnnotationType } from './types'
+
+export interface MapMarker {
+  id: string
+  type: AnnotationType
+  /** Document position as a fraction of doc length, 0..1. */
+  position: number
+  label: string
+  isActive: boolean
+}
+
+export interface MarkerCluster {
+  /** Mean position of the members, 0..1 — where the cluster dot renders. */
+  position: number
+  /** Document order (ascending position). Never empty. */
+  members: MapMarker[]
+}
+
+/**
+ * Group markers whose positions fall within `minGapFraction` of the first
+ * marker in the group (single-pass over markers sorted by position), so
+ * markers that would render at overlapping pixels become one cluster with a
+ * count badge instead of occluding each other.
+ *
+ * Invariant: every input marker appears in exactly one cluster — the sum of
+ * cluster sizes always equals the input count.
+ */
+export function clusterMarkers(markers: MapMarker[], minGapFraction = 0.05): MarkerCluster[] {
+  if (markers.length === 0) return []
+
+  const sorted = [...markers].sort((a, b) => a.position - b.position)
+  const clusters: MarkerCluster[] = []
+  let members: MapMarker[] = [sorted[0]]
+  let anchor = sorted[0].position
+
+  const flush = () => {
+    const mean = members.reduce((sum, m) => sum + m.position, 0) / members.length
+    clusters.push({ position: mean, members })
+  }
+
+  for (let i = 1; i < sorted.length; i++) {
+    const marker = sorted[i]
+    if (marker.position - anchor <= minGapFraction) {
+      members.push(marker)
+    } else {
+      flush()
+      members = [marker]
+      anchor = marker.position
+    }
+  }
+  flush()
+
+  return clusters
+}

--- a/src/lib/changes/__tests__/diffEngine.pure.test.ts
+++ b/src/lib/changes/__tests__/diffEngine.pure.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { computeWordDiff } from '../diffEngine'
+
+function joined(chunks: ReturnType<typeof computeWordDiff>, side: 'before' | 'after'): string {
+  const skip = side === 'before' ? 'insert' : 'delete'
+  return chunks
+    .filter((c) => c.type !== skip)
+    .map((c) => c.text)
+    .join('')
+}
+
+describe('computeWordDiff', () => {
+  it('marks only the changed word inside a long sentence', () => {
+    const before =
+      'The Q3 budget allocates $2.4M to platform engineering, with the remainder split between growth marketing and customer success.'
+    const after =
+      'The Q3 budget allocates $2.8M to platform engineering, with the remainder split between growth marketing and customer success.'
+    const chunks = computeWordDiff(before, after)
+
+    const deletes = chunks.filter((c) => c.type === 'delete')
+    const inserts = chunks.filter((c) => c.type === 'insert')
+    expect(deletes).toEqual([{ type: 'delete', text: '$2.4M' }])
+    expect(inserts).toEqual([{ type: 'insert', text: '$2.8M' }])
+    // The shared prefix AND suffix survive as equal text — no repaint past the edit.
+    expect(joined(chunks, 'before')).toBe(before)
+    expect(joined(chunks, 'after')).toBe(after)
+  })
+
+  it('handles a pure insertion', () => {
+    const chunks = computeWordDiff('alpha gamma', 'alpha beta gamma')
+    expect(chunks.filter((c) => c.type === 'delete')).toEqual([])
+    expect(joined(chunks, 'before')).toBe('alpha gamma')
+    expect(joined(chunks, 'after')).toBe('alpha beta gamma')
+    expect(chunks.some((c) => c.type === 'insert' && c.text.includes('beta'))).toBe(true)
+  })
+
+  it('handles a pure deletion', () => {
+    const chunks = computeWordDiff('alpha beta gamma', 'alpha gamma')
+    expect(chunks.filter((c) => c.type === 'insert')).toEqual([])
+    expect(joined(chunks, 'before')).toBe('alpha beta gamma')
+    expect(joined(chunks, 'after')).toBe('alpha gamma')
+    expect(chunks.some((c) => c.type === 'delete' && c.text.includes('beta'))).toBe(true)
+  })
+
+  it('returns a single equal chunk for identical inputs', () => {
+    const text = 'nothing changed here at all'
+    expect(computeWordDiff(text, text)).toEqual([{ type: 'equal', text }])
+  })
+
+  it('handles empty sides', () => {
+    expect(computeWordDiff('', '')).toEqual([])
+    expect(computeWordDiff('', 'new text')).toEqual([{ type: 'insert', text: 'new text' }])
+    expect(computeWordDiff('old text', '')).toEqual([{ type: 'delete', text: 'old text' }])
+  })
+
+  it('reconstructs multi-line slices exactly on both sides', () => {
+    const before = 'line one\nline two\nline three'
+    const after = 'line one\nline 2\nline three'
+    const chunks = computeWordDiff(before, after)
+    expect(joined(chunks, 'before')).toBe(before)
+    expect(joined(chunks, 'after')).toBe(after)
+  })
+})

--- a/src/lib/changes/diffEngine.ts
+++ b/src/lib/changes/diffEngine.ts
@@ -1,31 +1,65 @@
-// Simple diff computation for displaying changes
+// Word-level diff for displaying changes.
 export interface DiffChunk {
   type: 'equal' | 'insert' | 'delete'
   text: string
 }
 
-export function computeSimpleDiff(before: string, after: string): DiffChunk[] {
-  // Simple word-level diff
-  const beforeWords = before.split(/(\s+)/)
-  const afterWords = after.split(/(\s+)/)
+/**
+ * Word-level diff via longest common subsequence over whitespace-separated
+ * tokens (whitespace runs are tokens too, so joins reproduce the originals
+ * exactly). Unchanged runs come back as 'equal' chunks, so a one-word edit
+ * marks one word — not everything after the first mismatch. Adjacent chunks
+ * of the same type are merged.
+ *
+ * Slices here are bounded (annotation-sized), so the O(n·m) table is fine.
+ */
+export function computeWordDiff(before: string, after: string): DiffChunk[] {
+  const beforeTokens = tokenize(before)
+  const afterTokens = tokenize(after)
+  const n = beforeTokens.length
+  const m = afterTokens.length
 
-  const chunks: DiffChunk[] = []
-  let i = 0
-  let j = 0
-
-  while (i < beforeWords.length || j < afterWords.length) {
-    if (i < beforeWords.length && j < afterWords.length && beforeWords[i] === afterWords[j]) {
-      chunks.push({ type: 'equal', text: beforeWords[i] })
-      i++
-      j++
-    } else if (i < beforeWords.length) {
-      chunks.push({ type: 'delete', text: beforeWords[i] })
-      i++
-    } else if (j < afterWords.length) {
-      chunks.push({ type: 'insert', text: afterWords[j] })
-      j++
+  // lcs[i][j] = LCS length of beforeTokens[i..] and afterTokens[j..]
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0))
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] =
+        beforeTokens[i] === afterTokens[j]
+          ? lcs[i + 1][j + 1] + 1
+          : Math.max(lcs[i + 1][j], lcs[i][j + 1])
     }
   }
 
+  const chunks: DiffChunk[] = []
+  const push = (type: DiffChunk['type'], text: string) => {
+    if (!text) return
+    const last = chunks[chunks.length - 1]
+    if (last && last.type === type) last.text += text
+    else chunks.push({ type, text })
+  }
+
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (beforeTokens[i] === afterTokens[j]) {
+      push('equal', beforeTokens[i])
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      push('delete', beforeTokens[i])
+      i++
+    } else {
+      push('insert', afterTokens[j])
+      j++
+    }
+  }
+  while (i < n) push('delete', beforeTokens[i++])
+  while (j < m) push('insert', afterTokens[j++])
+
   return chunks
+}
+
+function tokenize(text: string): string[] {
+  if (!text) return []
+  return text.split(/(\s+)/).filter((token) => token !== '')
 }


### PR DESCRIPTION
Executes the work order in #80. The `@claude` Action channel could not run it (five runs died at credential validation — `secrets.CLAUDE_CODE_OAUTH_TOKEN` resolves empty; see the issue thread), so the dispatching session implemented the order directly and delivers it here. Scope is exactly the order's: three fixes, three commits, nothing from the audit's P1–P4 queue.

## 1. Change-set title painted over the status pills — `ChangesPanel.tsx`

The header row was flex with no wrap: the four status pills claim 241px of a ~254px content box, the title button was squeezed to ~0px, and its unclipped contents painted across the pill cluster (84px of measured overlap at the 320px rail), which also made the pills intercept clicks aimed at the title.

**Changed class on the title row:** `min-w-0 flex-1 text-left` → `min-w-0 flex-1 basis-40 text-left`, inside a header row that gained `flex-wrap` (`flex flex-wrap items-start justify-between gap-x-3 gap-y-2`), with the title span now `min-w-0 truncate`.

**Why the overlap can no longer occur at 320px:** the title truncates inside a `min-w-0` chain so it can never paint outside its own button, and when title and pill cluster cannot share the row, `basis-40` + `flex-wrap` drops the cluster to its own line instead of squeezing the button to zero.

## 2. Map markers occluding each other — `AnnotationMap.tsx`

7 annotations rendered as 4 dots (3 pairs at pixel-identical positions, unreachable) while the legend counted 7. The docstring claimed grouping "within 5% of doc length"; none was implemented.

New pure function `clusterMarkers` (`src/lib/annotations/clusterMarkers.ts`) implements exactly that grouping. Multi-member clusters render as a count badge; clicking it opens a member list where each row selects and scrolls to its annotation. Every annotation is reachable, and the sum of cluster sizes always equals the annotation count (tested invariant), so map and legend can no longer disagree.

## 3. Whole-slice repaint in diffs — `DiffView.tsx` + `diffEngine.ts`

A one-word edit rendered as the full before-slice struck out above the full after-slice (~22 wrapped lines at 21 chars/line). `diffEngine.ts`'s dead `computeSimpleDiff` never resyncs after a mismatch, so it was replaced with `computeWordDiff`: an LCS over word tokens (whitespace preserved as tokens, so joins reproduce each slice exactly). `DiffView` now renders unchanged runs as plain text with only changed words marked. The line-number gutter is removed rather than fixed — both blocks restarted at 1, slice-relative, with unnumbered wrap lines: decorative numbering implying document positions it didn't have.

## Verification (all run locally on this branch)

- `npm ci` — clean
- `npm run test` — 1029 passed, 10 skipped (69 files; includes the 11 new tests in `diffEngine.pure.test.ts` and `clusterMarkers.pure.test.ts` covering the order's required cases: single changed word in a long sentence, pure insertion, pure deletion, identical input; no collisions, exact-position collision, sum-of-cluster-sizes invariant)
- `npm run typecheck` — 0 errors
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7

---
_Generated by [Claude Code](https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7)_