### PR TITLE
Stop wiping every document's annotations/changes on new-document creation

### DIFF
--- a/src/components/DocInput/DocInputModal.tsx
+++ b/src/components/DocInput/DocInputModal.tsx
@@ -4,8 +4,6 @@ import { useState } from 'react'
 import { schema } from '@/lib/prosemirror/schema'
 import { useEditorStore } from '@/stores/editorStore'
 import { useSettingsStore } from '@/stores/settingsStore'
-import { useAnnotationStore } from '@/stores/annotationStore'
-import { useChangesStore } from '@/stores/changesStore'
 import { useSessionStore } from '@/stores/sessionStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -42,9 +40,12 @@ export function DocInputModal({ onClose }: DocInputModalProps) {
       collectionIds: collectionId ? [collectionId] : [],
     })
 
-    // Reset session state for new document
-    useAnnotationStore.getState().clear()
-    useChangesStore.getState().clear()
+    // Reset session-level (non-document-scoped) state for the new document.
+    // annotationStore/changesStore are NOT cleared here: their entries are
+    // already scoped by documentId and filtered per-document by every review
+    // surface (AnnotationPanel, ChangesPanel), so the new (empty) document
+    // shows nothing on its own. A global clear() would instead silently wipe
+    // every OTHER existing document's annotations and change history (#114).
     useSessionStore.getState().reset()
 
     onClose()

--- a/src/components/DocInput/__tests__/docInputModal.crossDocumentClear.test.tsx
+++ b/src/components/DocInput/__tests__/docInputModal.crossDocumentClear.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { EditorState } from 'prosemirror-state'
+import { EditorView } from 'prosemirror-view'
+import { DocInputModal } from '@/components/DocInput/DocInputModal'
+import { useEditorStore } from '@/stores/editorStore'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useChangesStore } from '@/stores/changesStore'
+import { schema } from '@/lib/prosemirror/schema'
+import type { Annotation } from '@/lib/annotations/types'
+import type { ChangeEntry, ChangeSet } from '@/lib/changes/changeLog'
+
+function mountView(): EditorView {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', { blockId: 'b1' }, [schema.text('Existing content.')]),
+  ])
+  const state = EditorState.create({ schema, doc })
+  const view: EditorView = new EditorView(host, {
+    state,
+    dispatchTransaction(transaction) {
+      view.updateState(view.state.apply(transaction))
+    },
+  })
+  return view
+}
+
+function makeAnnotation(id: string, documentId: string): Annotation {
+  return {
+    id,
+    documentId,
+    locationGroupKey: `${documentId}:0:10`,
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'annotation',
+    anchor: { from: 0, to: 10, scope: 'phrase', text: 'x' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+function makeChangeEntry(id: string, documentId: string): ChangeEntry {
+  return {
+    id,
+    documentId,
+    rootAnnotationId: null,
+    annotationId: null,
+    timestamp: 0,
+    description: 'edit',
+    beforeSlice: 'a',
+    afterSlice: 'b',
+    from: 0,
+    to: 1,
+    pmStep: null,
+    undone: false,
+  }
+}
+
+function makeChangeSet(id: string, documentId: string): ChangeSet {
+  return {
+    id,
+    documentId,
+    rootAnnotationId: 'ann-a',
+    annotationIds: ['ann-a'],
+    changeEntryIds: [],
+    auditRecordIds: [],
+    title: 'Thread',
+    status: 'pending',
+    updatedAt: 0,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  const view = useEditorStore.getState().view as EditorView | null
+  view?.destroy()
+  useEditorStore.setState({ view: null })
+  useDocumentStore.setState({ documents: [], collections: [], activeDocumentId: null })
+  useAnnotationStore.setState({ annotations: [], activeAnnotationId: null })
+  useChangesStore.setState({ entries: [], changeSets: [], snapshots: [] })
+})
+
+// Regression for #114: DocInputModal's loadDoc() (shared by Blank/Paste/
+// Generate/Import) called the GLOBAL annotationStore.clear() /
+// changesStore.clear() after creating a brand-new document — wiping every
+// OTHER existing document's annotations and change history, not just
+// resetting state for the new (empty) document.
+describe('DocInputModal loadDoc() does not wipe other documents (#114)', () => {
+  it('creating a blank document leaves an existing document\'s annotations and change history intact', () => {
+    useDocumentStore.setState({ documents: [{ id: 'doc-a', title: 'Doc A', createdAt: 0, updatedAt: 0, collectionIds: [] }] })
+    useAnnotationStore.setState({ annotations: [makeAnnotation('ann-a', 'doc-a')] })
+    useChangesStore.setState({
+      entries: [makeChangeEntry('entry-a', 'doc-a')],
+      changeSets: [makeChangeSet('set-a', 'doc-a')],
+      snapshots: [],
+    })
+
+    const view = mountView()
+    useEditorStore.setState({ view })
+
+    const { getByText } = render(<DocInputModal onClose={() => {}} />)
+    fireEvent.click(getByText('Create Blank Document'))
+
+    // A new document was created...
+    expect(useDocumentStore.getState().documents).toHaveLength(2)
+
+    // ...but Doc A's review history survives untouched.
+    expect(useAnnotationStore.getState().annotations.map((a) => a.id)).toEqual(['ann-a'])
+    expect(useChangesStore.getState().entries.map((e) => e.id)).toEqual(['entry-a'])
+    expect(useChangesStore.getState().changeSets.map((c) => c.id)).toEqual(['set-a'])
+  })
+})


### PR DESCRIPTION
## Summary

`DocInputModal.tsx`'s `loadDoc()` (the shared path behind Blank/Paste/Generate/Import) created a new document via `useDocumentStore.getState().createDocument(...)`, then unconditionally called the **global** `useAnnotationStore.getState().clear()` and `useChangesStore.getState().clear()`. Both wipe the entire `annotations`/`entries`/`changeSets`/`snapshots` arrays — not scoped to any document — so creating/pasting/generating/importing a document silently destroyed every *other* open document's annotations and change history with no warning.

Every review surface that reads these stores already filters by `documentId === activeDocumentId` (`AnnotationPanel.tsx:56`, `AnnotationMap.tsx`, `ChangesPanel.tsx:47-49`, `FloatingAnswer.tsx:69`), so a freshly created (empty) document was always going to render with zero annotations/changes regardless of whether the old data was cleared. The `clear()` calls were therefore both destructive and unnecessary.

**Fix:** removed the `useAnnotationStore.getState().clear()` / `useChangesStore.getState().clear()` calls (and their now-unused imports) from `loadDoc()`, keeping only `useSessionStore.getState().reset()` (genuinely session-level, non-document-scoped state).

## Process

Adversarial (troublemaker) review returned **MERGE**. It verified:
- Every consumer of the affected stores filters by active document, so leaving other documents' data in place is safe and correct.
- Dropping `clearHeldAnswers()` (previously called transitively) is itself a companion fix — it no longer force-reveals every buffered answer across *other* open documents when a new one is created.
- No stale-`activeAnnotationId` crash risk — every reader gates on `documentId === activeDocumentId` or clamps ranges.
- The new regression test drives the real `DocInputModal` component end-to-end and was verified to actually fail against the pre-fix code (`git stash` round-trip), not a vacuous assertion.
- Grepped for other call sites of the old `clear()` calls — none; all four entry points (Blank/Paste/Generate/Import) share the one `loadDoc()` path.

The review also surfaced two related-but-out-of-scope pre-existing bugs in the same area, filed as follow-ups rather than folded in:
- #116 — `StatusBar.tsx` shows global (not per-document) annotation/change counts.
- #117 — `DocInputModal.tsx`'s replace transaction isn't marked `addToHistory: false`, so Cmd-Z right after creating a document can resurrect the previous document's content and autosave it under the new document's id.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — clean
- [x] `npm run test` — 1094 passed + 10 skipped
- [x] New test `src/components/DocInput/__tests__/docInputModal.crossDocumentClear.test.tsx`: creates Document A with an annotation, a change entry, and a change set, drives the Blank flow to create Document B, and asserts Document A's data is untouched. Verified to fail on pre-fix code.

Closes #114

---
_Generated by [Claude Code](https://claude.ai/code/session_017Q4jxzkwTH2F1pumfvd3Gb)_