### PR TITLE
fix(pipeline): fail closed when the mermaid-retry annotation is deleted mid-flight

### DIFF
--- a/src/lib/voice/__tests__/pipeline.capture.test.ts
+++ b/src/lib/voice/__tests__/pipeline.capture.test.ts
@@ -46,6 +46,11 @@ vi.mock('mermaid', () => ({
   },
 }))
 
+// Imported after the mock above so this resolves to the same mocked module
+// instance validateMermaid's dynamic `await import('mermaid')` returns —
+// lets one test override `parse` for a single call via mockImplementationOnce.
+import mermaid from 'mermaid'
+
 vi.mock('@/lib/ai/resolver', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/ai/resolver')>()
   return {
@@ -697,6 +702,47 @@ describe('(g) mermaid guard on resolution content', () => {
     expect(
       getAnnotation(id).conversation.some((m) => 'auditFailed' in m),
     ).toBe(false)
+  })
+
+  it('an annotation removed between the stream resolving and the retry firing never sends a correction request for a diagram it never saw (#91)', async () => {
+    const INVALID_DIAGRAM = 'Here is the flow:\n\n```mermaid\ngrph BROKEN\n```\n\nOne caption.'
+    const { stub, calls } = makeFetchStub({ streamText: INVALID_DIAGRAM })
+    vi.stubGlobal('fetch', stub)
+
+    // The mermaid guard calls validateMermaid → mermaid.parse() BEFORE the
+    // pipeline's retry callback runs — the exact "between the stream
+    // finishing and the retry firing" window the issue describes. Deleting
+    // the annotation from inside this one-shot parse failure reproduces the
+    // real "user dismissed the card mid-flight" race deterministically,
+    // without a fixed sleep.
+    let targetId = ''
+    vi.mocked(mermaid.parse).mockImplementationOnce(async () => {
+      if (targetId) useAnnotationStore.getState().remove(targetId)
+      throw new Error('Parse error: bad node')
+    })
+
+    const id = captureAndResolveInBackground('dig', 'diagram this', FROM, TO, {
+      suggestedType: 'dig',
+      skipClassify: true,
+    })!
+    targetId = id
+
+    // The annotation is gone, so there is no `status === 'resolved'` to poll
+    // for — wait for the (only expected) initial /api/resolve call, then give
+    // an incorrect retry a window to have fired before asserting it didn't.
+    await waitFor(() => calls.some((c) => c.url.includes('/api/resolve')))
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(useAnnotationStore.getState().getById(id)).toBeUndefined()
+    const retryCalls = calls.filter(
+      (c) =>
+        c.url.includes('/api/resolve') &&
+        (c.body?.messages ?? []).some((m: { content: string }) =>
+          m.content.includes('The mermaid diagram failed to parse'),
+        ),
+    )
+    expect(retryCalls).toHaveLength(0)
+    expect(calls.filter((c) => c.url.includes('/api/resolve'))).toHaveLength(1)
   })
 })
 

--- a/src/lib/voice/pipeline.ts
+++ b/src/lib/voice/pipeline.ts
@@ -317,7 +317,15 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
             // added above) — continueThread would ask the model to correct
             // a diagram it has never seen. Read the live annotation and
             // inline the broken source directly into the correction prompt.
-            const fresh = annotationStore.getById(id) ?? current
+            // If the annotation was deleted mid-flight, there is no live
+            // snapshot to read — falling back to `current` would reintroduce
+            // that exact stale-conversation defect, so fail closed instead:
+            // throw, which ensureRenderableMermaid's contract degrades to
+            // the ORIGINAL (pre-correction-attempt) content.
+            const fresh = annotationStore.getById(id)
+            if (!fresh) {
+              throw new Error('Annotation was removed before the mermaid correction could be requested')
+            }
             const brokenSource = extractMermaidFence(resolution.content)?.code ?? ''
             const correction = `The mermaid diagram failed to parse: ${parseError}.\n\nHere is the diagram source:\n\`\`\`\n${brokenSource}\n\`\`\`\n\nReply with either a corrected single \`\`\`mermaid block or plain prose.`
             // This retry's message is discarded below (only .content is kept)


### PR DESCRIPTION
## Problem

PR #89's mermaid correction retry (`src/lib/voice/pipeline.ts`, inside `resolveCapturedAnnotation`) reads the *live* annotation instead of the stale pre-stream snapshot when building the correction prompt, because the stale snapshot's conversation never contained the broken diagram:

```ts
const fresh = annotationStore.getById(id) ?? current
```

Adversarial review of a later merge-conflict resolution on that same branch (2026-08-24) traced this fallback and found: if the annotation is deleted from the store between the stream finishing and the mermaid-retry firing (e.g. the user dismisses/deletes the annotation card mid-flight), `annotationStore.getById(id)` returns `undefined` and `fresh` silently falls back to `current` — the same stale pre-stream snapshot whose conversation never held the broken diagram. That reintroduces the exact "model asked to fix a diagram it never saw" defect PR #89 exists to close, for this one narrow timing window. Filed as #91.

## Fix

`src/lib/voice/pipeline.ts`: when `annotationStore.getById(id)` returns `undefined`, throw instead of falling back to `current`. This relies on `ensureRenderableMermaid`'s documented contract (`src/lib/ai/mermaidGuard.ts`): a thrown retry callback degrades the ORIGINAL content to plain prose via `degradeMermaidToProse` rather than trusting an unrelated reply — fail closed, not a silent stale-data leak.

## Tests

`src/lib/voice/__tests__/pipeline.capture.test.ts` (new case in the "(g) mermaid guard on resolution content" describe block): uses `vi.mocked(mermaid.parse).mockImplementationOnce(...)` to delete the annotation from the store at the exact moment `validateMermaid` calls `mermaid.parse()` — which the real `ensureRenderableMermaid` always runs *before* the pipeline's retry callback — deterministically reproducing the "deleted mid-flight" race without a fixed sleep. Asserts the annotation is gone, no fetch call ever carries "The mermaid diagram failed to parse" (no correction request built from a conversation that never saw the diagram), and exactly one `/api/resolve` call occurs (the initial stream only, no retry).

## Process

Ran an adversarial (troublemaker) review before pushing. Verdict: **MERGE**. It confirmed the race is closed, confirmed the test would fail against the pre-fix `?? current` fallback (a real second `/api/resolve` call would fire), found no other `getById(id) ?? current`-style stale-fallback sites elsewhere in the codebase, and confirmed the throw is caught internally by `ensureRenderableMermaid` with no stray toast or state corruption.

It also surfaced one adjacent, non-blocking gap out of this fix's scope: the flow-buffering block right after finalize (`pipeline.ts`, `holdAnswer(id, ...)`) runs unconditionally on the same pre-stream snapshot with no existence check, so *any* mid-resolution deletion (not just the mermaid race) can leave a permanently-dangling `heldAnswers[id]` entry. Filed as its own scoped follow-up: #95.

## Verification (all run locally on this branch)

- `npm ci` — clean
- `npm run typecheck` — 0 errors
- `npm run lint` — no warnings or errors
- `npm run test` — 1028 passed, 10 skipped (+1 new)
- `npm run build` — succeeds

Closes #91

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcmeVQUVubGHQt2UCvXfBz)_