### PR TITLE
Gate collection delete behind a confirmation step

### DIFF
--- a/src/components/Layout/DocumentHubSidebar.tsx
+++ b/src/components/Layout/DocumentHubSidebar.tsx
@@ -52,6 +52,23 @@ export function DocumentHubSidebar() {
     setDeleteTarget(null)
   }
 
+  // Second delete entry point gated the same way as document delete (#115) —
+  // deleteCollection never cascade-deletes member documents (only strips
+  // their collectionIds), but losing the collection's name/identity and
+  // every document's membership in it is still a one-click, irreversible
+  // loss the HITL principle requires a confirmation step for.
+  const [deleteCollectionTarget, setDeleteCollectionTarget] = useState<CollectionMeta | null>(null)
+  const deleteCollectionTargetDocCount = useDocumentStore((s) =>
+    deleteCollectionTarget
+      ? s.documents.filter((doc) => (doc.collectionIds ?? []).includes(deleteCollectionTarget.id)).length
+      : 0
+  )
+  const confirmDeleteCollection = () => {
+    if (!deleteCollectionTarget) return
+    deleteCollection(deleteCollectionTarget.id)
+    setDeleteCollectionTarget(null)
+  }
+
   const [expandedCollections, setExpandedCollections] = useState<Set<string>>(new Set())
   const [renamingDocId, setRenamingDocId] = useState<string | null>(null)
   const [renamingCollectionId, setRenamingCollectionId] = useState<string | null>(null)
@@ -253,7 +270,7 @@ export function DocumentHubSidebar() {
                   <button
                     onClick={(e) => {
                       e.stopPropagation()
-                      deleteCollection(collection.id)
+                      setDeleteCollectionTarget(collection)
                     }}
                     aria-label="Delete collection"
                     className="p-0.5 text-xs text-red-400 hover:text-red-600"
@@ -334,6 +351,28 @@ export function DocumentHubSidebar() {
               variant="destructive"
               onConfirm={confirmDelete}
               onCancel={() => setDeleteTarget(null)}
+            />
+          </div>
+        </div>
+      )}
+
+      {deleteCollectionTarget && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 p-6">
+            <Confirmation
+              title="Delete this collection?"
+              description={
+                deleteCollectionTargetDocCount > 0
+                  ? `"${deleteCollectionTarget.name}" will be permanently deleted. Its ${deleteCollectionTargetDocCount} document${
+                      deleteCollectionTargetDocCount === 1 ? '' : 's'
+                    } will be un-assigned from it but not deleted. This cannot be undone.`
+                  : `"${deleteCollectionTarget.name}" will be permanently deleted. This cannot be undone.`
+              }
+              confirmLabel="Delete"
+              cancelLabel="Cancel"
+              variant="destructive"
+              onConfirm={confirmDeleteCollection}
+              onCancel={() => setDeleteCollectionTarget(null)}
             />
           </div>
         </div>

--- a/src/components/Layout/__tests__/documentHubSidebar.deleteCollectionConfirmation.test.tsx
+++ b/src/components/Layout/__tests__/documentHubSidebar.deleteCollectionConfirmation.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, fireEvent, cleanup } from '@testing-library/react'
+import { DocumentHubSidebar } from '@/components/Layout/DocumentHubSidebar'
+import { useDocumentStore, type CollectionMeta, type DocumentMeta } from '@/stores/documentStore'
+import { useAnnotationStore } from '@/stores/annotationStore'
+
+function makeDocument(id: string, title: string, collectionIds: string[] = []): DocumentMeta {
+  return { id, title, createdAt: 0, updatedAt: 0, collectionIds }
+}
+
+function makeCollection(id: string, name: string): CollectionMeta {
+  return { id, name, createdAt: 0, updatedAt: 0 }
+}
+
+afterEach(() => {
+  cleanup()
+  useDocumentStore.setState({
+    documents: [],
+    collections: [],
+    activeDocumentId: null,
+    lastSavedAt: null,
+    isDirty: false,
+  })
+  useAnnotationStore.setState({ annotations: [], activeAnnotationId: null })
+})
+
+// Regression for #115: the collection delete button went straight to
+// deleteCollection with no confirmation step, unlike document delete (#110).
+describe('DocumentHubSidebar delete-collection confirmation gate (#115)', () => {
+  it('does not delete the collection until the user confirms', () => {
+    useDocumentStore.setState({
+      collections: [makeCollection('col-1', 'My Collection')],
+      documents: [makeDocument('doc-1', 'Doc A', ['col-1']), makeDocument('doc-2', 'Doc B', ['col-1'])],
+    })
+
+    const { getByLabelText, container } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete collection'))
+
+    // Still present — clicking the trash icon alone must not delete anything.
+    expect(useDocumentStore.getState().collections).toHaveLength(1)
+    expect(useDocumentStore.getState().documents[0].collectionIds).toEqual(['col-1'])
+
+    // The gate names what will be lost.
+    const description = container.querySelector('.confirmation-description')?.textContent ?? ''
+    expect(description).toMatch(/My Collection/)
+    expect(description).toMatch(/2 documents/)
+  })
+
+  it('deletes the collection and un-assigns its documents once confirmed', () => {
+    useDocumentStore.setState({
+      collections: [makeCollection('col-1', 'My Collection')],
+      documents: [makeDocument('doc-1', 'Doc A', ['col-1'])],
+    })
+
+    const { getByLabelText, getByRole } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete collection'))
+    fireEvent.click(getByRole('button', { name: 'Delete' }))
+
+    expect(useDocumentStore.getState().collections).toHaveLength(0)
+    // The document itself is not deleted — only un-assigned from the collection.
+    expect(useDocumentStore.getState().documents).toHaveLength(1)
+    expect(useDocumentStore.getState().documents[0].collectionIds).toEqual([])
+  })
+
+  it('leaves the collection untouched when cancelled', () => {
+    useDocumentStore.setState({
+      collections: [makeCollection('col-1', 'My Collection')],
+      documents: [makeDocument('doc-1', 'Doc A', ['col-1'])],
+    })
+
+    const { getByLabelText, getByRole, queryByText } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete collection'))
+    fireEvent.click(getByRole('button', { name: 'Cancel' }))
+
+    expect(useDocumentStore.getState().collections).toHaveLength(1)
+    expect(useDocumentStore.getState().documents[0].collectionIds).toEqual(['col-1'])
+    expect(queryByText('Delete this collection?')).toBeFalsy()
+  })
+
+  it('does not mention a document count when the collection is empty', () => {
+    useDocumentStore.setState({ collections: [makeCollection('col-1', 'Empty Collection')] })
+
+    const { getByLabelText, container } = render(<DocumentHubSidebar />)
+
+    fireEvent.click(getByLabelText('Delete collection'))
+
+    const description = container.querySelector('.confirmation-description')?.textContent ?? ''
+    expect(description).toMatch(/Empty Collection/)
+    expect(description).not.toMatch(/document/)
+  })
+})


### PR DESCRIPTION
## Summary
- `DocumentHubSidebar.tsx`'s "Delete collection" button called `deleteCollection` directly on click, with no confirmation step — unlike document delete, which already routes through the `Confirmation` HITL gate (#110/PR #112).
- Added the same gate for collection delete: clicking the trash icon now opens a `Confirmation` modal naming the collection and how many documents will be un-assigned from it, and `deleteCollection` only fires on explicit confirm.
- `deleteCollection`'s own behavior is untouched (it does not cascade-delete member documents — confirmed pre-existing behavior, out of scope per the issue).

## Test plan
- [x] New regression test file `documentHubSidebar.deleteCollectionConfirmation.test.tsx` (4 tests): delete is a no-op until confirmed and the modal names the collection + doc count; confirming deletes the collection and un-assigns (not deletes) its documents; cancelling leaves everything untouched; an empty collection's description omits "document".
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1104 passing + 10 skipped (up from 1100)
- [x] Adversarial review (troublemaker agent): verdict MERGE, mutation-tested (reverting the fix makes the new tests fail as expected)

Closes #115

---
_Generated by [Claude Code](https://claude.ai/code/session_0198n4DSHK45AeRoHc52bhPQ)_