### PR TITLE
Scope StatusBar counts to the active document

### DIFF
--- a/memory-bank/changelog.md
+++ b/memory-bank/changelog.md
@@ -5,6 +5,20 @@ All notable changes to the Intent IDE project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026-08-27] StatusBar chip counts scoped to active document — fix delivered, PR #120 open (not yet merged)
+
+### Fixed
+- **`StatusBar.tsx`'s annotation/change-set/change count chips** now filter by `documentId === activeDocumentId`, matching every other consumer of `annotationStore`/`changesStore` (`AnnotationPanel.tsx`, `ChangesPanel.tsx`). Previously read raw, unfiltered totals across all documents. Fixed by adding `activeDocumentId` from `useDocumentStore` and filtering all three chip counts by it.
+
+### Process
+- Adversarial (troublemaker) review verdict: **MERGE**. Mutation-tested — reverting only `StatusBar.tsx` makes all 3 new tests fail, confirming they aren't vacuous.
+- Two findings surfaced, both non-blocking: **(1) medium** — `inFlightCount` (the "N thinking…" chip) remains unscoped across all documents, since `documentStore.setActiveDocument` has no side effects to pause background classification/resolution on document switch; deliberately out of #116's stated scope, filed as follow-up **issue #121**. **(2) low, pre-existing, not introduced by this PR** — `changesStore.ts` has no legacy-data migration for `entries`/`changeSets` analogous to `annotationStore.ts`'s `migrateAnnotations`, so a pre-multi-document persisted change record with a missing `documentId` silently vanishes from `ChangesPanel.tsx`'s and now `StatusBar.tsx`'s filtered views; predates this PR (same filter already existed in `ChangesPanel.tsx`), not filed as a separate GitHub issue.
+- `npm run test` — 1103 passing + 10 skipped on the PR branch (1100 before this branch). `npm run typecheck` / `npm run lint` clean. New test file `src/components/Layout/__tests__/statusBar.activeDocumentScope.test.tsx`.
+
+**PR #120 (branch `claude/statusbar-active-doc-scope`, https://github.com/Vinylfigure/intent-ide/pull/120, body "Closes #116") is OPEN, not yet merged to `main` — awaiting operator review.**
+
+Closes #116 (on merge). Files #121.
+
 ## [2026-08-25] `heldAnswers` leak on annotation removal — fix delivered, PR #106 open (not yet merged)
 
 Continues a `heldAnswers` leak-fix chain this changelog has no prior entries for (issue #95 → PR #102 → issue #103 → PR #106 → issue #107); #95/#102 predate this entry and are not detailed here.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -9,6 +9,17 @@
 
 ## 2. Completed Milestones (What Works)
 
+### `StatusBar.tsx` chip counts scoped to active document -- fix delivered, PR #120 OPEN (pending operator merge, 2026-08-27)
+Closes issue #116 (task: label, filed by the repo owner; done-means: scope StatusBar's three named counts to the active document; out of scope: any change to the stores themselves).
+- [x] **`StatusBar.tsx`'s annotation/change-set/change count chips now scoped to `documentId === activeDocumentId`**, matching every other consumer of the same stores (`AnnotationPanel.tsx`, `ChangesPanel.tsx`) — previously read raw, unfiltered totals across all documents from `annotationStore`/`changesStore`. Fixed by adding `activeDocumentId` from `useDocumentStore` and filtering all three chip counts by it.
+- [x] **New test file `src/components/Layout/__tests__/statusBar.activeDocumentScope.test.tsx`** (3 tests).
+- [x] **Adversarial review (troublemaker agent) verdict: MERGE.** Mutation-tested — reverting only `StatusBar.tsx` makes all 3 new tests fail, confirming they aren't vacuous.
+- [x] **Two findings surfaced, both non-blocking, neither gates this PR (full detail in `raw_reflection_log.md`):**
+  - Medium — `inFlightCount` (the "N thinking…" chip) is still unscoped across all documents: `documentStore.setActiveDocument` has no side effects to pause background classification/resolution on document switch, so it can show "N thinking…" for unrelated background work on a different document. Deliberately left out of #116's stated scope. Filed as follow-up **issue #121** (`discovered-from: work-loop adversarial review of PR #120 for #116, 2026-08-27`).
+  - Low, pre-existing, NOT introduced by this PR — `changesStore.ts` has no legacy-data migration for `entries`/`changeSets` analogous to `annotationStore.ts`'s `migrateAnnotations`. A pre-multi-document persisted change record with a missing/undefined `documentId` would never match `activeDocumentId` and silently vanish from `ChangesPanel.tsx`'s and now `StatusBar.tsx`'s filtered views. Predates this PR (the same filter already existed in `ChangesPanel.tsx`) — this fix just surfaces the gap in one more place. Not filed as a GitHub issue; recorded as a known gap for a future session.
+- [x] **Verification:** `npm run typecheck` clean, `npm run lint` clean, `npm run test` — 1103 passing + 10 skipped (up from 1100 before this branch).
+- [ ] **PR #120 still OPEN** (branch `claude/statusbar-active-doc-scope`, https://github.com/Vinylfigure/intent-ide/pull/120, body "Closes #116") — awaiting operator review and merge. Not yet in `main`.
+
 ### `heldAnswers` leak on annotation/document removal -- fix delivered, PR #106 OPEN (pending operator merge, 2026-08-25)
 Continues a leak-fix chain this memory bank has no prior entries for: issue #95 → PR #102 → issue #103 → PR #106 (this entry) → issue #107 (filed, not yet fixed). #95/#102 predate any record in this memory bank and are not detailed here.
 - [x] **`useAnnotationStore.remove(id)`** now also calls `useFlowStore.getState().revealAnswer(id)` to purge a matching `heldAnswers[id]` entry — a held answer for a removed annotation had no live poll and could otherwise never be revealed, leaking in `useFlowStore` for the rest of the session. Adversarial review found `remove()` itself has zero production call sites (confirmed by repo-wide grep).

--- a/src/components/Layout/StatusBar.tsx
+++ b/src/components/Layout/StatusBar.tsx
@@ -4,6 +4,7 @@ import { useSettingsStore } from '@/stores/settingsStore'
 import { useAnnotationStore } from '@/stores/annotationStore'
 import { useChangesStore } from '@/stores/changesStore'
 import { useDocGraphStore } from '@/stores/docGraphStore'
+import { useDocumentStore } from '@/stores/documentStore'
 
 /** Chip state for annotations still being classified/resolved in the background. */
 function inFlightChip(count: number): { label: string; title: string } | null {
@@ -46,15 +47,22 @@ export function StatusBar() {
   const provider = useSettingsStore((s) => s.llmConfig.provider)
   const model = useSettingsStore((s) => s.llmConfig.model)
   const hasKeys = useSettingsStore((s) => s.llmConfig.apiKey.length > 0)
-  const annotationCount = useAnnotationStore((s) => s.annotations.length)
+  const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
+  const annotationCount = useAnnotationStore(
+    (s) => s.annotations.filter((a) => a.documentId === activeDocumentId).length,
+  )
   const inFlightCount = useAnnotationStore(
     (s) =>
       s.annotations.filter(
         (a) => a.status === 'pending' || a.status === 'classified' || a.status === 'resolving',
       ).length,
   )
-  const changeSetCount = useChangesStore((s) => s.changeSets.length)
-  const changeCount = useChangesStore((s) => s.entries.filter((e) => !e.undone).length)
+  const changeSetCount = useChangesStore(
+    (s) => s.changeSets.filter((cs) => cs.documentId === activeDocumentId).length,
+  )
+  const changeCount = useChangesStore(
+    (s) => s.entries.filter((e) => !e.undone && e.documentId === activeDocumentId).length,
+  )
   const graphStatus = useDocGraphStore((s) => s.status)
   const graph = useDocGraphStore((s) => s.graph)
   const chip = graphChip(graphStatus, graph)

--- a/src/components/Layout/__tests__/statusBar.activeDocumentScope.test.tsx
+++ b/src/components/Layout/__tests__/statusBar.activeDocumentScope.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { StatusBar } from '@/components/Layout/StatusBar'
+import { useDocumentStore } from '@/stores/documentStore'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useChangesStore } from '@/stores/changesStore'
+import type { Annotation } from '@/lib/annotations/types'
+import type { ChangeEntry, ChangeSet } from '@/lib/changes/changeLog'
+
+function makeAnnotation(id: string, documentId: string): Annotation {
+  return {
+    id,
+    documentId,
+    locationGroupKey: `${documentId}:0:10`,
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'annotation',
+    anchor: { from: 0, to: 10, scope: 'phrase', text: 'x' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+function makeEntry(id: string, documentId: string): ChangeEntry {
+  return {
+    id,
+    documentId,
+    rootAnnotationId: null,
+    annotationId: null,
+    timestamp: 0,
+    description: 'change',
+    beforeSlice: 'a',
+    afterSlice: 'b',
+    from: 0,
+    to: 1,
+    pmStep: null,
+    undone: false,
+  }
+}
+
+function makeChangeSet(id: string, documentId: string): ChangeSet {
+  return {
+    id,
+    documentId,
+    rootAnnotationId: 'ann-1',
+    annotationIds: [],
+    changeEntryIds: [],
+    auditRecordIds: [],
+    title: 'set',
+    status: 'pending',
+    updatedAt: 0,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  useDocumentStore.setState({
+    documents: [],
+    collections: [],
+    activeDocumentId: null,
+    lastSavedAt: null,
+    isDirty: false,
+  })
+  useAnnotationStore.setState({ annotations: [], activeAnnotationId: null })
+  useChangesStore.setState({ entries: [], changeSets: [], snapshots: [] })
+})
+
+// Regression for #116: the status bar chips read raw, unfiltered store
+// totals instead of scoping to the active document like AnnotationPanel /
+// ChangesPanel already do.
+describe('StatusBar active-document scoping (#116)', () => {
+  it('shows only the active document counts, not every document combined', () => {
+    useDocumentStore.setState({ activeDocumentId: 'doc-1' })
+    useAnnotationStore.setState({
+      annotations: [
+        makeAnnotation('ann-1', 'doc-1'),
+        makeAnnotation('ann-2', 'doc-2'),
+        makeAnnotation('ann-3', 'doc-2'),
+      ],
+    })
+    useChangesStore.setState({
+      entries: [makeEntry('c-1', 'doc-1'), makeEntry('c-2', 'doc-2')],
+      changeSets: [makeChangeSet('cs-1', 'doc-1'), makeChangeSet('cs-2', 'doc-2')],
+    })
+
+    const { getByText } = render(<StatusBar />)
+
+    expect(getByText('1 annotations')).toBeTruthy()
+    expect(getByText('1 change sets')).toBeTruthy()
+    expect(getByText('1 changes')).toBeTruthy()
+  })
+
+  it('updates the displayed counts when the active document changes', () => {
+    useDocumentStore.setState({ activeDocumentId: 'doc-1' })
+    useAnnotationStore.setState({
+      annotations: [
+        makeAnnotation('ann-1', 'doc-1'),
+        makeAnnotation('ann-2', 'doc-1'),
+        makeAnnotation('ann-3', 'doc-2'),
+      ],
+    })
+
+    const { getByText, rerender } = render(<StatusBar />)
+    expect(getByText('2 annotations')).toBeTruthy()
+
+    useDocumentStore.setState({ activeDocumentId: 'doc-2' })
+    rerender(<StatusBar />)
+
+    expect(getByText('1 annotations')).toBeTruthy()
+  })
+
+  it('shows zero counts when no document is active', () => {
+    useDocumentStore.setState({ activeDocumentId: null })
+    useAnnotationStore.setState({ annotations: [makeAnnotation('ann-1', 'doc-1')] })
+    useChangesStore.setState({
+      entries: [makeEntry('c-1', 'doc-1')],
+      changeSets: [makeChangeSet('cs-1', 'doc-1')],
+    })
+
+    const { getByText } = render(<StatusBar />)
+
+    expect(getByText('0 annotations')).toBeTruthy()
+    expect(getByText('0 change sets')).toBeTruthy()
+    expect(getByText('0 changes')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- `StatusBar.tsx`'s "N annotations / N change sets / N changes" chips read raw, unfiltered totals from `annotationStore`/`changesStore` — unlike every other consumer of the same stores (`AnnotationPanel.tsx`, `ChangesPanel.tsx`, `FloatingAnswer.tsx`), which all scope to `documentId === activeDocumentId`. Switching to (or creating) a document with zero annotations of its own still showed a nonzero count if any other document in the workspace had review history.
- Added the same `documentId === activeDocumentId` scoping (pulled from `useDocumentStore`) to all three StatusBar counts. The "N thinking…" in-flight chip is deliberately left unscoped — out of this issue's stated scope (see follow-up filed below).
- No change to `annotationStore`/`changesStore` themselves — this is a read-side filtering fix in `StatusBar.tsx` only, per the issue's stated scope.

## Test plan
- [x] New regression test file `src/components/Layout/__tests__/statusBar.activeDocumentScope.test.tsx` (3 tests): counts scoped correctly with two documents present; counts update when the active document switches; counts are zero when no document is active.
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1103 passing + 10 skipped
- [x] Adversarial review (troublemaker agent): verdict MERGE, mutation-tested (reverting `StatusBar.tsx` alone makes all 3 new tests fail as expected)

## Follow-up filed
- Review flagged that the "N thinking…" chip (`inFlightCount`) still counts in-flight background classification/resolution across *all* documents, not just the active one — same bug class as this issue, just not named in its done-means. Filing as a separate `task:` issue rather than folding it in here.

Closes #116

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRQGKB39Awr69dD42d27e3)_