### PR TITLE
test(annotations): add regression coverage for the "Simplify thread" double-click guard

### DIFF
--- a/src/components/Annotations/__tests__/resolutionActions.simplifyThreadDoubleClick.test.tsx
+++ b/src/components/Annotations/__tests__/resolutionActions.simplifyThreadDoubleClick.test.tsx
@@ -8,6 +8,13 @@ import type { Annotation } from '@/lib/annotations/types'
 // simplifyThread is the only call this test needs to control the timing of —
 // everything else ResolutionActions imports is left real (module import
 // alone doesn't touch network/env, and no other handler is exercised here).
+// Safety of that depends on the fixture below: `resolution.actions: []`
+// keeps every other action button (apply-edit, add-to-doc, etc. — several
+// of which reach `fetch`-touching code like `createCommit`) from rendering
+// at all, and a 3-message `conversation` keeps `showDiffModal` at its
+// initial `false` for the whole test, so `SemanticCommitModal` never
+// mounts. Widening this fixture (e.g. adding a real `resolution.actions`
+// entry) can pull one of those real, unmocked paths into the render tree.
 vi.mock('@/lib/ai/resolver', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/ai/resolver')>()
   return { ...actual, simplifyThread: vi.fn() }
@@ -54,7 +61,19 @@ afterEach(() => {
 // #88's and #92's coverage both re-implement the surrounding branch logic in
 // isolation (resolutionActions.simplifyThreadGate.pure.test.ts) rather than
 // clicking the actual button twice. This test mounts the real component and
-// asserts the guard itself, not a re-implementation of it.
+// asserts the observable outcome (no duplicate `simplifyThread` call across
+// two rapid clicks), not one specific mechanism in isolation: two clicks
+// fired back-to-back via `fireEvent` are each individually `act()`-flushed,
+// so by the second click the `disabled={isSimplifying}` attribute has
+// already committed and jsdom (like a real browser) never dispatches a
+// click to a disabled button — meaning this test is only guaranteed to
+// catch a regression that drops *both* the `if (isSimplifying) return`
+// early-return and the `disabled` attribute together, not one alone.
+// Verified directly: reverting the early-return only, or the `disabled`
+// attribute only, each still leaves this test green; reverting both at once
+// makes it fail (`called 1 times, but got 2 times`) — which is still
+// strictly more coverage of the real component than the pure
+// re-implementations above provide today (they cover neither).
 describe('Simplify thread double-click in-flight guard (#93)', () => {
   it('fires simplifyThread only once for two rapid clicks while the first request is in flight', async () => {
     const annotation = makeAnnotation()

--- a/src/components/Annotations/__tests__/resolutionActions.simplifyThreadDoubleClick.test.tsx
+++ b/src/components/Annotations/__tests__/resolutionActions.simplifyThreadDoubleClick.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { ResolutionActions } from '@/components/Annotations/ResolutionActions'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import type { Annotation } from '@/lib/annotations/types'
+
+// simplifyThread is the only call this test needs to control the timing of —
+// everything else ResolutionActions imports is left real (module import
+// alone doesn't touch network/env, and no other handler is exercised here).
+vi.mock('@/lib/ai/resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ai/resolver')>()
+  return { ...actual, simplifyThread: vi.fn() }
+})
+
+import { simplifyThread } from '@/lib/ai/resolver'
+
+function makeAnnotation(): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:0:1',
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'What does this mean?',
+    anchor: { from: 0, to: 1, scope: 'sentence', text: 'What does this mean?' },
+    resolution: {
+      type: 'ask',
+      content: 'An explanation.',
+      suggestedEdit: null,
+      actions: [],
+    },
+    conversation: [
+      { id: 'm1', role: 'user', content: 'First message', suggestedEdit: null, timestamp: 1 },
+      { id: 'm2', role: 'agent', content: 'First reply', suggestedEdit: null, timestamp: 2 },
+      { id: 'm3', role: 'user', content: 'Second message', suggestedEdit: null, timestamp: 3 },
+    ],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: 1,
+    verbosity: 'normal',
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  useAnnotationStore.setState({ annotations: [] })
+})
+
+// Regression for #93: the #88 fix added an `isSimplifying` React-state guard
+// to the "Simplify thread" button, but no test exercised the real button —
+// #88's and #92's coverage both re-implement the surrounding branch logic in
+// isolation (resolutionActions.simplifyThreadGate.pure.test.ts) rather than
+// clicking the actual button twice. This test mounts the real component and
+// asserts the guard itself, not a re-implementation of it.
+describe('Simplify thread double-click in-flight guard (#93)', () => {
+  it('fires simplifyThread only once for two rapid clicks while the first request is in flight', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+
+    let resolveRequest: (v: { content: string; requestFailed?: boolean }) => void
+    const pending = new Promise<{ content: string; requestFailed?: boolean }>((resolve) => {
+      resolveRequest = resolve
+    })
+    vi.mocked(simplifyThread).mockReturnValue(pending)
+
+    const { getByRole, findByRole } = render(<ResolutionActions annotation={annotation} />)
+    const button = getByRole('button', { name: /simplify thread/i })
+
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(simplifyThread).toHaveBeenCalledTimes(1)
+    const disabledButton = await findByRole('button', { name: /simplifying/i })
+    expect((disabledButton as HTMLButtonElement).disabled).toBe(true)
+
+    resolveRequest!({ content: 'A concise summary.' })
+    await pending
+
+    expect(simplifyThread).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-enables the button and allows a fresh request once the in-flight one settles', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+
+    let resolveRequest: (v: { content: string; requestFailed?: boolean }) => void
+    const firstPending = new Promise<{ content: string; requestFailed?: boolean }>((resolve) => {
+      resolveRequest = resolve
+    })
+    vi.mocked(simplifyThread).mockReturnValueOnce(firstPending)
+
+    const { getByRole, findByRole } = render(<ResolutionActions annotation={annotation} />)
+    const button = getByRole('button', { name: /simplify thread/i })
+
+    fireEvent.click(button)
+    resolveRequest!({ content: 'A concise summary.' })
+    await firstPending
+
+    // Re-enabling happens in the same handler that applies the summary, so
+    // wait for the button to actually flip back before clicking again —
+    // asserting immediately after a bare `await` races React's own
+    // (unbatched, outside `act()`) state flush.
+    const reenabledButton = await findByRole('button', { name: /^simplify thread$/i })
+
+    vi.mocked(simplifyThread).mockResolvedValueOnce({ content: 'Another summary.' })
+    fireEvent.click(reenabledButton)
+
+    expect(simplifyThread).toHaveBeenCalledTimes(2)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,15 @@ import { defineConfig } from 'vitest/config'
 import path from 'path'
 
 export default defineConfig({
+  // Source .tsx files rely on Next.js's own SWC pipeline for the JSX
+  // automatic runtime (tsconfig's `jsx: "preserve"` is a no-op outside that
+  // pipeline) and never import React themselves, so esbuild — the transform
+  // vitest uses directly — needs the same runtime told explicitly, or every
+  // JSX call compiles to a bare `React.createElement` with no such import in
+  // scope.
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],


### PR DESCRIPTION
## Summary

Issue #93: the `isSimplifying` React-state guard added for #88 to the "Simplify thread" button in `src/components/Annotations/ResolutionActions.tsx` had no test exercising the real button. The existing coverage (`resolutionActions.simplifyThreadGate.pure.test.ts`) re-implements the surrounding branch logic in isolation for #88/#92 — neither test would catch a regression in the `isSimplifying` guard itself.

## Change

New `src/components/Annotations/__tests__/resolutionActions.simplifyThreadDoubleClick.test.tsx` — the first `.test.tsx` in this repo. It mounts the real `<ResolutionActions>` component (`@vitest-environment jsdom` + `@testing-library/react`), mocks only `simplifyThread` (via `vi.mock` with an `importOriginal` passthrough for everything else in `@/lib/ai/resolver`), fires two rapid clicks while the mocked call is held pending, and asserts it fires exactly once. A second test confirms the button re-enables and accepts a fresh request once the first settles.

**`vitest.config.ts`** gained `esbuild: { jsx: 'automatic' }`. This repo's `.tsx` source files rely on Next.js's own SWC pipeline for the JSX automatic runtime and never import React themselves (`tsconfig.json`'s `jsx: "preserve"` is a no-op outside that pipeline), so without this, every JSX call under vitest's own esbuild transform compiled to a bare `React.createElement(...)` with no `React` in scope, throwing `ReferenceError: React is not defined` at render time — this was blocking, not optional, for the new test to run at all.

## Adversarial review

Ran a troublemaker review before pushing. Verdict: **MERGE**.
- Independently reran `npm run test` (76 files / 1066 passing + 10 skipped), `npm run typecheck`, `npm run lint` — all green; confirmed `esbuild.jsx: 'automatic'` only affects the `.tsx` loader, leaving the many `.test.ts` files with `<...>` generics/comparisons unaffected (empirically, all still pass).
- Confirmed the diff is scoped to exactly the two files touched, no dependency changes needed (`jsdom`/`@testing-library/react` were already present as unused devDependencies).
- **Real finding, addressed before merge:** two rapid `fireEvent.click()` calls are each individually `act()`-flushed, so by the second click the `disabled={isSimplifying}` attribute has already committed — jsdom (like a real browser) never dispatches a click to a disabled button. That means this test is only guaranteed to catch a regression that drops *both* the `if (isSimplifying) return` early-return and the `disabled` attribute together, not one in isolation (reverting either alone still leaves the test green). Non-blocking per the reviewer (it does correctly catch the combined-mechanism regression, and is still strictly more real-component coverage than the pure re-implementations provide today), but documented explicitly in the test's own comment rather than left implicit, along with why the fixture's empty `resolution.actions` and 3-message `conversation` keep the component's other real, unmocked (some `fetch`-touching) code paths from ever rendering.
- Verified the `findByRole` polling in the second test is load-bearing, not decorative: `setIsSimplifying(false)` fires inside the async handler's `finally` after `await simplifyThread(...)`, outside `act()`'s synchronous flush, so a bare assertion right after `await` can race React's state update.

## Verification

- Non-vacuous, verified directly: reverted the `isSimplifying` early-return **and** the `disabled` attribute together, confirmed the first test fails (`called 1 times, but got 2 times`), then restored the source clean (`git diff` confirmed no residual change).
- `npm run typecheck` — 0 errors
- `npm run lint` — clean
- `npm run test` — 1066 passing + 10 skipped (was 1064 + 10; +2 new)

Closes #93

---
_Generated by [Claude Code](https://claude.ai/code/session_014mXqUpzRUvyDQiGdNLqf3F)_