### PR TITLE
fix(voice): skip holdAnswer for an annotation deleted mid-resolution

### DIFF
--- a/src/lib/voice/__tests__/pipeline.capture.test.ts
+++ b/src/lib/voice/__tests__/pipeline.capture.test.ts
@@ -480,6 +480,35 @@ describe('(f) flow-state answer buffering', () => {
     expect(useAnnotationStore.getState().activeAnnotationId).toBe(id)
     expect(useFlowStore.getState().heldAnswers[id]).toBeUndefined()
   })
+
+  it('an annotation deleted mid-resolution (card dismissed while streaming) never gets a heldAnswers entry (#95)', async () => {
+    useFlowStore.getState().setBufferAnswersEnabled(true)
+    let release!: () => void
+    const gate = new Promise<void>((r) => {
+      release = r
+    })
+    const { stub } = makeFetchStub({ resolveGate: gate })
+    vi.stubGlobal('fetch', stub)
+
+    const id = captureAndResolveInBackground('ask', 'about to vanish', FROM, TO, {
+      suggestedType: 'ask',
+      skipClassify: true,
+      notify: 'quiet',
+    })!
+    // Not watching the card — buffering would normally hold this answer.
+    useAnnotationStore.getState().setActive(null)
+    // The card is dismissed (e.g. the user deletes the annotation) while the
+    // resolve is still in flight, before the flow-buffering block runs.
+    useAnnotationStore.getState().remove(id)
+
+    release()
+    // No `status === 'resolved'` to poll for once the annotation is gone —
+    // wait for the gated /api/resolve call to actually settle instead.
+    await new Promise((r) => setTimeout(r, 50))
+
+    expect(useAnnotationStore.getState().getById(id)).toBeUndefined()
+    expect(useFlowStore.getState().heldAnswers[id]).toBeUndefined()
+  })
 })
 
 describe('(h) finalize survives a shrunken doc (stale anchor)', () => {

--- a/src/lib/voice/pipeline.ts
+++ b/src/lib/voice/pipeline.ts
@@ -377,7 +377,11 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
         // Never hold against a vanished anchor (doc shrank below it during
         // resolution): the breakpoint poll would insta-reveal anyway, so
         // reveal directly instead of a meaningless hold.
-        current.anchor.from <= view.state.doc.content.size
+        current.anchor.from <= view.state.doc.content.size &&
+        // Never hold for an annotation deleted mid-resolution (e.g. its card
+        // dismissed while streaming): nothing will ever mount to reveal it,
+        // so the hold would just leak in useFlowStore for the rest of the session.
+        annotationStore.getById(id)
       ) {
         const blockText = getBlockText(view.state, current.anchor.from)
         useFlowStore.getState().holdAnswer(id, answerDwellMs(blockText))


### PR DESCRIPTION
## Summary

`resolveCapturedAnnotation`'s flow-buffering block (`src/lib/voice/pipeline.ts`) ran unconditionally after a resolution finalized, calling `useFlowStore.getState().holdAnswer(id, ...)` with no check that the annotation still exists in `useAnnotationStore`. If the annotation is deleted while its resolution is in flight (e.g. the card is dismissed mid-stream — the same race class as #91, but general to any resolution, not just the mermaid-retry path), this left a permanently-dangling `heldAnswers[id]` entry: nothing mounts `AnnotationCard` for a deleted annotation, so nothing ever calls `revealAnswer` for it.

- Added `annotationStore.getById(id)` as an additional guard condition before `holdAnswer` is called.
- Added a regression test in `pipeline.capture.test.ts`'s "(f) flow-state answer buffering" block: captures an ask annotation with a gated `/api/resolve` stub, removes the annotation from the store before releasing the gate, and asserts `heldAnswers[id]` never gets an entry.

## Review

Pre-push adversarial review (troublemaker agent) returned **MERGE**, independently confirming the regression test fails against the pre-fix code and passes with the fix restored, and that `annotationStore.getById` reads live Zustand state (not a stale closure) consistent with the same pattern already used elsewhere in the function.

It also surfaced one MEDIUM finding that is real but outside this issue's stated done-means: `useAnnotationStore.remove()` doesn't purge `heldAnswers`, and `AnnotationCard`'s reveal-poll effect doesn't call `revealAnswer` on unmount — so an annotation removed *after* `holdAnswer` already ran (e.g. the localStorage-quota emergency prune) can still leak the same class of dangling entry through a different path than the one #95 asked to close. Filing that as its own follow-up task issue rather than silently expanding this PR's scope.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1067 passed + 10 skipped (was 1066 + 10 before the new test)
- [x] New regression test verified to fail against the pre-fix code and pass against the fix

Closes #95

---
_Generated by [Claude Code](https://claude.ai/code/session_012Bpar9YwUbCdEJYupTkWaX)_