### PR TITLE
The map becomes the document map: headings spine + annotation clusters + read-line (audit P3.12)

### DIFF
--- a/src/components/Annotations/AnnotationMap.tsx
+++ b/src/components/Annotations/AnnotationMap.tsx
@@ -1,13 +1,26 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import type { Node as PMNode } from 'prosemirror-model'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useEditorStore } from '@/stores/editorStore'
 import { markUserActivated } from '@/lib/voice/pipeline'
 import { clusterMarkers } from '@/lib/annotations/clusterMarkers'
+import { collectHeadings, visibleHeadingLabels } from '@/lib/annotations/documentOutline'
+import { readLinePluginKey } from '@/lib/prosemirror/plugins/readLinePlugin'
 import { ANNOTATION_COLORS } from '@/lib/annotations/types'
 
+const HEADING_LABEL_CLASS: Record<number, string> = {
+  1: 'font-semibold text-ink',
+  2: 'text-ink/80',
+}
+
+/**
+ * The document map: headings form the spine, annotation clusters sit on it as
+ * markers, and the read-line shows how far the reader has gotten — document
+ * structure and review state in one proportional view.
+ */
 export function AnnotationMap() {
   const annotations = useAnnotationStore((s) => s.annotations)
   const activeId = useAnnotationStore((s) => s.activeAnnotationId)
@@ -15,12 +28,32 @@ export function AnnotationMap() {
   const view = useEditorStore((s) => s.view)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
   const [openClusterIndex, setOpenClusterIndex] = useState<number | null>(null)
+
+  // ProseMirror edits and read-line advances don't flow through a React store,
+  // so poll a snapshot; the identity bail-out below makes quiet ticks free.
+  const [snapshot, setSnapshot] = useState<{ doc: PMNode | null; readPos: number }>({
+    doc: null,
+    readPos: 0,
+  })
+  useEffect(() => {
+    if (!view) return
+    const read = () => {
+      if (view.isDestroyed) return
+      const doc = view.state.doc
+      const readPos = readLinePluginKey.getState(view.state)?.highWaterMark ?? 0
+      setSnapshot((prev) => (prev.doc === doc && prev.readPos === readPos ? prev : { doc, readPos }))
+    }
+    read()
+    const timer = setInterval(read, 1500)
+    return () => clearInterval(timer)
+  }, [view])
+
   const visibleAnnotations = useMemo(
     () => annotations.filter((annotation) => annotation.documentId === activeDocumentId),
     [activeDocumentId, annotations]
   )
 
-  const docLength = view?.state.doc.content.size ?? 1
+  const docLength = snapshot.doc?.content.size || 1
 
   const markers = useMemo(() => {
     return visibleAnnotations.map((a) => ({
@@ -37,50 +70,99 @@ export function AnnotationMap() {
   // rendering at pixel-identical positions where only the topmost is clickable.
   const clusters = useMemo(() => clusterMarkers(markers), [markers])
 
+  const headings = useMemo(() => (snapshot.doc ? collectHeadings(snapshot.doc) : []), [snapshot.doc])
+  const headingLabels = useMemo(() => visibleHeadingLabels(headings), [headings])
+  const readFraction = snapshot.readPos > 0 ? snapshot.readPos / docLength : 0
+
   // A stale index after the cluster list reshapes would open the wrong popover.
   useEffect(() => {
     setOpenClusterIndex(null)
   }, [clusters.length, activeDocumentId])
+
+  const scrollToPos = (pos: number) => {
+    if (!view) return
+    const coords = view.coordsAtPos(Math.min(pos, view.state.doc.content.size))
+    if (!coords) return
+    const container = view.dom.closest('.editor-scroll-container')
+    if (!container) return
+    const containerRect = container.getBoundingClientRect()
+    container.scrollTo({
+      top: container.scrollTop + (coords.top - containerRect.top) - 100,
+      behavior: 'smooth',
+    })
+  }
 
   const handleSelect = (id: string) => {
     // Map-marker selection is user attention — clear the capture mark.
     markUserActivated(id)
     setActive(id)
     setOpenClusterIndex(null)
-    if (view) {
-      const ann = visibleAnnotations.find((a) => a.id === id)
-      if (ann) {
-        const coords = view.coordsAtPos(ann.anchor.from)
-        if (coords) {
-          const container = view.dom.closest('.editor-scroll-container')
-          if (container) {
-            const containerRect = container.getBoundingClientRect()
-            container.scrollTo({
-              top: container.scrollTop + (coords.top - containerRect.top) - 100,
-              behavior: 'smooth',
-            })
-          }
-        }
-      }
-    }
+    const ann = visibleAnnotations.find((a) => a.id === id)
+    if (ann) scrollToPos(ann.anchor.from)
   }
 
-  if (visibleAnnotations.length === 0) {
+  if (!snapshot.doc) {
     return (
       <div className="flex items-center justify-center h-32 text-xs text-muted-foreground">
-        No annotations to map
+        No document open
       </div>
     )
   }
 
+  if (visibleAnnotations.length === 0 && headings.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-32 px-6 text-center text-xs text-muted-foreground">
+        Nothing to map yet — headings and annotations will appear here
+      </div>
+    )
+  }
+
+  const clamp = (fraction: number) => Math.max(2, Math.min(98, fraction * 100))
+
   return (
-    <div className="relative h-full min-h-[200px] px-3 py-2">
-      {/* Vertical track */}
+    <div className="relative h-full min-h-[260px] px-3 py-2">
+      {/* Vertical track — the document, top to bottom */}
       <div className="absolute left-1/2 top-2 bottom-2 w-px bg-border -translate-x-1/2" />
 
-      {/* Markers — one dot per cluster */}
+      {/* Read-line: how far the reader has gotten */}
+      {readFraction > 0 && (
+        <div
+          className="absolute inset-x-2 z-0"
+          style={{ top: `${clamp(readFraction)}%` }}
+          title="Read up to here"
+        >
+          <div className="border-t border-dashed border-accent/70" />
+          <span className="absolute right-0 -top-2 text-[8px] font-mono uppercase tracking-widest text-accent/80">
+            read
+          </span>
+        </div>
+      )}
+
+      {/* Headings — the spine, labels to the left of the track */}
+      {headings.map((heading, index) => (
+        <button
+          key={`${heading.pos}-${index}`}
+          onClick={() => scrollToPos(heading.pos)}
+          title={heading.text || '(untitled heading)'}
+          className="group absolute right-1/2 z-10 flex -translate-y-1/2 items-center gap-1.5 pr-0"
+          style={{ top: `${clamp(heading.position)}%` }}
+        >
+          {headingLabels[index] && (
+            <span
+              className={`max-w-[9rem] truncate text-right text-[10px] leading-tight transition-colors group-hover:text-accent ${
+                HEADING_LABEL_CLASS[heading.level] ?? 'text-muted-foreground'
+              }`}
+            >
+              {heading.text || '(untitled)'}
+            </span>
+          )}
+          <span className="h-px w-2.5 shrink-0 bg-border group-hover:bg-accent" />
+        </button>
+      ))}
+
+      {/* Annotation markers — one dot per cluster, on the track */}
       {clusters.map((cluster, index) => {
-        const top = `${Math.max(2, Math.min(98, cluster.position * 100))}%`
+        const top = `${clamp(cluster.position)}%`
         const hasActive = cluster.members.some((m) => m.isActive)
 
         if (cluster.members.length === 1) {
@@ -90,7 +172,7 @@ export function AnnotationMap() {
               key={m.id}
               onClick={() => handleSelect(m.id)}
               title={m.label}
-              className={`absolute left-1/2 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm transition-transform hover:scale-150 ${
+              className={`absolute left-1/2 z-10 -translate-x-1/2 w-3 h-3 rounded-full border-2 border-white shadow-sm transition-transform hover:scale-150 ${
                 m.isActive ? 'scale-150 ring-2 ring-offset-1' : ''
               }`}
               style={{
@@ -104,7 +186,7 @@ export function AnnotationMap() {
 
         const isOpen = openClusterIndex === index
         return (
-          <div key={cluster.members[0].id} className="absolute left-1/2 -translate-x-1/2" style={{ top }}>
+          <div key={cluster.members[0].id} className="absolute left-1/2 z-10 -translate-x-1/2" style={{ top }}>
             <button
               onClick={() => setOpenClusterIndex(isOpen ? null : index)}
               aria-expanded={isOpen}

--- a/src/lib/annotations/__tests__/documentOutline.pure.test.ts
+++ b/src/lib/annotations/__tests__/documentOutline.pure.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import type { Node as PMNode } from 'prosemirror-model'
+import { schema } from '@/lib/prosemirror/schema'
+import { collectHeadings, visibleHeadingLabels } from '../documentOutline'
+
+function h(level: number, text: string): PMNode {
+  return schema.node('heading', { level }, [schema.text(text)])
+}
+
+function p(text: string): PMNode {
+  return schema.node('paragraph', null, [schema.text(text)])
+}
+
+describe('collectHeadings', () => {
+  it('collects headings in document order with level, text, and fraction', () => {
+    const doc = schema.node('doc', null, [
+      h(1, 'Title'),
+      p('Intro paragraph with some words in it.'),
+      h(2, 'Section one'),
+      p('Body.'),
+      h(3, 'Detail'),
+    ])
+    const headings = collectHeadings(doc)
+    expect(headings.map((x) => x.text)).toEqual(['Title', 'Section one', 'Detail'])
+    expect(headings.map((x) => x.level)).toEqual([1, 2, 3])
+    // Positions are ascending fractions of doc length in [0, 1)
+    expect(headings[0].position).toBe(0)
+    for (let i = 1; i < headings.length; i++) {
+      expect(headings[i].position).toBeGreaterThan(headings[i - 1].position)
+      expect(headings[i].position).toBeLessThan(1)
+    }
+  })
+
+  it('returns an empty list for a doc without headings', () => {
+    const doc = schema.node('doc', null, [p('Just prose.')])
+    expect(collectHeadings(doc)).toEqual([])
+  })
+})
+
+describe('visibleHeadingLabels', () => {
+  const mk = (position: number) => ({ pos: 0, level: 2, text: 'x', position })
+
+  it('labels every heading when they are well separated', () => {
+    expect(visibleHeadingLabels([mk(0), mk(0.3), mk(0.7)])).toEqual([true, true, true])
+  })
+
+  it('drops labels inside a dense run but keeps their ticks (parallel array)', () => {
+    const flags = visibleHeadingLabels([mk(0.1), mk(0.11), mk(0.12), mk(0.5)], 0.04)
+    expect(flags).toEqual([true, false, false, true])
+    expect(flags).toHaveLength(4)
+  })
+
+  it('always labels the first heading', () => {
+    expect(visibleHeadingLabels([mk(0.999)])).toEqual([true])
+  })
+})

--- a/src/lib/annotations/documentOutline.ts
+++ b/src/lib/annotations/documentOutline.ts
@@ -1,0 +1,46 @@
+import type { Node as PMNode } from 'prosemirror-model'
+
+export interface OutlineHeading {
+  /** Document position of the heading node. */
+  pos: number
+  level: number
+  text: string
+  /** Position as a fraction of doc length, 0..1 — where it sits on the map. */
+  position: number
+}
+
+/** Collect every heading in document order, with proportional positions. */
+export function collectHeadings(doc: PMNode): OutlineHeading[] {
+  const size = doc.content.size || 1
+  const headings: OutlineHeading[] = []
+  doc.descendants((node, pos) => {
+    if (node.type.name === 'heading') {
+      headings.push({
+        pos,
+        level: (node.attrs.level as number) ?? 1,
+        text: node.textContent,
+        position: pos / size,
+      })
+      return false
+    }
+    return true
+  })
+  return headings
+}
+
+/**
+ * Which headings get a text label on the map. The map is proportional, so
+ * headings in a dense run would overprint each other's labels; a heading keeps
+ * its label only when it sits at least `minGapFraction` below the previous
+ * labelled one — the rest render as bare ticks. Parallel to the input array.
+ */
+export function visibleHeadingLabels(headings: OutlineHeading[], minGapFraction = 0.04): boolean[] {
+  let lastLabelled = Number.NEGATIVE_INFINITY
+  return headings.map((heading) => {
+    if (heading.position - lastLabelled >= minGapFraction) {
+      lastLabelled = heading.position
+      return true
+    }
+    return false
+  })
+}


### PR DESCRIPTION
Executes P3.12 from `docs/INTENT-IDE-DESIGN-AUDIT-2026-08.md` (overlord repo), per the operator's design call: **both, not either** — the map keeps its annotation markers and gains document structure, in one proportional view. Delivered session-side like #90 (the Actions dispatch channel remains credential-blocked).

## What the map now shows

- **Headings as the spine.** `collectHeadings` (new pure lib, `documentOutline.ts`) walks the ProseMirror doc and places every heading at its proportional position — clickable ticks with labels, weighted by level (h1 semibold → h3 muted). In dense runs, `visibleHeadingLabels` thins labels (ticks stay) so a proportional map can never overprint itself; both functions are unit-tested against the real schema.
- **Annotation clusters, unchanged.** The cluster markers from #90 sit on the track as before — count badges, member popovers, every annotation reachable.
- **The read-line.** The `readLinePlugin`'s high-water mark renders as a dashed indicator with a small "read" label, so review position is visible at a glance.
- The empty state now distinguishes "no document open" from "nothing to map yet", and a document with headings but no annotations still gets a useful map.

ProseMirror edits and read-line advances don't flow through a React store, so the component polls a `{doc, readPos}` snapshot every 1.5s with an identity bail-out — quiet ticks cause no re-render.

Independent of #97 (different files); the two can merge in either order.

## Verification (run locally on this branch)

- `npm run test` — 1052 passed, 10 skipped (includes the new outline tests)
- `npm run typecheck` — 0 errors
- `npm run lint` — no warnings or errors
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7

---
_Generated by [Claude Code](https://claude.ai/code/session_019RTFgJKGsMjmABMHMGq6w7)_