### PR TITLE
fix(annotations): guard AnnotationCard's handleFollowUp against stale-conversation and status-clobber races

### DIFF
--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -248,25 +248,40 @@ export function AnnotationCard({
       }
     }
 
-    try {
-      const freshAnnotation = useAnnotationStore.getState().getById(annotation.id)
-      if (!freshAnnotation) return
-      // Snapshot the message ids this request is generated from — id
-      // overlap (not array reference equality) is what distinguishes a real
-      // collapse (e.g. "Simplify thread") from a benign concurrent write.
-      // See the matching comment at ResolutionActions.tsx's sendFollowUp.
-      const snapshotIds = new Set(freshAnnotation.conversation.map((m) => m.id))
+    const freshAnnotation = useAnnotationStore.getState().getById(annotation.id)
+    if (!freshAnnotation) return
+    // Snapshot the message ids this request is generated from — id overlap
+    // (not array reference equality) is what distinguishes a real collapse
+    // (e.g. "Simplify thread") from a benign concurrent write. See the
+    // matching comment at ResolutionActions.tsx's sendFollowUp. Declared
+    // outside the try so BOTH the success and catch paths below can check
+    // against the same snapshot — an unguarded catch path was the exact gap
+    // an adversarial review of this fix found: a request that fails (rather
+    // than resolves) after a collapse would otherwise still silently attach
+    // its error message to the fresh, post-collapse conversation.
+    const snapshotIds = new Set(freshAnnotation.conversation.map((m) => m.id))
 
-      const agentMessage = await continueThread(freshAnnotation, text, currentView.state)
-
+    // Returns the live annotation if the conversation this request was
+    // generated from has survived, else toasts and returns null. Shared by
+    // the success and catch paths so they can't drift out of sync on this
+    // check again.
+    const liveIfNotCollapsed = () => {
       const live = useAnnotationStore.getState().getById(annotation.id)
-      if (!live) return // Annotation was deleted while the request was in flight.
+      if (!live) return null // Annotation was deleted while the request was in flight.
       const collapsed = snapshotIds.size > 0 && !live.conversation.some((m) => snapshotIds.has(m.id))
       if (collapsed) {
         useToastStore.getState().addToast(
-          'This conversation changed while replying — the new reply was generated from context that no longer exists, so it was discarded.',
+          'This conversation changed while replying — the response was generated from context that no longer exists, so it was discarded.',
           'error'
         )
+        return null
+      }
+      return live
+    }
+
+    try {
+      const agentMessage = await continueThread(freshAnnotation, text, currentView.state)
+      if (!liveIfNotCollapsed()) {
         finishFollowUp()
         return
       }
@@ -274,6 +289,10 @@ export function AnnotationCard({
       finishFollowUp()
     } catch (err) {
       console.error('Follow-up failed:', err)
+      if (!liveIfNotCollapsed()) {
+        finishFollowUp()
+        return
+      }
       const errorMessage: ConversationMessage = {
         id: generateId(),
         role: 'agent',

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -14,6 +14,7 @@ import { readLinePluginKey } from '@/lib/prosemirror/plugins/readLinePlugin'
 import { partitionCascadeReveal, cascadeBreakpointPos, pollCascadeReveal } from '@/lib/annotations/cascadeReveal'
 import { answerBreakpointPos, shouldRevealAnswer } from '@/lib/annotations/answerReveal'
 import { useFlowStore } from '@/stores/flowStore'
+import { useToastStore } from '@/stores/toastStore'
 import { ResolutionActions } from './ResolutionActions'
 import { CascadeList } from './CascadeList'
 import { ConversationThread } from './ConversationThread'
@@ -210,24 +211,67 @@ export function AnnotationCard({
   }
 
   const handleFollowUp = async (text: string) => {
-    if (!view) return
+    const currentView = useEditorStore.getState().view
+    if (!currentView) return
+
+    // Mirrors ResolutionActions.tsx's sendFollowUp guard (#100 round 3,
+    // carried to this call site by #104): a terminal status has no legal
+    // outgoing transition, and this free-text box / "Tell me more" stay
+    // clickable after Apply/Dismiss — bail before touching the conversation
+    // or calling continueThread at all.
+    const currentStatus = useAnnotationStore.getState().getById(annotation.id)?.status
+    if (currentStatus === 'applied' || currentStatus === 'dismissed') {
+      useToastStore.getState().addToast(
+        'This annotation has already been applied or dismissed — start a new annotation to continue.',
+        'info'
+      )
+      return
+    }
+
+    const userMessage: ConversationMessage = {
+      id: generateId(),
+      role: 'user',
+      content: text,
+      suggestedEdit: null,
+      timestamp: Date.now(),
+    }
+    addMessage(annotation.id, userMessage)
+    updateAnnotation(annotation.id, { status: 'resolving' })
+
+    // A terminal action (apply/dismiss) can complete on this annotation
+    // while this follow-up is still in flight — only write 'resolved' while
+    // this follow-up's own 'resolving' status still stands, so it can never
+    // resurrect a status that has since become terminal.
+    const finishFollowUp = () => {
+      if (useAnnotationStore.getState().getById(annotation.id)?.status === 'resolving') {
+        updateAnnotation(annotation.id, { status: 'resolved' })
+      }
+    }
 
     try {
-      updateAnnotation(annotation.id, { status: 'resolving' })
+      const freshAnnotation = useAnnotationStore.getState().getById(annotation.id)
+      if (!freshAnnotation) return
+      // Snapshot the message ids this request is generated from — id
+      // overlap (not array reference equality) is what distinguishes a real
+      // collapse (e.g. "Simplify thread") from a benign concurrent write.
+      // See the matching comment at ResolutionActions.tsx's sendFollowUp.
+      const snapshotIds = new Set(freshAnnotation.conversation.map((m) => m.id))
 
-      const userMessage: ConversationMessage = {
-        id: generateId(),
-        role: 'user',
-        content: text,
-        suggestedEdit: null,
-        timestamp: Date.now(),
+      const agentMessage = await continueThread(freshAnnotation, text, currentView.state)
+
+      const live = useAnnotationStore.getState().getById(annotation.id)
+      if (!live) return // Annotation was deleted while the request was in flight.
+      const collapsed = snapshotIds.size > 0 && !live.conversation.some((m) => snapshotIds.has(m.id))
+      if (collapsed) {
+        useToastStore.getState().addToast(
+          'This conversation changed while replying — the new reply was generated from context that no longer exists, so it was discarded.',
+          'error'
+        )
+        finishFollowUp()
+        return
       }
-      addMessage(annotation.id, userMessage)
-
-      const agentMessage = await continueThread(annotation, text, view.state)
       addMessage(annotation.id, agentMessage)
-
-      updateAnnotation(annotation.id, { status: 'resolved' })
+      finishFollowUp()
     } catch (err) {
       console.error('Follow-up failed:', err)
       const errorMessage: ConversationMessage = {
@@ -238,7 +282,7 @@ export function AnnotationCard({
         timestamp: Date.now(),
       }
       addMessage(annotation.id, errorMessage)
-      updateAnnotation(annotation.id, { status: 'resolved' })
+      finishFollowUp()
     }
   }
 

--- a/src/components/Annotations/__tests__/annotationCard.followUpStaleConversation.test.tsx
+++ b/src/components/Annotations/__tests__/annotationCard.followUpStaleConversation.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import { AnnotationCard } from '@/components/Annotations/AnnotationCard'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useToastStore } from '@/stores/toastStore'
+import { useEditorStore } from '@/stores/editorStore'
+import { useFlowStore } from '@/stores/flowStore'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation, ConversationMessage } from '@/lib/annotations/types'
+
+// continueThread is the only call these tests need to control the timing of.
+vi.mock('@/lib/ai/resolver', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/ai/resolver')>()
+  return { ...actual, continueThread: vi.fn() }
+})
+
+import { continueThread } from '@/lib/ai/resolver'
+
+// A provocation gives the card a second, always-clickable follow-up entry
+// point ("Tell me more") distinct from FollowUpInput's free-text box —
+// FollowUpInput disables itself while `status === 'resolving'`, so it can't
+// by itself originate a second concurrent request; the provocation button
+// can, and both are wired to the same `handleFollowUp`.
+function makeAnnotation(): Annotation {
+  return {
+    id: 'ann-1',
+    documentId: 'doc-1',
+    locationGroupKey: 'doc-1:0:1',
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'What does this mean?',
+    anchor: { from: 0, to: 1, scope: 'sentence', text: 'What does this mean?' },
+    resolution: {
+      type: 'ask',
+      content: 'An explanation.',
+      suggestedEdit: null,
+      actions: [],
+      provocation: 'This might not hold in every case.',
+    },
+    conversation: [
+      { id: 'm1', role: 'user', content: 'What does this mean?', suggestedEdit: null, timestamp: 1 },
+      { id: 'm2', role: 'agent', content: 'An explanation.', suggestedEdit: null, timestamp: 2 },
+    ],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: 1,
+    verbosity: 'normal',
+  }
+}
+
+function mountView(): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Some text here.')]),
+  ])
+  const state = EditorState.create({ schema, doc })
+  // EXACT EditorShell dispatchTransaction shape — see editorMount.smoke.test.ts.
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      view.updateState(view.state.apply(transaction))
+    },
+  })
+  return view
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  useAnnotationStore.setState({ annotations: [] })
+  useToastStore.setState({ toasts: [] })
+  useFlowStore.setState({ heldAnswers: {} })
+  const view = useEditorStore.getState().view as EditorView | null
+  view?.destroy()
+  useEditorStore.setState({ view: null })
+})
+
+function sendViaFollowUpInput(getByPlaceholderText: (t: RegExp | string) => HTMLElement, text: string) {
+  const input = getByPlaceholderText(/follow up/i) as HTMLInputElement
+  fireEvent.change(input, { target: { value: text } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+}
+
+// Regression for #104: AnnotationCard.handleFollowUp — a second, unpatched
+// call site sharing #100's exact vulnerability (a "Simplify thread" collapse
+// or a concurrent terminal action landing while a follow-up is in flight).
+describe('AnnotationCard.handleFollowUp vs. a concurrent conversation collapse / terminal status (#104)', () => {
+  it('discards the stale-context reply and toasts instead of appending it', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    let resolveRequest: (v: ConversationMessage) => void
+    const pending = new Promise<ConversationMessage>((resolve) => {
+      resolveRequest = resolve
+    })
+    vi.mocked(continueThread).mockReturnValue(pending)
+
+    const { getByPlaceholderText } = render(<AnnotationCard annotation={annotation} isActive={true} />)
+    sendViaFollowUpInput(getByPlaceholderText, 'Tell me more about that')
+
+    await waitFor(() => expect(continueThread).toHaveBeenCalledTimes(1))
+    // Simulate "Simplify thread" collapsing the conversation before the
+    // follow-up resolves.
+    useAnnotationStore.getState().update('ann-1', {
+      conversation: [
+        { id: 'summary-1', role: 'agent', content: 'A concise summary.', suggestedEdit: null, timestamp: 99 },
+      ],
+    })
+
+    resolveRequest!({
+      id: 'agent-reply-1',
+      role: 'agent',
+      content: 'Stale-context reply.',
+      suggestedEdit: null,
+      timestamp: 100,
+    })
+    await pending
+    await waitFor(() =>
+      expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('resolved'),
+    )
+
+    const live = useAnnotationStore.getState().getById('ann-1')
+    expect(live?.conversation).toHaveLength(1)
+    expect(live?.conversation.some((m) => m.id === 'agent-reply-1')).toBe(false)
+
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].type).toBe('error')
+    expect(toasts[0].message).toMatch(/changed while replying/i)
+  })
+
+  it('does not resurrect a terminal status set by a concurrent action (e.g. Apply) while a follow-up is in flight', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    let resolveRequest: (v: ConversationMessage) => void
+    const pending = new Promise<ConversationMessage>((resolve) => {
+      resolveRequest = resolve
+    })
+    vi.mocked(continueThread).mockReturnValue(pending)
+
+    const { getByPlaceholderText } = render(<AnnotationCard annotation={annotation} isActive={true} />)
+    sendViaFollowUpInput(getByPlaceholderText, 'Go deeper please')
+
+    await waitFor(() => expect(continueThread).toHaveBeenCalledTimes(1))
+    expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('resolving')
+
+    // A concurrent Apply completes on this same annotation while the
+    // follow-up is still in flight. Apply doesn't touch `conversation`, so
+    // this must not be misread as a collapse — but it IS a terminal status
+    // the follow-up must not overwrite.
+    useAnnotationStore.getState().update('ann-1', { status: 'applied' })
+
+    resolveRequest!({
+      id: 'agent-reply-1',
+      role: 'agent',
+      content: 'A real reply.',
+      suggestedEdit: null,
+      timestamp: 100,
+    })
+    await pending
+    await waitFor(() =>
+      expect(
+        useAnnotationStore.getState().getById('ann-1')?.conversation.some((m) => m.id === 'agent-reply-1'),
+      ).toBe(true),
+    )
+
+    expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('applied')
+  })
+
+  it('refuses to start a follow-up on an annotation that already reached a terminal status, with no network call', async () => {
+    const annotation = makeAnnotation()
+    annotation.status = 'applied'
+    useAnnotationStore.setState({ annotations: [annotation] })
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    const { getByPlaceholderText } = render(<AnnotationCard annotation={annotation} isActive={true} />)
+    sendViaFollowUpInput(getByPlaceholderText, 'One more thing')
+
+    expect(continueThread).not.toHaveBeenCalled()
+    expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('applied')
+    expect(useAnnotationStore.getState().getById('ann-1')?.conversation).toHaveLength(2)
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].message).toMatch(/already been applied or dismissed/i)
+  })
+
+  it('allows a second concurrent follow-up from a different entry point (the provocation "Tell me more" button) while the first is still in flight', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    const deferred: Array<(v: ConversationMessage) => void> = []
+    vi.mocked(continueThread).mockImplementation(
+      () => new Promise((resolve) => { deferred.push(resolve) }),
+    )
+
+    const { getByPlaceholderText, getByRole } = render(
+      <AnnotationCard annotation={annotation} isActive={true} />,
+    )
+
+    sendViaFollowUpInput(getByPlaceholderText, 'First question')
+    await waitFor(() => expect(continueThread).toHaveBeenCalledTimes(1))
+    expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('resolving')
+
+    // FollowUpInput disables itself once resolving, but the provocation's
+    // "Tell me more" button carries no such guard — it reaches the same
+    // handleFollowUp and must not be blocked or its reply discarded.
+    fireEvent.click(getByRole('button', { name: /tell me more/i }))
+    await waitFor(() => expect(continueThread).toHaveBeenCalledTimes(2))
+
+    deferred[0]({ id: 'reply-a', role: 'agent', content: 'Reply A', suggestedEdit: null, timestamp: 100 })
+    deferred[1]({ id: 'reply-b', role: 'agent', content: 'Reply B', suggestedEdit: null, timestamp: 101 })
+    await waitFor(() =>
+      expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('resolved'),
+    )
+
+    const live = useAnnotationStore.getState().getById('ann-1')
+    expect(live?.conversation.some((m) => m.id === 'reply-a')).toBe(true)
+    expect(live?.conversation.some((m) => m.id === 'reply-b')).toBe(true)
+    expect(
+      useToastStore.getState().toasts.some((t) => /already been applied or dismissed/i.test(t.message)),
+    ).toBe(false)
+  })
+})

--- a/src/components/Annotations/__tests__/annotationCard.followUpStaleConversation.test.tsx
+++ b/src/components/Annotations/__tests__/annotationCard.followUpStaleConversation.test.tsx
@@ -136,6 +136,53 @@ describe('AnnotationCard.handleFollowUp vs. a concurrent conversation collapse /
     expect(toasts[0].message).toMatch(/changed while replying/i)
   })
 
+  // Regression for a gap an adversarial review of this fix found: the
+  // success path above discards a stale-context REPLY, but the catch path
+  // (continueThread REJECTS instead of resolving) had no equivalent check —
+  // a request that fails after a collapse would silently attach its error
+  // message to the fresh, post-collapse conversation. Same bug class as
+  // #100/#104, just on the failure branch instead of the success branch.
+  it('discards a stale-context error message and toasts instead of appending it, when continueThread rejects after a collapse', async () => {
+    const annotation = makeAnnotation()
+    useAnnotationStore.setState({ annotations: [annotation] })
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    let rejectRequest: (err: Error) => void
+    const pending = new Promise<ConversationMessage>((_resolve, reject) => {
+      rejectRequest = reject
+    })
+    vi.mocked(continueThread).mockReturnValue(pending)
+
+    const { getByPlaceholderText } = render(<AnnotationCard annotation={annotation} isActive={true} />)
+    sendViaFollowUpInput(getByPlaceholderText, 'Tell me more about that')
+
+    await waitFor(() => expect(continueThread).toHaveBeenCalledTimes(1))
+    // Simulate "Simplify thread" collapsing the conversation before the
+    // in-flight follow-up settles.
+    useAnnotationStore.getState().update('ann-1', {
+      conversation: [
+        { id: 'summary-1', role: 'agent', content: 'A concise summary.', suggestedEdit: null, timestamp: 99 },
+      ],
+    })
+
+    rejectRequest!(new Error('network fail'))
+    await pending.catch(() => {})
+    await waitFor(() =>
+      expect(useAnnotationStore.getState().getById('ann-1')?.status).toBe('resolved'),
+    )
+
+    const live = useAnnotationStore.getState().getById('ann-1')
+    expect(live?.conversation).toHaveLength(1)
+    expect(live?.conversation.map((m) => m.id)).toEqual(['summary-1'])
+    expect(live?.conversation.some((m) => m.content.includes('network fail'))).toBe(false)
+
+    const toasts = useToastStore.getState().toasts
+    expect(toasts).toHaveLength(1)
+    expect(toasts[0].type).toBe('error')
+    expect(toasts[0].message).toMatch(/changed while replying/i)
+  })
+
   it('does not resurrect a terminal status set by a concurrent action (e.g. Apply) while a follow-up is in flight', async () => {
     const annotation = makeAnnotation()
     useAnnotationStore.setState({ annotations: [annotation] })


### PR DESCRIPTION
## Summary

`ResolutionActions.tsx`'s `sendFollowUp` was hardened against two races for issue #100 (three rounds of adversarial review): a `continueThread` reply generated from a conversation that gets collapsed (e.g. "Simplify thread") while the request is in flight silently attaching to the fresh, post-collapse conversation; and a late-settling follow-up unconditionally overwriting a terminal `applied`/`dismissed` status.

Adversarial review of that fix (round 3) found a second, completely separate call site with the identical vulnerability, left unpatched: `AnnotationCard.tsx`'s own `handleFollowUp` — wired to `FollowUpInput`'s free-text send box and the "Tell me more" button on a MADS provocation callout.

This PR applies the same two guards to `handleFollowUp`:

- **Stale-conversation guard:** snapshot the message ids the request was generated from (from a fresh store read, after the user message is added — not the closure-captured `annotation` prop); if none survive in the live conversation when the request settles, discard the response and toast instead of appending it. Id-overlap (not array reference equality) distinguishes a real collapse from a benign concurrent write, same as #100's fix.
- **Status-clobber guard, both ends:** entry — bail out (with a toast) before touching the conversation or calling `continueThread` at all if the annotation's live status is already `applied`/`dismissed` (checked directly, not via `canTransition`, since `lifecycle.ts`'s `TRANSITIONS['resolving']` doesn't list `'resolving'` itself and would wrongly block a second legitimate concurrent follow-up). Exit — only write `status: 'resolved'` while the annotation's live status is still `'resolving'`.

## Process

Two rounds of adversarial (troublemaker) review:
1. **Round 1 (NO-MERGE):** the success path was correctly guarded, but the catch/error path was not — an unconditional `addMessage` of the error message meant a request that *rejects* (rather than resolves) after a collapse would still silently attach its error message to the fresh, post-collapse conversation. Reproduced concretely by the reviewer.
2. **Round 2 (MERGE):** fixed by hoisting the conversation-id snapshot above the `try` and sharing a single `liveIfNotCollapsed()` check between the success and catch paths, so they can't drift out of sync on this again. Independently re-verified: the new regression test fails against pre-fix code and passes against the fix; both paths now call the shared guard; no other unconditional `addMessage`/status write remains.

Deliberately did **not** extract a shared helper across `AnnotationCard.tsx` and `ResolutionActions.tsx` (the issue explicitly invited considering it) — their catch-path behavior genuinely differs (one appends a visible error message to the conversation transcript, the other only toasts), and unifying would have forced a behavior change not requested by the issue. The reviewer flagged this as worth a future design-consistency pass but not a blocker here.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run test` — 1084 passed + 10 skipped (was 1072; +12 new, incl. 1 in `resolutionActions` collateral coverage)
- [x] New file `src/components/Annotations/__tests__/annotationCard.followUpStaleConversation.test.tsx` (5 tests): stale-context reply discarded + toast; stale-context *error* discarded + toast (the round-1 finding); concurrent terminal action not resurrected; follow-up refused with no network call when already terminal at entry; a second concurrent follow-up from a different entry point (the provocation button) is not blocked or discarded.
- [x] Each regression test verified to fail against pre-fix code (via `git stash`) and pass against the fix.

Closes #104

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZMCpwCWVJyiS3gihKSGpE)_