### PR TITLE
Gate document delete behind a confirmation modal

### DIFF
--- a/src/components/Layout/DocumentHubSidebar.tsx
+++ b/src/components/Layout/DocumentHubSidebar.tsx
@@ -22,7 +22,6 @@ export function DocumentHubSidebar() {
   const deleteCollection = useDocumentStore((s) => s.deleteCollection)
   const assignDocumentToCollection = useDocumentStore((s) => s.assignDocumentToCollection)
   const removeDocumentFromCollection = useDocumentStore((s) => s.removeDocumentFromCollection)
-  const annotations = useAnnotationStore((s) => s.annotations)
 
   // Deleting a document must also purge its annotations (and, via remove()'s
   // own purge, any held answers) — otherwise they're orphaned forever, still
@@ -38,9 +37,14 @@ export function DocumentHubSidebar() {
   // #107/#109, now also silently destroys every annotation for the document
   // in the same click.
   const [deleteTarget, setDeleteTarget] = useState<DocumentMeta | null>(null)
-  const deleteTargetAnnotationCount = useMemo(
-    () => (deleteTarget ? annotations.filter((a) => a.documentId === deleteTarget.id).length : 0),
-    [annotations, deleteTarget]
+  // Selected as a derived primitive (not a subscription to the whole
+  // `annotations` array) so this component doesn't re-render on every
+  // annotation mutation elsewhere in the app (e.g. every streamed token of
+  // an unrelated AI resolution) — only when the count for the *targeted*
+  // document actually changes, which is only possible while the modal is
+  // open.
+  const deleteTargetAnnotationCount = useAnnotationStore((s) =>
+    deleteTarget ? s.annotations.filter((a) => a.documentId === deleteTarget.id).length : 0
   )
   const confirmDelete = () => {
     if (!deleteTarget) return

--- a/src/components/Layout/DocumentHubSidebar.tsx
+++ b/src/components/Layout/DocumentHubSidebar.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { useDocumentStore, type CollectionMeta, type DocumentMeta } from '@/stores/documentStore'
 import { useAnnotationStore } from '@/stores/annotationStore'
+import { Confirmation } from '@/components/ui/Confirmation'
 
 function sortDocsByRecent(docs: DocumentMeta[]): DocumentMeta[] {
   return [...docs].sort((a, b) => b.updatedAt - a.updatedAt)
@@ -21,6 +22,7 @@ export function DocumentHubSidebar() {
   const deleteCollection = useDocumentStore((s) => s.deleteCollection)
   const assignDocumentToCollection = useDocumentStore((s) => s.assignDocumentToCollection)
   const removeDocumentFromCollection = useDocumentStore((s) => s.removeDocumentFromCollection)
+  const annotations = useAnnotationStore((s) => s.annotations)
 
   // Deleting a document must also purge its annotations (and, via remove()'s
   // own purge, any held answers) — otherwise they're orphaned forever, still
@@ -29,6 +31,21 @@ export function DocumentHubSidebar() {
   const handleDeleteDocument = (documentId: string) => {
     useAnnotationStore.getState().removeByDocumentId(documentId)
     deleteDocument(documentId)
+  }
+
+  // Both delete entry points route through this confirmation gate rather
+  // than deleting on click (#110) — deletion is irreversible and, since
+  // #107/#109, now also silently destroys every annotation for the document
+  // in the same click.
+  const [deleteTarget, setDeleteTarget] = useState<DocumentMeta | null>(null)
+  const deleteTargetAnnotationCount = useMemo(
+    () => (deleteTarget ? annotations.filter((a) => a.documentId === deleteTarget.id).length : 0),
+    [annotations, deleteTarget]
+  )
+  const confirmDelete = () => {
+    if (!deleteTarget) return
+    handleDeleteDocument(deleteTarget.id)
+    setDeleteTarget(null)
   }
 
   const [expandedCollections, setExpandedCollections] = useState<Set<string>>(new Set())
@@ -163,7 +180,7 @@ export function DocumentHubSidebar() {
               onActivate={() => setActiveDocument(doc.id)}
               onStartRename={() => startRenameDocument(doc)}
               onDuplicate={() => duplicateDocument(doc.id)}
-              onDelete={() => handleDeleteDocument(doc.id)}
+              onDelete={() => setDeleteTarget(doc)}
               onAssignToCollection={(collectionId) => assignDocumentToCollection(doc.id, collectionId)}
               onRemoveFromCollection={(collectionId) => removeDocumentFromCollection(doc.id, collectionId)}
             />
@@ -259,7 +276,7 @@ export function DocumentHubSidebar() {
                       onActivate={() => setActiveDocument(doc.id)}
                       onStartRename={() => startRenameDocument(doc)}
                       onDuplicate={() => duplicateDocument(doc.id)}
-                      onDelete={() => handleDeleteDocument(doc.id)}
+                      onDelete={() => setDeleteTarget(doc)}
                       onAssignToCollection={(collectionId) => assignDocumentToCollection(doc.id, collectionId)}
                       onRemoveFromCollection={(collectionId) => removeDocumentFromCollection(doc.id, collectionId)}
                       compact
@@ -295,6 +312,28 @@ export function DocumentHubSidebar() {
           </div>
         )}
       </section>
+
+      {deleteTarget && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+            <Confirmation
+              title="Delete this document?"
+              description={
+                deleteTargetAnnotationCount > 0
+                  ? `"${deleteTarget.title}" and its ${deleteTargetAnnotationCount} annotation${
+                      deleteTargetAnnotationCount === 1 ? '' : 's'
+                    } will be permanently deleted. This cannot be undone.`
+                  : `"${deleteTarget.title}" will be permanently deleted. This cannot be undone.`
+              }
+              confirmLabel="Delete"
+              cancelLabel="Cancel"
+              variant="destructive"
+              onConfirm={confirmDelete}
+              onCancel={() => setDeleteTarget(null)}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/Layout/__tests__/documentHubSidebar.deleteConfirmation.test.tsx
+++ b/src/components/Layout/__tests__/documentHubSidebar.deleteConfirmation.test.tsx
@@ -1,13 +1,17 @@
 // @vitest-environment jsdom
 import { describe, it, expect, afterEach } from 'vitest'
-import { render, fireEvent, cleanup, within } from '@testing-library/react'
+import { render, fireEvent, cleanup } from '@testing-library/react'
 import { DocumentHubSidebar } from '@/components/Layout/DocumentHubSidebar'
-import { useDocumentStore, type DocumentMeta } from '@/stores/documentStore'
+import { useDocumentStore, type CollectionMeta, type DocumentMeta } from '@/stores/documentStore'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import type { Annotation } from '@/lib/annotations/types'
 
-function makeDocument(id: string, title: string): DocumentMeta {
-  return { id, title, createdAt: 0, updatedAt: 0, collectionIds: [] }
+function makeDocument(id: string, title: string, collectionIds: string[] = []): DocumentMeta {
+  return { id, title, createdAt: 0, updatedAt: 0, collectionIds }
+}
+
+function makeCollection(id: string, name: string): CollectionMeta {
+  return { id, name, createdAt: 0, updatedAt: 0 }
 }
 
 function makeAnnotation(id: string, documentId: string): Annotation {
@@ -105,5 +109,37 @@ describe('DocumentHubSidebar delete confirmation gate (#110)', () => {
     const description = container.querySelector('.confirmation-description')?.textContent ?? ''
     expect(description).toMatch(/Empty Doc/)
     expect(description).not.toMatch(/annotation/)
+  })
+
+  // Distinct from the "All documents" list above: a document assigned to a
+  // collection renders a SECOND DocumentRow (with its own delete button)
+  // inside the expanded collection section (DocumentHubSidebar.tsx's
+  // `isExpanded` branch) — a separate onDelete call site from the
+  // "All documents" one already covered. Verified this test actually
+  // exercises that second call site and isn't vacuous: reverting only that
+  // call site back to `onDelete={() => handleDeleteDocument(doc.id)}` (while
+  // leaving the "All documents" one fixed) makes this test fail.
+  it('gates delete for the second call site inside an expanded collection', () => {
+    useDocumentStore.setState({
+      documents: [makeDocument('doc-1', 'Collected Doc', ['col-1'])],
+      collections: [makeCollection('col-1', 'My Collection')],
+    })
+    useAnnotationStore.setState({ annotations: [makeAnnotation('ann-1', 'doc-1')] })
+
+    const { getByText, getAllByLabelText } = render(<DocumentHubSidebar />)
+
+    // Expand the collection so its DocumentRow (and delete button) mounts.
+    fireEvent.click(getByText('My Collection'))
+
+    const deleteButtons = getAllByLabelText('Delete document')
+    // One in "All documents", one in the now-expanded collection section.
+    expect(deleteButtons).toHaveLength(2)
+
+    fireEvent.click(deleteButtons[1])
+
+    // Still present — the collection row's delete button must also gate.
+    expect(useDocumentStore.getState().documents).toHaveLength(1)
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+    expect(getByText('Delete this document?')).toBeTruthy()
   })
 })

--- a/src/components/Layout/__tests__/documentHubSidebar.deleteConfirmation.test.tsx
+++ b/src/components/Layout/__tests__/documentHubSidebar.deleteConfirmation.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, cleanup, within } from '@testing-library/react'
+import { DocumentHubSidebar } from '@/components/Layout/DocumentHubSidebar'
+import { useDocumentStore, type DocumentMeta } from '@/stores/documentStore'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import type { Annotation } from '@/lib/annotations/types'
+
+function makeDocument(id: string, title: string): DocumentMeta {
+  return { id, title, createdAt: 0, updatedAt: 0, collectionIds: [] }
+}
+
+function makeAnnotation(id: string, documentId: string): Annotation {
+  return {
+    id,
+    documentId,
+    locationGroupKey: `${documentId}:0:10`,
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'annotation',
+    anchor: { from: 0, to: 10, scope: 'phrase', text: 'x' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  useDocumentStore.setState({
+    documents: [],
+    collections: [],
+    activeDocumentId: null,
+    lastSavedAt: null,
+    isDirty: false,
+  })
+  useAnnotationStore.setState({ annotations: [], activeAnnotationId: null })
+})
+
+// Regression for #110: both onDelete call sites went straight to
+// handleDeleteDocument with no confirmation step, and since #109 that also
+// silently purges every annotation for the document in the same click.
+describe('DocumentHubSidebar delete confirmation gate (#110)', () => {
+  it('does not delete the document or its annotations until the user confirms', () => {
+    useDocumentStore.setState({ documents: [makeDocument('doc-1', 'My Document')] })
+    useAnnotationStore.setState({
+      annotations: [makeAnnotation('ann-1', 'doc-1'), makeAnnotation('ann-2', 'doc-1')],
+    })
+
+    const { getByLabelText, container } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete document'))
+
+    // Still present — clicking the trash icon alone must not delete anything.
+    expect(useDocumentStore.getState().documents).toHaveLength(1)
+    expect(useAnnotationStore.getState().annotations).toHaveLength(2)
+
+    // The gate names what will be lost.
+    const description = container.querySelector('.confirmation-description')?.textContent ?? ''
+    expect(description).toMatch(/My Document/)
+    expect(description).toMatch(/2 annotations/)
+  })
+
+  it('deletes the document and purges its annotations once confirmed', () => {
+    useDocumentStore.setState({ documents: [makeDocument('doc-1', 'My Document')] })
+    useAnnotationStore.setState({
+      annotations: [makeAnnotation('ann-1', 'doc-1'), makeAnnotation('ann-2', 'doc-2')],
+    })
+
+    const { getByLabelText, getByRole } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete document'))
+    fireEvent.click(getByRole('button', { name: 'Delete' }))
+
+    expect(useDocumentStore.getState().documents).toHaveLength(0)
+    expect(useAnnotationStore.getState().annotations.map((a) => a.id)).toEqual(['ann-2'])
+  })
+
+  it('leaves the document and its annotations untouched when cancelled', () => {
+    useDocumentStore.setState({ documents: [makeDocument('doc-1', 'My Document')] })
+    useAnnotationStore.setState({ annotations: [makeAnnotation('ann-1', 'doc-1')] })
+
+    const { getByLabelText, getByRole, queryByText } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete document'))
+    fireEvent.click(getByRole('button', { name: 'Cancel' }))
+
+    expect(useDocumentStore.getState().documents).toHaveLength(1)
+    expect(useAnnotationStore.getState().annotations).toHaveLength(1)
+    expect(queryByText('Delete this document?')).toBeFalsy()
+  })
+
+  it('does not mention an annotation count when the document has none', () => {
+    useDocumentStore.setState({ documents: [makeDocument('doc-1', 'Empty Doc')] })
+    useAnnotationStore.setState({ annotations: [] })
+
+    const { getByLabelText, container } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete document'))
+
+    const description = container.querySelector('.confirmation-description')?.textContent ?? ''
+    expect(description).toMatch(/Empty Doc/)
+    expect(description).not.toMatch(/annotation/)
+  })
+})


### PR DESCRIPTION
## Summary

`DocumentHubSidebar.tsx`'s two delete entry points ("All documents" list and each expanded collection's document list) deleted a document — and, since PR #109, every one of its annotations — on a single click with no confirmation step. This has been called out twice as a known gap and deferred both times (PR #106, issue #107).

- Both `onDelete` call sites now route through a `deleteTarget` state instead of deleting directly.
- A `Confirmation` modal (same pattern as `HistoryPanel.tsx`'s restore gate) names the document title and its live annotation count before `handleDeleteDocument` runs.
- The annotation count is selected as a derived primitive (not a subscription to the whole `annotations` array), so the component doesn't re-render on every annotation mutation elsewhere in the app — only when the count for the *targeted* document actually changes.
- `deleteCollection` is untouched — traced into `documentStore.ts` and confirmed it never deletes documents or touches `annotationStore`, so it's out of scope per the issue.

## Process

Pre-push adversarial review (troublemaker agent) found two real issues, both fixed before this push:
- **HIGH:** the collection-list `onDelete` call site had no dedicated test coverage — reverting just that one call site back to a direct delete still passed all 4 original tests. Added a 5th test that expands a collection and exercises its delete button; verified concretely that it fails against the reverted call site.
- **MEDIUM:** the original fix subscribed to the whole `annotations` array, which would re-render this component on every annotation mutation anywhere in the app (e.g. every streamed token of an unrelated AI resolution). Changed to a derived-primitive selector scoped to the targeted document.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1093 passing + 10 skipped (was 1090 before this PR)
- [x] New regression tests in `documentHubSidebar.deleteConfirmation.test.tsx`: blocks delete until confirmed, deletes + purges annotations on confirm, no-op on cancel, no annotation-count text when count is 0, and gates the second (collection-list) call site independently

Closes #110

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2wN4iQgeEoz2F95WUjXCV)_