### PR TITLE
fix(fleet-status): a delivered branch is not stranded work — prove it two ways

### DIFF
--- a/scripts/fleet-status.sh
+++ b/scripts/fleet-status.sh
@@ -45,6 +45,14 @@ if [[ -z "$REPO" ]]; then
   REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
 fi
 OWNER="${REPO%%/*}"
+# The L-047 detector compares every branch against this, so it must be the
+# repo's REAL default — DryDock's is `Main`, not `main`, and guessing would
+# make every branch there look stranded.
+DEFAULT_BRANCH="${GITHUB_DEFAULT_BRANCH:-}"
+if [[ -z "$DEFAULT_BRANCH" ]]; then
+  DEFAULT_BRANCH="$(gh api "repos/$REPO" --jq .default_branch 2>/dev/null || true)"
+fi
+[[ -n "$DEFAULT_BRANCH" ]] || DEFAULT_BRANCH=main
 NOW_EPOCH="$(date -u +%s)"
 NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -158,18 +166,47 @@ run_aging_ladder() {
 # (c) L-047 detector: claude/* branches, head commit >24h old, no open PR.
 # ---------------------------------------------------------------------------
 RED_FINDINGS=()
+MERGED_BRANCHES=()
 
+# Two independent proofs that a branch's work has landed. BOTH are needed.
+#
+#   merged PR  — the head of a MERGED pull request. Under squash-merge the
+#                branch tip is NOT an ancestor of the default branch, so these
+#                read ahead=1..4 forever: content landed, commits did not.
+#   ahead == 0 — the tip IS an ancestor of the default branch (merge-commit or
+#                rebase). Catches branches merged without a PR at all.
+#
+# Anything else carrying commits of its own is genuinely unshipped work.
+# Flagging a delivered branch red rendered "already delivered" and "silently
+# stranded" as the same colour (L-064), which trained the operator to stop
+# reading the detector — so the branches that WERE stranded went unread with
+# them. `unknown` (API unreachable) stays red: fail closed, never hide a
+# possible stranding behind a failed lookup.
 detect_stale_branches() {
-  local pr_heads branch sha head_date hours
+  local pr_heads merged_heads branch sha head_date hours ahead
   pr_heads="$(jq -r '.[].headRefName' <<<"$PRS_JSON")"
+  merged_heads="$(gh pr list -R "$REPO" --state merged --limit 500 --json headRefName \
+    --jq '.[].headRefName' 2>/dev/null || true)"
   while IFS=$'\t' read -r branch sha; do
     [[ -z "$branch" ]] && continue
     [[ "$branch" == claude/* ]] || continue
     grep -qxF "$branch" <<<"$pr_heads" && continue
     head_date="$(gh api "repos/$REPO/commits/$sha" --jq .commit.committer.date)"
     hours="$(age_hours "$head_date")"
-    if (( hours > STALE_BRANCH_HOURS )); then
-      RED_FINDINGS+=("L-047: remote branch \`$branch\` head commit is ${hours}h old with no open PR — work-in-flight is going stale (open a PR or delete the branch).")
+    (( hours > STALE_BRANCH_HOURS )) || continue
+    if grep -qxF "$branch" <<<"$merged_heads"; then
+      MERGED_BRANCHES+=("\`$branch\` — its PR merged, safe to delete")
+      continue
+    fi
+    ahead="$(gh api "repos/$REPO/compare/$DEFAULT_BRANCH...$branch" \
+      --jq 'if type == "object" then (.ahead_by // 0) else "unknown" end' 2>/dev/null || echo unknown)"
+    [[ -n "$ahead" ]] || ahead=unknown
+    if [[ "$ahead" == "0" ]]; then
+      MERGED_BRANCHES+=("\`$branch\` — already in \`$DEFAULT_BRANCH\`, safe to delete")
+    elif [[ "$ahead" == "unknown" ]]; then
+      RED_FINDINGS+=("L-047: remote branch \`$branch\` head commit is ${hours}h old with no open PR, and its ahead-count could not be read — treat as stranded until proven otherwise.")
+    else
+      RED_FINDINGS+=("L-047: remote branch \`$branch\` head commit is ${hours}h old, has no merged PR, and carries **${ahead} commit(s) not in \`$DEFAULT_BRANCH\`** — work-in-flight is going stale (open a PR or delete the branch).")
     fi
   done <<<"$BRANCHES_TSV"
 }
@@ -278,6 +315,21 @@ build_body() {
     local f
     for f in "${RED_FINDINGS[@]}"; do
       body+="- :red_circle: $f"$'\n'
+    done
+  fi
+  body+=$'\n'
+
+  # -- Merged branches, not yet deleted --------------------------------------
+  # Housekeeping, deliberately NOT a red finding: the work is already in the
+  # default branch, so nothing is at risk and nothing should fail a check.
+  body+="## Merged branches, not yet deleted"$'\n\n'
+  if (( ${#MERGED_BRANCHES[@]} == 0 )); then
+    body+="_None._"$'\n'
+  else
+    body+="Housekeeping only — the work is already in \`$DEFAULT_BRANCH\`."$'\n\n'
+    local m
+    for m in "${MERGED_BRANCHES[@]}"; do
+      body+="- $m"$'\n'
     done
   fi
   body+=$'\n'


### PR DESCRIPTION
## What

The L-047 detector could not tell **already delivered** from **silently
stranded**. A branch whose PR merged and was simply never deleted stayed red
forever — L-064's two-states-one-colour defect living inside the detector built
to prevent it.

## Why it matters

| Repo | red/day | of which false |
|---|---|---|
| `overlord-exp-arm-a` | ~4 | 3 of 3 (all delivered, since 2026-08-18) |
| `overlord-exp-arm-b` | ~4 | 3 of 3 |
| `intent-ide` | ~6 | 11 of 12 |
| `janus` | ~4 | 0 of 2 |

~17 of the operator's ~20 daily "Run failed" mails were this false positive.
That trained them to stop reading the detector — so the branches that **were**
stranded went unread with it. A fleet sweep this session found **13 branches
ahead of default with no PR ever opened, across 7 repos**, one 21 commits deep.
The noise was hiding the exact class of failure the detector exists to catch.

## Change — two independent proofs of delivery, because either alone is wrong

1. **Merged PR.** Under squash-merge a merged branch's tip is *not* an ancestor
   of the default branch and reads `ahead=1..4` forever. On an ahead-count
   alone, overlord-ui's **23 delivered branches all look stranded**.
2. **`ahead == 0`.** Catches branches merged with no PR at all, which a PR-head
   match alone would miss.

Matching PR heads with `--state all` was considered and rejected: it also skips
a branch whose PR was **closed** while still carrying unshipped commits. That
false negative had been hiding overlord-ui's `claude/issue-140-20260827-1141`
(PR #141 closed, 1 commit not in `main`) since 2026-08-27.

Red findings now state **how many commits are at risk**. An unreachable compare
**stays red** — fail closed, never hide a possible stranding behind a failed
lookup. The default branch is read from the API rather than assumed `main`
(DryDock's is `Main`), since this script is about to be installed fleet-wide.

## Verification

BSD `date` cannot parse the script's `-d` form, so the `>24h` gate never fires
locally — tested through a GNU-`date` shim against **live** repos. All three
divergent copies of the script (janus / intent-ide / overlord-ui) were run
against all four repos and agree exactly:

| target | red | housekeeping | was |
|---|---|---|---|
| `janus` | 2 | 0 | 2 red |
| `intent-ide` | 1 | 11 | 12 red |
| `overlord-ui` | 1 | 23 | 23 red on ahead-only; 0 red under `--state all`, which hid it |
| `overlord-exp-arm-a` | 0 | 3 | 3 red |

Every surviving red is genuinely unshipped work with no merged PR.
`scripts/test-hooks.sh` → `ALL SCAFFOLD TESTS PASSED`.

## Notes

Template change — the sibling copies get the same logical patch in their own
PRs (janus#59, intent-ide#145, overlord-ui#208). The two `overlord-exp-arm-*`
copies are deliberately **not** patched: they are live L-037 experiment fixtures
with reps 2–3 outstanding, and `EXPERIMENT.md` decision rule 4 forbids changing
the stimulus once runs exist. Their cron is disabled instead, recorded as a
dated pre-rep-2 amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWnGJhvkmGhbXbfVLLMLLZ
