### PR TITLE
Backfill missing documentId on changesStore entries/changeSets during rehydration

### DIFF
--- a/src/stores/__tests__/changesStore.migration.test.ts
+++ b/src/stores/__tests__/changesStore.migration.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ChangeEntry, ChangeSet } from '@/lib/changes/changeLog'
+
+class MemoryStorage {
+  private store = new Map<string, string>()
+
+  getItem(key: string) {
+    return this.store.get(key) ?? null
+  }
+
+  setItem(key: string, value: string) {
+    this.store.set(key, value)
+  }
+
+  removeItem(key: string) {
+    this.store.delete(key)
+  }
+
+  clear() {
+    this.store.clear()
+  }
+}
+
+function makeEntry(overrides: Partial<ChangeEntry> = {}): ChangeEntry {
+  return {
+    id: 'entry-1',
+    documentId: 'doc-1',
+    rootAnnotationId: null,
+    annotationId: null,
+    timestamp: 100,
+    description: 'Applied edit',
+    beforeSlice: 'old',
+    afterSlice: 'new',
+    from: 1,
+    to: 10,
+    pmStep: null,
+    undone: false,
+    ...overrides,
+  }
+}
+
+function makeChangeSet(overrides: Partial<ChangeSet> = {}): ChangeSet {
+  return {
+    id: 'cs-1',
+    documentId: 'doc-1',
+    rootAnnotationId: 'ann-1',
+    annotationIds: ['ann-1'],
+    changeEntryIds: ['entry-1'],
+    auditRecordIds: [],
+    title: 'Test change set',
+    status: 'pending',
+    updatedAt: 100,
+    ...overrides,
+  }
+}
+
+/**
+ * Loads a fresh copy of both stores in the same module-cache generation
+ * (matching production, where changesStore.ts statically imports
+ * documentStore.ts) and seeds documentStore's activeDocumentId BEFORE
+ * changesStore's persist hydration runs at import time.
+ */
+async function loadStores(activeDocumentId: string | null) {
+  vi.resetModules()
+  const { useDocumentStore } = await import('@/stores/documentStore')
+  useDocumentStore.setState({ activeDocumentId })
+  const changesStore = await import('@/stores/changesStore')
+  return { useDocumentStore, ...changesStore }
+}
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', new MemoryStorage())
+})
+
+describe('changesStore — legacy documentId migration', () => {
+  it('backfills a missing documentId on entries and changeSets using activeDocumentId, and the record becomes visible to a documentId === activeDocumentId filter', async () => {
+    const legacyEntry = makeEntry({ documentId: undefined as unknown as string })
+    const legacyChangeSet = makeChangeSet({ documentId: undefined as unknown as string })
+    localStorage.setItem(
+      'intent-ide-changes',
+      JSON.stringify({
+        state: { entries: [legacyEntry], changeSets: [legacyChangeSet] },
+        version: 0,
+      })
+    )
+
+    const { useChangesStore } = await loadStores('doc-active')
+
+    const { entries, changeSets } = useChangesStore.getState()
+    expect(entries[0].documentId).toBe('doc-active')
+    expect(changeSets[0].documentId).toBe('doc-active')
+
+    // Now visible to the same filter ChangesPanel.tsx / StatusBar.tsx use.
+    expect(entries.filter((e) => e.documentId === 'doc-active')).toHaveLength(1)
+    expect(changeSets.filter((cs) => cs.documentId === 'doc-active')).toHaveLength(1)
+  })
+
+  it('falls back to "legacy" when no active document exists at rehydration time', async () => {
+    const legacyEntry = makeEntry({ documentId: undefined as unknown as string })
+    localStorage.setItem(
+      'intent-ide-changes',
+      JSON.stringify({ state: { entries: [legacyEntry], changeSets: [] }, version: 0 })
+    )
+
+    const { useChangesStore } = await loadStores(null)
+
+    expect(useChangesStore.getState().entries[0].documentId).toBe('legacy')
+  })
+
+  it('leaves an already-populated documentId untouched', async () => {
+    const entry = makeEntry({ documentId: 'doc-real' })
+    const changeSet = makeChangeSet({ documentId: 'doc-real' })
+    localStorage.setItem(
+      'intent-ide-changes',
+      JSON.stringify({ state: { entries: [entry], changeSets: [changeSet] }, version: 0 })
+    )
+
+    const { useChangesStore } = await loadStores('doc-active')
+
+    expect(useChangesStore.getState().entries[0].documentId).toBe('doc-real')
+    expect(useChangesStore.getState().changeSets[0].documentId).toBe('doc-real')
+  })
+
+  it('does not disturb entries that already carry a documentId when mixed with legacy ones', async () => {
+    const legacy = makeEntry({ id: 'entry-legacy', documentId: undefined as unknown as string })
+    const modern = makeEntry({ id: 'entry-modern', documentId: 'doc-modern' })
+    localStorage.setItem(
+      'intent-ide-changes',
+      JSON.stringify({ state: { entries: [legacy, modern], changeSets: [] }, version: 0 })
+    )
+
+    const { useChangesStore } = await loadStores('doc-active')
+
+    const byId = Object.fromEntries(
+      useChangesStore.getState().entries.map((e) => [e.id, e.documentId])
+    )
+    expect(byId['entry-legacy']).toBe('doc-active')
+    expect(byId['entry-modern']).toBe('doc-modern')
+  })
+
+  it('is idempotent — rehydrating an already-migrated record does not change it', async () => {
+    const entry = makeEntry({ documentId: 'doc-active' })
+    localStorage.setItem(
+      'intent-ide-changes',
+      JSON.stringify({ state: { entries: [entry], changeSets: [] }, version: 0 })
+    )
+
+    const { useChangesStore } = await loadStores('doc-different')
+
+    // Already had a real documentId — must not be overwritten by the
+    // *current* activeDocumentId, only backfilled when missing.
+    expect(useChangesStore.getState().entries[0].documentId).toBe('doc-active')
+  })
+})
+
+describe('migrateChanges — direct unit coverage', () => {
+  it('backfills entries and changeSets independently', async () => {
+    const { migrateChanges } = await loadStores('doc-active')
+    const result = migrateChanges(
+      [makeEntry({ documentId: undefined as unknown as string })],
+      [makeChangeSet({ documentId: undefined as unknown as string })]
+    )
+    expect(result.entries[0].documentId).toBe('doc-active')
+    expect(result.changeSets[0].documentId).toBe('doc-active')
+  })
+
+  it('does not mutate the input arrays', async () => {
+    const { migrateChanges } = await loadStores('doc-active')
+    const entry = makeEntry({ documentId: undefined as unknown as string })
+    const entries = [entry]
+    migrateChanges(entries, [])
+    expect(entry.documentId).toBeUndefined()
+  })
+
+  it('returns empty arrays unchanged', async () => {
+    const { migrateChanges } = await loadStores(null)
+    expect(migrateChanges([], [])).toEqual({ entries: [], changeSets: [] })
+  })
+})

--- a/src/stores/changesStore.ts
+++ b/src/stores/changesStore.ts
@@ -5,6 +5,26 @@ import { persist } from 'zustand/middleware'
 import type { Annotation } from '@/lib/annotations/types'
 import type { ChangeEntry, ChangeSet, ChangeSetStatus, VersionSnapshot } from '@/lib/changes/changeLog'
 import { generateId } from '@/lib/utils/id'
+import { useDocumentStore } from '@/stores/documentStore'
+
+/**
+ * Backfill a missing/undefined `documentId` on persisted entries/changeSets
+ * written before multi-document support existed (Phase 8, 2026-03-16) —
+ * mirrors annotationStore.ts's migrateAnnotations. Without this, such a
+ * record can never match any real activeDocumentId in a `documentId ===
+ * activeDocumentId` filter (ChangesPanel.tsx, StatusBar.tsx) and silently
+ * disappears from every view.
+ */
+export function migrateChanges(
+  entries: ChangeEntry[],
+  changeSets: ChangeSet[]
+): { entries: ChangeEntry[]; changeSets: ChangeSet[] } {
+  const activeDocumentId = useDocumentStore.getState().activeDocumentId ?? 'legacy'
+  return {
+    entries: entries.map((e) => ({ ...e, documentId: e.documentId ?? activeDocumentId })),
+    changeSets: changeSets.map((cs) => ({ ...cs, documentId: cs.documentId ?? activeDocumentId })),
+  }
+}
 
 const MAX_PERSISTED_ENTRIES = 500
 const MAX_PERSISTED_CHANGE_SETS = 100
@@ -234,7 +254,12 @@ export const useChangesStore = create<ChangesState>()(
         },
         removeItem: (name: string) => localStorage.removeItem(name),
       },
-      onRehydrateStorage: () => () => {
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          const migrated = migrateChanges(state.entries, state.changeSets)
+          state.entries = migrated.entries
+          state.changeSets = migrated.changeSets
+        }
         // Snapshots are not persisted — ensure empty array on rehydration
         const current = useChangesStore.getState()
         if (!current.snapshots || current.snapshots.length === 0) {


### PR DESCRIPTION
## Summary
- `annotationStore.ts` has `migrateAnnotations()`, run on rehydration, which backfills a missing/undefined `documentId` on every persisted annotation — a safety net for records written before multi-document support existed (Phase 8, 2026-03-16).
- `src/stores/changesStore.ts` had no equivalent for its `entries` (`ChangeEntry[]`) and `changeSets` (`ChangeSet[]`) arrays. Both types declare `documentId: string` as required at the type level only — that does nothing for JSON already sitting in a user's `localStorage` from before `documentId` existed on these records.
- `ChangesPanel.tsx` and `StatusBar.tsx` both filter by `entry.documentId === activeDocumentId` / `changeSet.documentId === activeDocumentId` (the latter added by PR #120). A pre-multi-document persisted record with a missing/undefined `documentId` would never equal any real `activeDocumentId`, so it silently and permanently disappears from both views.
- Added `migrateChanges(entries, changeSets)` to `changesStore.ts`, mirroring `migrateAnnotations`'s shape: backfills `documentId ?? activeDocumentId` (falling back to `'legacy'` when no document is active), wired into the existing `onRehydrateStorage` callback.

## Test plan
- [x] New test file `src/stores/__tests__/changesStore.migration.test.ts` (8 tests): backfills through real rehydration and confirms the record becomes visible to the same `documentId === activeDocumentId` filter the UI uses; falls back to `'legacy'` when no document is active; leaves an already-populated `documentId` untouched; doesn't disturb sibling records that already carry a real `documentId`; idempotent on a second rehydration; plus direct unit coverage of `migrateChanges` (including non-mutation of its inputs).
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 1116 passing + 10 skipped
- [x] Adversarial review (troublemaker agent): verdict **MERGE**. Independently re-ran typecheck/lint/test, traced zustand's persist-middleware internals directly in `node_modules` to confirm the `onRehydrateStorage` mutation genuinely takes effect (rather than relying on it "being proven by annotationStore's own tests," which the review found doesn't actually cover this exact mechanic today), and mutation-tested by reverting only the production fix — 6 of 8 new tests failed as expected, the other 2 correctly insensitive to that specific mutation.

## Follow-up filed
- Review surfaced a real, reproducible MEDIUM finding inherited from `annotationStore.ts`'s already-accepted design (and explicitly required by mirroring it here): a user who used the app across multiple distinct documents before multi-document support existed will have all of those documents' legacy records stamped with the same single fallback `documentId` on first rehydration — i.e. one document's history can appear merged into another's view. Correctly out of scope for this PR (mirroring the existing pattern was the ask); filed as **#128**.
- Two additional LOW findings, both pre-existing/parity issues not introduced or worsened by this PR, disclosed here rather than filed separately: `DocumentHubSidebar.tsx`'s document-delete path purges `annotationStore` but has no equivalent purge for `changesStore` (orphaned dead weight, capped by the existing persistence limits, not a quota risk); `migrateChanges`/`migrateAnnotations` both lack a null-guard against a genuinely malformed (`null`, not just absent) persisted array — parity with existing `annotationStore.ts` fragility, not a regression.

Closes #126

---
_Generated by [Claude Code](https://claude.ai/code/session_012ctw1hiB5QwrganbaG4bBq)_