### PR TITLE
fix(annotations): guard "Simplify thread" against a stale-write clobber

### DIFF
--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -752,7 +752,11 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
               // annotation while this request was in flight — applying the
               // stale summary on top would silently discard that write.
               const live = useAnnotationStore.getState().getById(annotation.id)
-              if (!live || live.conversation !== conversationSnapshot) {
+              if (!live) {
+                // Nothing to retry — the annotation itself is gone.
+                return
+              }
+              if (live.conversation !== conversationSnapshot) {
                 useToastStore.getState().addToast(
                   'This conversation changed while simplifying — try again.',
                   'error'
@@ -768,6 +772,12 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
                   timestamp: Date.now(),
                 }],
               })
+            } catch (err) {
+              console.error('Simplify thread failed unexpectedly:', err)
+              useToastStore.getState().addToast(
+                'Simplifying this thread failed — the conversation was left unchanged.',
+                'error'
+              )
             } finally {
               setIsSimplifying(false)
             }

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -733,11 +733,28 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
             e.stopPropagation()
             if (isSimplifying) return
             setIsSimplifying(true)
+            const conversationSnapshot = annotation.conversation
             try {
               const result = await simplifyThread(annotation)
               if (result.requestFailed) {
                 useToastStore.getState().addToast(
                   'Simplifying this thread failed — the conversation was left unchanged.',
+                  'error'
+                )
+                return
+              }
+              // The conversation is a store-owned reference that is only
+              // reassigned when its own content changes (annotationStore's
+              // plain `update` spreads the patch over the existing
+              // annotation, so an unrelated field write leaves `conversation`
+              // pointing at the same array). A reference mismatch here means
+              // another reply (or another simplify) landed on this
+              // annotation while this request was in flight — applying the
+              // stale summary on top would silently discard that write.
+              const live = useAnnotationStore.getState().getById(annotation.id)
+              if (!live || live.conversation !== conversationSnapshot) {
+                useToastStore.getState().addToast(
+                  'This conversation changed while simplifying — try again.',
                   'error'
                 )
                 return

--- a/src/components/Annotations/__tests__/resolutionActions.simplifyThreadGate.pure.test.ts
+++ b/src/components/Annotations/__tests__/resolutionActions.simplifyThreadGate.pure.test.ts
@@ -30,6 +30,20 @@ function makeConversation(): ConversationMessage[] {
   ]
 }
 
+// Source-faithful re-implementation of the stale-write guard added for #92:
+// annotationStore's `update(id, patch)` spreads the patch over the existing
+// annotation, so `conversation` keeps its prior array reference unless the
+// patch itself touches it. A reference mismatch (or a missing annotation —
+// deleted mid-flight) means another write landed on this annotation while
+// the summarize request was in flight, and the stale summary must be
+// discarded rather than applied on top of it.
+function shouldApplySimplifySummary(
+  conversationSnapshot: ConversationMessage[],
+  liveConversation: ConversationMessage[] | undefined,
+): boolean {
+  return liveConversation !== undefined && liveConversation === conversationSnapshot
+}
+
 // Regression for #88: a failed simplifyThread request must never overwrite
 // real conversation history with the synthesized error string.
 describe('Simplify thread destructive-write gate (#88)', () => {
@@ -65,5 +79,41 @@ describe('Simplify thread destructive-write gate (#88)', () => {
 
     expect(next).toHaveLength(1)
     expect(next[0].content).toBe('Error: is the wrong word to use here.')
+  })
+})
+
+// Regression for #92: a successful simplify must not clobber a conversation
+// that changed (another reply, or another simplify) while the request for
+// this one was still in flight.
+describe('Simplify thread stale-write guard (#92)', () => {
+  it('discards the summary when the conversation changed while the request was in flight', () => {
+    const snapshot = makeConversation()
+    const liveConversation = [...snapshot, {
+      id: 'm4', role: 'agent' as const, content: 'A reply that landed mid-flight', suggestedEdit: null, timestamp: 4,
+    }]
+
+    expect(shouldApplySimplifySummary(snapshot, liveConversation)).toBe(false)
+  })
+
+  it('discards the summary when the annotation was deleted while the request was in flight', () => {
+    const snapshot = makeConversation()
+
+    expect(shouldApplySimplifySummary(snapshot, undefined)).toBe(false)
+  })
+
+  it('applies the summary when the conversation is unchanged since the request started', () => {
+    const snapshot = makeConversation()
+
+    expect(shouldApplySimplifySummary(snapshot, snapshot)).toBe(true)
+  })
+
+  it('discards the summary even when the live conversation is deep-equal but a different array (another simplify replaced it)', () => {
+    const snapshot = makeConversation()
+    // A second, unrelated simplify (or any conversation-touching write)
+    // always produces a fresh array — even one that happens to contain the
+    // same messages is evidence of a write this request didn't see.
+    const liveConversation = makeConversation()
+
+    expect(shouldApplySimplifySummary(snapshot, liveConversation)).toBe(false)
   })
 })

--- a/src/stores/__tests__/annotationStore.conversationReference.test.ts
+++ b/src/stores/__tests__/annotationStore.conversationReference.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+  clear() {
+    this.store.clear()
+  }
+}
+
+function makeAnnotation(conversation: ConversationMessage[]): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:0:10',
+    type: 'flag',
+    status: 'resolved',
+    transcript: 'annotation',
+    anchor: { from: 0, to: 10, scope: 'phrase', text: 'x' },
+    resolution: null,
+    conversation,
+    parentId: null,
+    childIds: [],
+    createdAt: Date.now(),
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+async function loadStore() {
+  vi.resetModules()
+  return import('@/stores/annotationStore')
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+// Regression for #92: the "Simplify thread" stale-write guard in
+// ResolutionActions.tsx detects an in-flight write on another annotation
+// field by comparing `conversation` array *references*, not deep equality.
+// That guard is only correct if annotationStore's own actions honor this
+// contract: a patch that doesn't touch `conversation` must leave its
+// reference untouched, and any action that does touch it must produce a new
+// array. These tests exercise the real store (not a re-implementation) so a
+// future refactor of annotationStore.ts that breaks the contract fails here,
+// not just silently reopening #92 behind an untouched pure-logic test.
+describe('annotationStore conversation-reference contract (#92)', () => {
+  it('update() with a patch that does not touch conversation preserves the array reference', async () => {
+    const { useAnnotationStore } = await loadStore()
+    const conversation: ConversationMessage[] = [
+      { id: 'm1', role: 'user', content: 'hi', suggestedEdit: null, timestamp: 1 },
+    ]
+    useAnnotationStore.getState().add(makeAnnotation(conversation))
+
+    useAnnotationStore.getState().update('ann-1', { status: 'applied' })
+
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).toBe(conversation)
+  })
+
+  it('update() with a patch that replaces conversation changes the reference', async () => {
+    const { useAnnotationStore } = await loadStore()
+    const conversation: ConversationMessage[] = [
+      { id: 'm1', role: 'user', content: 'hi', suggestedEdit: null, timestamp: 1 },
+    ]
+    useAnnotationStore.getState().add(makeAnnotation(conversation))
+
+    const replacement: ConversationMessage[] = [
+      { id: 'm2', role: 'agent', content: 'summary', suggestedEdit: null, timestamp: 2 },
+    ]
+    useAnnotationStore.getState().update('ann-1', { conversation: replacement })
+
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).not.toBe(conversation)
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).toBe(replacement)
+  })
+
+  it('addMessage() changes the conversation reference', async () => {
+    const { useAnnotationStore } = await loadStore()
+    const conversation: ConversationMessage[] = [
+      { id: 'm1', role: 'user', content: 'hi', suggestedEdit: null, timestamp: 1 },
+    ]
+    useAnnotationStore.getState().add(makeAnnotation(conversation))
+
+    useAnnotationStore.getState().addMessage('ann-1', {
+      id: 'm2', role: 'agent', content: 'reply', suggestedEdit: null, timestamp: 2,
+    })
+
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).not.toBe(conversation)
+  })
+
+  it('updateMessage() changes the conversation reference', async () => {
+    const { useAnnotationStore } = await loadStore()
+    const conversation: ConversationMessage[] = [
+      { id: 'm1', role: 'user', content: 'hi', suggestedEdit: null, timestamp: 1 },
+    ]
+    useAnnotationStore.getState().add(makeAnnotation(conversation))
+
+    useAnnotationStore.getState().updateMessage('ann-1', 'm1', { content: 'edited' })
+
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).not.toBe(conversation)
+  })
+
+  it('remove() leaves getById() returning undefined, mirroring the guard\'s "annotation deleted mid-flight" branch', async () => {
+    const { useAnnotationStore } = await loadStore()
+    const conversation: ConversationMessage[] = [
+      { id: 'm1', role: 'user', content: 'hi', suggestedEdit: null, timestamp: 1 },
+    ]
+    useAnnotationStore.getState().add(makeAnnotation(conversation))
+
+    useAnnotationStore.getState().remove('ann-1')
+
+    expect(useAnnotationStore.getState().getById('ann-1')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

`ResolutionActions.tsx`'s "Simplify thread" success path unconditionally overwrote the annotation's live `conversation` with the summary, with no check that the conversation was still what it was when the request started. A reply (`continueThread`) or another "Simplify thread" landing on the same annotation while the summarize request was in flight got silently clobbered, with no HITL step of any kind — a gap CLAUDE.md §3 forbids for destructive/global changes.

## Changes

- Snapshot the conversation array reference before awaiting `simplifyThread`. On success, compare it against the live annotation's conversation (`useAnnotationStore.getState().getById(...)`); if the annotation was deleted or its conversation reference changed, discard the summary instead of applying it (with an error toast when the conversation changed — nothing to retry if the annotation itself is gone).
- This relies on `annotationStore.ts`'s actual update semantics: a patch that doesn't touch `conversation` leaves its array reference untouched (`{...a, ...patch}`), while `addMessage`/`updateMessage`/a `conversation`-touching `update()` always produce a new array — so reference inequality is a correct proxy for "something wrote to this conversation since the snapshot."
- Added a `catch` alongside the existing `finally` so an unexpected synchronous throw in the new guard surfaces as a toast rather than an unhandled rejection.

## Tests

- `src/components/Annotations/__tests__/resolutionActions.simplifyThreadGate.pure.test.ts`: extended the existing source-faithful re-implementation of the button's branching logic with `shouldApplySimplifySummary`, covering conversation-changed, annotation-deleted, unchanged, and deep-equal-but-different-instance cases.
- `src/stores/__tests__/annotationStore.conversationReference.test.ts` (new): an adversarial review of this fix flagged that its correctness depends entirely on `annotationStore.ts`'s reference-identity contract, which no existing test exercised directly. This new file calls the real `update`/`addMessage`/`updateMessage`/`remove` store actions and asserts the reference is preserved or replaced as the guard assumes — so a future store refactor that breaks this contract fails a test instead of silently reopening this bug.

`npm run typecheck`, `npm run lint`, `npm run test` (1064 passing + 10 skipped) all green.

## Process

Ran an adversarial (troublemaker) review before push. Verdict: MERGE, with one MEDIUM finding (the untested store-reference-identity dependency, addressed above) and a few LOW findings (misleading toast on the deleted-annotation branch, missing `catch`) — both fixed. One LOW finding was judged out of scope and filed separately: `continueThread`'s reply path has no reciprocal staleness check against a `conversation`-collapsing "Simplify thread" landing concurrently — same race class, different call site, not part of #92's stated scope.

Closes #92


---
_Generated by [Claude Code](https://claude.ai/code/session_0172FxUV9CzfFyhTqxvRaGYz)_