### PR TITLE
Drag-resizable sidebar rail + one status control per change-set row (audit P1)

### DIFF
--- a/src/components/Changes/ChangesPanel.tsx
+++ b/src/components/Changes/ChangesPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useChangesStore } from '@/stores/changesStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { ChangeEntry } from './ChangeEntry'
@@ -21,6 +21,27 @@ export function ChangesPanel() {
   const updateChangeSetStatus = useChangesStore((s) => s.updateChangeSetStatus)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [statusMenuId, setStatusMenuId] = useState<string | null>(null)
+
+  // Status menu dismisses on outside click or Escape, like every other
+  // transient surface in the app.
+  useEffect(() => {
+    if (!statusMenuId) return
+    function handlePointerDown(e: MouseEvent) {
+      if (!(e.target as HTMLElement).closest('[data-status-menu]')) {
+        setStatusMenuId(null)
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setStatusMenuId(null)
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [statusMenuId])
 
   const { documentChangeSets, directEdits } = useMemo(() => {
     const documentEntries = entries.filter((entry) => entry.documentId === activeDocumentId)
@@ -89,33 +110,53 @@ export function ChangesPanel() {
                     }}
                     className="min-w-0 flex-1 basis-40 text-left"
                   >
-                    <div className="flex min-w-0 items-center gap-2">
-                      <span className={`shrink-0 px-2 py-0.5 rounded text-[10px] font-mono ${STATUS_STYLES[changeSet.status]}`}>
-                        {changeSet.status}
-                      </span>
-                      <span className="min-w-0 truncate text-sm font-medium text-ink" title={changeSet.title}>
-                        {changeSet.title}
-                      </span>
-                    </div>
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {changeSet.annotationIds.length} annotations, {changeSet.entries.length} applied changes, {changeSet.auditRecordIds.length} audit events
+                    <span className="block min-w-0 truncate text-sm font-medium text-ink" title={changeSet.title}>
+                      {changeSet.title}
+                    </span>
+                    <p
+                      className="mt-1 min-w-0 truncate text-xs text-muted-foreground"
+                      title={`${changeSet.annotationIds.length} annotations · ${changeSet.entries.length} applied changes · ${changeSet.auditRecordIds.length} audit events`}
+                    >
+                      {changeSet.annotationIds.length} annotations · {changeSet.entries.length} changes · {changeSet.auditRecordIds.length} audit
                     </p>
                   </button>
 
-                  <div className="flex shrink-0 flex-wrap justify-end gap-1">
-                    {STATUS_OPTIONS.map((status) => (
-                      <button
-                        key={status}
-                        onClick={() => updateChangeSetStatus(changeSet.id, status)}
-                        className={`px-2.5 py-1 text-[10px] font-mono rounded-full border transition-colors ${
-                          changeSet.status === status
-                            ? 'border-accent bg-accent/10 text-accent shadow-sm'
-                            : 'border-border/70 text-muted-foreground hover:text-ink hover:bg-warm/70'
-                        }`}
+                  {/* One status control per row: the current status is the
+                      trigger, the other states live behind it in a menu. */}
+                  <div className="relative shrink-0" data-status-menu>
+                    <button
+                      onClick={() => setStatusMenuId(statusMenuId === changeSet.id ? null : changeSet.id)}
+                      aria-haspopup="menu"
+                      aria-expanded={statusMenuId === changeSet.id}
+                      title="Change status"
+                      className={`flex items-center gap-1 rounded-full px-2.5 py-1 text-[10px] font-mono transition-opacity hover:opacity-80 ${STATUS_STYLES[changeSet.status]}`}
+                    >
+                      {changeSet.status}
+                      <span aria-hidden="true" className="text-[8px]">&#9662;</span>
+                    </button>
+                    {statusMenuId === changeSet.id && (
+                      <div
+                        role="menu"
+                        className="absolute right-0 top-full z-30 mt-1 min-w-[7rem] rounded-xl border border-border/70 bg-white py-1 shadow-lg"
                       >
-                        {status}
-                      </button>
-                    ))}
+                        {STATUS_OPTIONS.map((status) => (
+                          <button
+                            key={status}
+                            role="menuitem"
+                            onClick={() => {
+                              updateChangeSetStatus(changeSet.id, status)
+                              setStatusMenuId(null)
+                            }}
+                            className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-warm ${
+                              changeSet.status === status ? 'font-semibold text-accent' : 'text-ink'
+                            }`}
+                          >
+                            <span className={`h-2 w-2 rounded-full ${STATUS_STYLES[status]}`} />
+                            {status}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </div>
 

--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -18,6 +18,7 @@ import { ToastContainer } from '@/components/Layout/ToastContainer'
 import { FloatingIconBar } from '@/components/Editor/FloatingIconBar'
 import { CommandPalette } from '@/components/Layout/CommandPalette'
 import { useSettingsStore } from '@/stores/settingsStore'
+import { useLayoutStore, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH } from '@/stores/layoutStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { useVoiceStore } from '@/stores/voiceStore'
 import { useDocumentStore } from '@/stores/documentStore'
@@ -59,6 +60,30 @@ export function AppShell() {
   const [showCommandPalette, setShowCommandPalette] = useState(false)
   const [showAgentConfig, setShowAgentConfig] = useState(false)
   const showApiKeyModal = useSettingsStore((s) => s.showApiKeyModal)
+  const sidebarWidth = useLayoutStore((s) => s.sidebarWidth)
+  const setSidebarWidth = useLayoutStore((s) => s.setSidebarWidth)
+
+  // Drag-to-resize: pointer capture keeps move events on the handle even when
+  // the cursor leaves it; the store clamps every value, so drags can't strand
+  // the rail. Width persists via the layout store.
+  const startSidebarResize = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const handle = e.currentTarget
+    const startX = e.clientX
+    const startWidth = useLayoutStore.getState().sidebarWidth
+    handle.setPointerCapture(e.pointerId)
+    const onMove = (ev: PointerEvent) => {
+      useLayoutStore.getState().setSidebarWidth(startWidth + (ev.clientX - startX))
+    }
+    const stop = () => {
+      handle.removeEventListener('pointermove', onMove)
+      handle.removeEventListener('pointerup', stop)
+      handle.removeEventListener('pointercancel', stop)
+    }
+    handle.addEventListener('pointermove', onMove)
+    handle.addEventListener('pointerup', stop)
+    handle.addEventListener('pointercancel', stop)
+  }
   const isRecording = useVoiceStore((s) => s.isRecording)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
   const isDirty = useDocumentStore((s) => s.isDirty)
@@ -186,9 +211,11 @@ export function AppShell() {
     <div className="flex flex-col h-screen app-shell-backdrop">
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Left sidebar */}
+        {/* Left sidebar — width lives in layoutStore (drag the right edge, or
+            arrow keys on the focused handle) and persists across sessions */}
         {!isSidebarCollapsed ? (
-        <div className="w-80 border-r border-border/70 panel-shell flex flex-col shrink-0">
+        <div className="relative shrink-0" style={{ width: sidebarWidth }}>
+        <div className="h-full border-r border-border/70 panel-shell flex flex-col">
           {/* Sidebar tabs */}
           <div className="flex items-center border-b border-border/70 bg-white/55">
             {PRIMARY_TABS.map((tab) => (
@@ -271,6 +298,27 @@ export function AppShell() {
               <DocumentHubSidebar />
             )}
           </div>
+        </div>
+
+        {/* Resize handle */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize sidebar"
+          aria-valuemin={SIDEBAR_MIN_WIDTH}
+          aria-valuemax={SIDEBAR_MAX_WIDTH}
+          aria-valuenow={sidebarWidth}
+          tabIndex={0}
+          title="Drag to resize the sidebar"
+          onPointerDown={startSidebarResize}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+              e.preventDefault()
+              setSidebarWidth(sidebarWidth + (e.key === 'ArrowRight' ? 16 : -16))
+            }
+          }}
+          className="absolute -right-1 top-0 z-20 h-full w-2 cursor-col-resize rounded-full transition-colors hover:bg-accent/30 focus-visible:bg-accent/30 focus-visible:outline-none"
+        />
         </div>
         ) : (
           <div className="w-12 border-r border-border/70 panel-shell flex items-start justify-center py-4 shrink-0">

--- a/src/stores/__tests__/sidebarWidth.pure.test.ts
+++ b/src/stores/__tests__/sidebarWidth.pure.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clampSidebarWidth,
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+} from '../layoutStore'
+
+describe('clampSidebarWidth', () => {
+  it('passes through in-range widths, rounded to whole pixels', () => {
+    expect(clampSidebarWidth(320)).toBe(320)
+    expect(clampSidebarWidth(419.6)).toBe(420)
+  })
+
+  it('clamps below the minimum and above the maximum', () => {
+    expect(clampSidebarWidth(0)).toBe(SIDEBAR_MIN_WIDTH)
+    expect(clampSidebarWidth(-50)).toBe(SIDEBAR_MIN_WIDTH)
+    expect(clampSidebarWidth(10_000)).toBe(SIDEBAR_MAX_WIDTH)
+  })
+
+  it('falls back to the default for non-numeric or non-finite values', () => {
+    expect(clampSidebarWidth(undefined)).toBe(SIDEBAR_DEFAULT_WIDTH)
+    expect(clampSidebarWidth(null)).toBe(SIDEBAR_DEFAULT_WIDTH)
+    expect(clampSidebarWidth('340')).toBe(SIDEBAR_DEFAULT_WIDTH)
+    expect(clampSidebarWidth(Number.NaN)).toBe(SIDEBAR_DEFAULT_WIDTH)
+    expect(clampSidebarWidth(Number.POSITIVE_INFINITY)).toBe(SIDEBAR_DEFAULT_WIDTH)
+  })
+})

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -25,8 +25,24 @@ export function normalizeAnswerPlacement(value: unknown): AnswerPlacement {
     : 'sidebar'
 }
 
+export const SIDEBAR_MIN_WIDTH = 280
+export const SIDEBAR_MAX_WIDTH = 560
+export const SIDEBAR_DEFAULT_WIDTH = 320
+
+/**
+ * Map any persisted or in-flight value onto a usable sidebar width: numbers
+ * clamp into [MIN, MAX] and round to whole pixels; anything else (older
+ * snapshots without the field, corrupt values) falls back to the default.
+ */
+export function clampSidebarWidth(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return SIDEBAR_DEFAULT_WIDTH
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, Math.round(value)))
+}
+
 interface LayoutState {
   answerPlacement: AnswerPlacement
+  /** Width of the left sidebar rail in pixels, drag-resizable and persisted. */
+  sidebarWidth: number
   /**
    * Manual drag offset for the floating panel, in pixels from its computed
    * resting place. Session-scratch on purpose: a persisted offset taken from
@@ -35,6 +51,7 @@ interface LayoutState {
    */
   floatingOffset: { dx: number; dy: number }
   setAnswerPlacement: (placement: AnswerPlacement) => void
+  setSidebarWidth: (width: number) => void
   toggleAnswerPlacement: () => void
   setFloatingOffset: (offset: { dx: number; dy: number }) => void
   resetFloatingOffset: () => void
@@ -46,6 +63,7 @@ export const useLayoutStore = create<LayoutState>()(
   persist(
     (set) => ({
       answerPlacement: 'sidebar',
+      sidebarWidth: SIDEBAR_DEFAULT_WIDTH,
       floatingOffset: ZERO_OFFSET,
       // Changing placement always re-parks the panel: the offset was chosen
       // against the old layout and means nothing in the new one.
@@ -56,17 +74,19 @@ export const useLayoutStore = create<LayoutState>()(
           answerPlacement: s.answerPlacement === 'sidebar' ? 'floating' : 'sidebar',
           floatingOffset: ZERO_OFFSET,
         })),
+      setSidebarWidth: (width) => set({ sidebarWidth: clampSidebarWidth(width) }),
       setFloatingOffset: (offset) => set({ floatingOffset: offset }),
       resetFloatingOffset: () => set({ floatingOffset: ZERO_OFFSET }),
     }),
     {
       name: 'intent-ide-layout',
-      partialize: (s) => ({ answerPlacement: s.answerPlacement }),
+      partialize: (s) => ({ answerPlacement: s.answerPlacement, sidebarWidth: s.sidebarWidth }),
       onRehydrateStorage: () => (state) => {
         // A snapshot from an older build may carry a placement this one has
         // never heard of; fall back to the sidebar rather than render nothing.
         if (state) {
           state.answerPlacement = normalizeAnswerPlacement(state.answerPlacement)
+          state.sidebarWidth = clampSidebarWidth(state.sidebarWidth)
           state.floatingOffset = ZERO_OFFSET
         }
       },


### PR DESCRIPTION
Executes the P1 package from `docs/INTENT-IDE-DESIGN-AUDIT-2026-08.md` (overlord repo), per the operator's design call: **resize the rail rather than move diff detail to a separate full-width surface** — the word-level diff from #90 is what makes diffs readable at any rail width, so a resizable panel closes the squish without a second review surface. Delivered session-side like #90 (the Actions dispatch channel remains credential-blocked).

## Drag-resizable rail, width persisted

The rail was a fixed 320px (`w-80`) serving five panels with different information shapes. Its width now lives in `layoutStore`:

- `clampSidebarWidth` clamps to **[280, 560]**, rounds to whole pixels, and maps stale/corrupt persisted values to the 320 default — unit-tested (`sidebarWidth.pure.test.ts`).
- The width persists across sessions via the existing `intent-ide-layout` store.
- A pointer-capture drag handle sits on the rail's right edge; it is also keyboard-operable (`role="separator"`, focusable, arrow keys ±16px, `aria-value*` reporting the width).

## One status control per change-set row

The four always-on status pills (241px in a ~254px content box) were the force behind the squeeze — they wrapped to two rows and crowded the title even after #90's overlap fix. The current status is now the single control: a chip that opens a menu with the four states (outside-click/Escape dismissal, matching the app's other transient surfaces). The metadata line collapses to one truncated line (`2 annotations · 2 changes · 3 audit`) with the full text in its tooltip.

## Verification (run locally on this branch)

- `npm run test` — 1050 passed, 10 skipped (includes the new clamp tests)
- `npm run typecheck` — 0 errors
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds

Remaining P1 item deliberately not done: migrating diff detail to a full-width surface — declined by the operator's design call in favour of the resizable rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7

---
_Generated by [Claude Code](https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7)_