### PR TITLE
feat(panel): highlight-to-ask everywhere, and depth that stops eating the column

### DIFF
--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -26,6 +26,7 @@ import { generateId } from '@/lib/utils/id'
 import type { Annotation, AnnotationType, ConversationMessage } from '@/lib/annotations/types'
 import { ANNOTATION_COLORS, ANNOTATION_LABELS, ANNOTATION_DESCRIPTIONS, getDefaultVerbosity } from '@/lib/annotations/types'
 import { AgentMarkdown } from '@/components/ui/AgentMarkdown'
+import { drillFromAnswer } from '@/lib/annotations/drill'
 import { ResolutionProgress } from './ResolutionProgress'
 
 const ALL_TYPES: AnnotationType[] = ['ask', 'edit', 'dig', 'flag']
@@ -52,6 +53,14 @@ interface AnnotationCardProps {
    * so a click inside it must not collapse the thread out from under the user.
    */
   lockActive?: boolean
+  /**
+   * Render collapsed unless the reader has explicitly expanded this card.
+   * Set for deep threads (depth >= 3), where opening every nested card by
+   * default is what made a sub-of-a-sub unreadable. The explicit expansions
+   * are tracked separately from ordinary collapses so the collapsed list does
+   * not have to be pre-filled with every deep id in the document.
+   */
+  defaultCollapsed?: boolean
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -77,6 +86,7 @@ export function AnnotationCard({
   isActive,
   detailElsewhere = false,
   lockActive = false,
+  defaultCollapsed = false,
 }: AnnotationCardProps) {
   // The expanded body — and everything that only makes sense alongside it —
   // belongs to whichever card is actually rendering the detail.
@@ -89,8 +99,14 @@ export function AnnotationCard({
 
   // Per-card collapse: a view preference persisted in layoutStore, NOT
   // annotation state (see layoutStore's doc comment on collapsedAnnotationIds).
-  const collapsed = useLayoutStore((s) => s.collapsedAnnotationIds.includes(annotation.id))
-  const toggleAnnotationCollapsed = useLayoutStore((s) => s.toggleAnnotationCollapsed)
+  // A deep card inverts the question — it is collapsed unless explicitly
+  // expanded — so that the default state of a deep thread costs no storage.
+  const explicitlyCollapsed = useLayoutStore((s) => s.collapsedAnnotationIds.includes(annotation.id))
+  const explicitlyExpanded = useLayoutStore((s) => s.expandedAnnotationIds.includes(annotation.id))
+  const collapsed = defaultCollapsed ? !explicitlyExpanded : explicitlyCollapsed
+  const toggleCollapsed = useLayoutStore((s) =>
+    defaultCollapsed ? s.toggleAnnotationExpanded : s.toggleAnnotationCollapsed,
+  )
 
   // Flow-state answer buffering: while this card's answer is held, keep
   // presenting it as "Thinking..." and hide the conversation/resolution body.
@@ -384,7 +400,7 @@ export function AnnotationCard({
           <button
             onClick={(e) => {
               e.stopPropagation()
-              toggleAnnotationCollapsed(annotation.id)
+              toggleCollapsed(annotation.id)
             }}
             aria-expanded={!collapsed}
             aria-label={collapsed ? 'Expand annotation' : 'Collapse annotation'}
@@ -601,7 +617,16 @@ export function AnnotationCard({
       {showDetail && !held && annotation.resolution && (!annotation.conversation || annotation.conversation.length === 0) && (
         <div className="mt-3 pt-3 border-t border-border/70" onClick={(e) => e.stopPropagation()}>
           <div className="text-sm text-ink leading-relaxed">
-            <AgentMarkdown content={annotation.resolution.content} />
+            {/* Highlight-to-ask must work here too. This path (a resolution
+                with an empty conversation) used to render a bare AgentMarkdown
+                with no interactive/onDrill, so dragging a selection across one
+                of these answers silently did nothing — which is what made the
+                affordance read as "click Spin off annotation first". */}
+            <AgentMarkdown
+              content={annotation.resolution.content}
+              interactive={annotation.status !== 'resolving'}
+              onDrill={(payload) => drillFromAnswer(annotation.id, payload)}
+            />
           </div>
 
           {annotation.resolution.suggestedEdit && (

--- a/src/components/Annotations/AnnotationPanel.tsx
+++ b/src/components/Annotations/AnnotationPanel.tsx
@@ -7,6 +7,7 @@ import { useDocumentStore } from '@/stores/documentStore'
 import { AnnotationCard } from './AnnotationCard'
 import { AnnotationMap } from './AnnotationMap'
 import type { Annotation } from '@/lib/annotations/types'
+import { annotationLabel } from '@/lib/annotations/subject'
 
 type ViewMode = 'list' | 'map'
 
@@ -86,12 +87,82 @@ function computeDepth(id: string, byId: Map<string, Annotation>): number {
   return depth
 }
 
+
+/**
+ * Depth is no longer drawn as indentation.
+ *
+ * The panel is a ~400px rail. Readable prose runs 45-75 characters, and below
+ * about 45 the line breaks so often that reading itself degrades — so the old
+ * `marginLeft: min(depth,5)rem` did not merely look cramped, it pushed the text
+ * column under the legibility floor. Every team that has publicly reasoned
+ * about deep threading reached the same place: Slack capped replies at one
+ * level and called it "an instant success on all fronts"; Discourse rejected
+ * nesting outright, its third stated objection being that indentation eats
+ * horizontal space as depth grows; NN/g finds more than two disclosure levels
+ * loses users between the levels.
+ *
+ * So: one fixed indent step, ever. Depth is carried by a left rail, a badge,
+ * and — past MAX_INLINE_DEPTH — by leaving the list entirely for a focused
+ * view you return from by breadcrumb rather than by scrolling back up.
+ */
+const INDENT_PX = 14
+/** From this depth a card renders collapsed until the reader opens it. */
+const DEEP_COLLAPSE_DEPTH = 3
+/** Past this depth a thread stops rendering inline and is entered instead. */
+const MAX_INLINE_DEPTH = 5
+
+/** Rail weight/colour by depth — the replacement for a growing left margin. */
+function railClass(depth: number): string {
+  if (depth <= 0) return ''
+  if (depth === 1) return 'border-l-2 border-accent/40'
+  if (depth === 2) return 'border-l-2 border-accent/60'
+  return 'border-l-[3px] border-accent/80'
+}
+
+type PanelRow =
+  | { kind: 'card'; annotation: Annotation; depth: number }
+  | { kind: 'fold'; anchorId: string; count: number }
+
+/**
+ * Turn a group's DFS-flattened thread list into render rows, folding away
+ * everything deeper than MAX_INLINE_DEPTH into one "N replies deep" row.
+ * Descendants of a folded node follow it contiguously in DFS order, so a
+ * single pass suffices.
+ */
+export function buildPanelRows(annotations: Annotation[], depths: Map<string, number>): PanelRow[] {
+  const rows: PanelRow[] = []
+  let folding: { anchorId: string; index: number } | null = null
+
+  for (const annotation of annotations) {
+    const depth = depths.get(annotation.id) ?? 0
+    if (depth > MAX_INLINE_DEPTH) {
+      if (folding) {
+        const row = rows[folding.index]
+        if (row.kind === 'fold') row.count += 1
+      } else {
+        // Anchor the fold on the deepest still-inline ancestor, which is what
+        // entering the focused view should re-root on.
+        const anchorId = annotation.parentId ?? annotation.id
+        folding = { anchorId, index: rows.length }
+        rows.push({ kind: 'fold', anchorId, count: 1 })
+      }
+      continue
+    }
+    folding = null
+    rows.push({ kind: 'card', annotation, depth })
+  }
+
+  return rows
+}
+
 export function AnnotationPanel() {
   const annotations = useAnnotationStore((s) => s.annotations)
   const activeId = useAnnotationStore((s) => s.activeAnnotationId)
   const activeDocumentId = useDocumentStore((s) => s.activeDocumentId)
   const placement = useLayoutStore((s) => s.answerPlacement)
   const setPlacement = useLayoutStore((s) => s.setAnswerPlacement)
+  const focusedSubtreeId = useLayoutStore((s) => s.focusedSubtreeId)
+  const setFocusedSubtree = useLayoutStore((s) => s.setFocusedSubtree)
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   // "Show N resolved" toggle: local view state (not persisted, not
   // annotation state) — reveals hidden annotations and hides them again.
@@ -173,7 +244,68 @@ export function AnnotationPanel() {
       .sort((a, b) => a.anchor - b.anchor)
   }, [documentAnnotations, showResolved])
 
-  const annotationCount = groupedAnnotations.reduce((sum, group) => sum + group.annotations.length, 0)
+  /**
+   * The subtree the reader has entered, plus the ancestor crumbs that lead back
+   * out. Breadcrumbs rather than scroll position: NN/g's finding is that
+   * breadcrumbs "never cause problems in user testing", and in a narrow rail
+   * they are the only way back that does not require retracing every level.
+   */
+  const focusView = useMemo(() => {
+    if (!focusedSubtreeId) return null
+    const byId = new Map(documentAnnotations.map((a) => [a.id, a]))
+    const focused = byId.get(focusedSubtreeId)
+    if (!focused) return null
+
+    const crumbs: Annotation[] = []
+    const seen = new Set<string>([focused.id])
+    let cursor = focused.parentId ? byId.get(focused.parentId) : undefined
+    while (cursor && !seen.has(cursor.id)) {
+      seen.add(cursor.id)
+      crumbs.unshift(cursor)
+      cursor = cursor.parentId ? byId.get(cursor.parentId) : undefined
+    }
+
+    const byParent = new Map<string, Annotation[]>()
+    for (const a of documentAnnotations) {
+      if (!a.parentId) continue
+      byParent.set(a.parentId, [...(byParent.get(a.parentId) ?? []), a])
+    }
+    const ids = new Set<string>()
+    const stack = [focused.id]
+    while (stack.length) {
+      const id = stack.pop() as string
+      if (ids.has(id)) continue
+      ids.add(id)
+      for (const child of byParent.get(id) ?? []) stack.push(child.id)
+    }
+
+    return { focused, crumbs, ids }
+  }, [focusedSubtreeId, documentAnnotations])
+
+  // A focus that no longer resolves (the thread was dismissed, or the document
+  // switched) must not strand the panel showing nothing.
+  useEffect(() => {
+    if (focusedSubtreeId && !focusView) setFocusedSubtree(null)
+  }, [focusedSubtreeId, focusView, setFocusedSubtree])
+
+  const displayGroups = useMemo(() => {
+    if (!focusView) return groupedAnnotations
+    const base = focusView.crumbs.length
+    return groupedAnnotations
+      .map((group) => {
+        const annotations = group.annotations.filter((a) => focusView.ids.has(a.id))
+        if (annotations.length === 0) return null
+        // Re-root the depths so the entered thread reads from zero rather than
+        // inheriting the indentation of wherever it happened to sit.
+        const depths = new Map(
+          [...group.depths].map(([id, depth]) => [id, Math.max(0, depth - base)] as const),
+        )
+        return { ...group, annotations, depths }
+      })
+      .filter((group): group is NonNullable<typeof group> => group !== null)
+  }, [groupedAnnotations, focusView])
+
+  const annotationCount = displayGroups.reduce((sum, group) => sum + group.annotations.length, 0)
 
   if (!activeDocumentId || documentAnnotations.length === 0) {
     return (
@@ -259,9 +391,37 @@ export function AnnotationPanel() {
         </div>
       </div>
 
+      {focusView && (
+        <nav
+          aria-label="Thread breadcrumb"
+          className="flex flex-wrap items-center gap-1 px-4 py-2 border-b border-border/70 bg-warm/30 text-[11px]"
+        >
+          <button
+            onClick={() => setFocusedSubtree(null)}
+            className="text-muted-foreground hover:text-accent transition-colors"
+          >
+            All threads
+          </button>
+          {focusView.crumbs.map((crumb) => (
+            <span key={crumb.id} className="flex items-center gap-1">
+              <span aria-hidden="true" className="text-muted-foreground/60">›</span>
+              <button
+                onClick={() => setFocusedSubtree(crumb.id)}
+                className="text-muted-foreground hover:text-accent transition-colors truncate max-w-[10rem]"
+              >
+                {annotationLabel(crumb)}
+              </button>
+            </span>
+          ))}
+          <span aria-hidden="true" className="text-muted-foreground/60">›</span>
+          <span className="font-medium text-ink truncate max-w-[12rem]">
+            {annotationLabel(focusView.focused)}
+          </span>
+        </nav>
+      )}
       <div ref={listRef} className="flex-1 overflow-y-auto">
         {viewMode === 'list' ? (
-          groupedAnnotations.length === 0 ? (
+          displayGroups.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-48 text-center px-6">
               <p className="text-sm text-muted-foreground">All caught up</p>
               <p className="text-xs text-muted-foreground mt-1">
@@ -270,7 +430,7 @@ export function AnnotationPanel() {
             </div>
           ) : (
           <div className="space-y-3 p-4">
-            {groupedAnnotations.map((group) => (
+            {displayGroups.map((group) => (
               <section key={group.key} className="rounded-[22px] border border-border/70 bg-white/78 overflow-hidden shadow-sm">
                 <div className="px-4 py-3 border-b border-border/70 bg-gradient-to-r from-warm/50 to-white/70">
                   <div className="flex items-center justify-between gap-3">
@@ -286,18 +446,36 @@ export function AnnotationPanel() {
                   </p>
                 </div>
                 <div className="divide-y divide-border/70">
-                  {group.annotations.map((annotation) => {
-                    const depth = group.depths.get(annotation.id) ?? 0
-                    // Cap the visual indent — a level-9 sub-chat still reads
-                    // as "deeply nested," it just doesn't shove the card off
-                    // the edge of a narrow rail.
-                    const indent = Math.min(depth, 5)
+                  {buildPanelRows(group.annotations, group.depths).map((row) => {
+                    if (row.kind === 'fold') {
+                      return (
+                        <button
+                          key={`fold-${row.anchorId}`}
+                          onClick={() => setFocusedSubtree(row.anchorId)}
+                          style={{ marginLeft: `${INDENT_PX}px` }}
+                          className="w-full text-left px-2.5 py-2 border-l-[3px] border-accent/80 bg-warm/10 text-[11px] text-muted-foreground hover:text-accent transition-colors"
+                        >
+                          {row.count} {row.count === 1 ? 'reply' : 'replies'} deeper · view thread
+                        </button>
+                      )
+                    }
+                    const { annotation, depth } = row
                     return (
                       <div
                         key={annotation.id}
-                        className={depth > 0 ? 'border-l border-border/60 bg-warm/10' : ''}
-                        style={depth > 0 ? { marginLeft: `${indent}rem` } : undefined}
+                        data-depth={depth}
+                        className={`${railClass(depth)} ${depth > 0 ? 'bg-warm/10' : ''}`}
+                        // One indent step at any depth. See INDENT_PX.
+                        style={depth > 0 ? { marginLeft: `${INDENT_PX}px` } : undefined}
                       >
+                        {depth >= DEEP_COLLAPSE_DEPTH && (
+                          <span
+                            aria-label={`Depth ${depth}`}
+                            className="ml-2.5 mt-1.5 inline-block rounded bg-accent/10 px-1.5 py-px text-[10px] font-mono text-accent"
+                          >
+                            ↳{depth}
+                          </span>
+                        )}
                         {annotation.sourceQuote && (
                           <p className="px-2.5 pt-1.5 text-[10px] font-mono text-muted-foreground truncate">
                             “{annotation.sourceQuote}”
@@ -307,6 +485,7 @@ export function AnnotationPanel() {
                           annotation={annotation}
                           isActive={annotation.id === activeId}
                           detailElsewhere={placement === 'floating'}
+                          defaultCollapsed={depth >= DEEP_COLLAPSE_DEPTH}
                         />
                       </div>
                     )

--- a/src/components/Annotations/ConversationThread.tsx
+++ b/src/components/Annotations/ConversationThread.tsx
@@ -8,6 +8,7 @@ import { generateId } from '@/lib/utils/id'
 import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { refreshAnchorAfterApply } from '@/lib/annotations/anchoring'
+import { drillFromAnswer } from '@/lib/annotations/drill'
 import { captureAndResolveInBackground } from '@/lib/voice/pipeline'
 import type { ConversationMessage, SuggestedEdit } from '@/lib/annotations/types'
 import { AgentMarkdown } from '@/components/ui/AgentMarkdown'
@@ -82,7 +83,10 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
 
   return (
     <div className="flex flex-col gap-2 mb-3">
-      {messages.map((message) => (
+      {messages.map((message) => {
+        const isThisMessageStreaming =
+          isStreaming && message.id === messages[messages.length - 1]?.id
+        return (
         <div key={message.id}>
           {message.role === 'user' ? (
             <div className="bg-warm rounded px-3 py-2">
@@ -98,26 +102,14 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
               <div className="text-sm text-ink leading-relaxed">
                 <AgentMarkdown
                   content={message.content}
-                  isStreaming={isStreaming && message.role === 'agent' && message.id === messages[messages.length - 1]?.id}
-                  interactive={!!annotationId && !isStreaming}
-                  onDrill={({ transcript, suggestedIntent, skipClassify, quote }) => {
+                  isStreaming={isThisMessageStreaming}
+                  // Only the message actually streaming is inert. Gating on the
+                  // thread-wide `isStreaming` killed highlight-to-ask on every
+                  // finished answer in the thread while any one of them streamed.
+                  interactive={!!annotationId && !isThisMessageStreaming}
+                  onDrill={(payload) => {
                     if (!annotationId) return
-                    // Deliberate split: the DOCUMENT position comes from the
-                    // parent's anchor (there is no document position for
-                    // text that only exists inside the AI's answer), while
-                    // the SUBJECT MATTER comes from `quote` — the exact
-                    // answer text the user highlighted. Do not "fix" this to
-                    // derive both from the same source.
-                    const parentAnn = useAnnotationStore.getState().getById(annotationId)
-                    const from = parentAnn?.anchor.from ?? 0
-                    const to = parentAnn?.anchor.to ?? 0
-                    captureAndResolveInBackground(suggestedIntent ?? 'dig', transcript, from, to, {
-                      parentId: annotationId,
-                      suggestedType: suggestedIntent,
-                      skipClassify,
-                      quote,
-                    })
-                    useToastStore.getState().addToast('Sub-annotation created', 'success')
+                    drillFromAnswer(annotationId, payload)
                   }}
                 />
               </div>
@@ -183,7 +175,7 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
                       }}
                       className="text-[10px] font-medium text-muted-foreground hover:text-accent transition-colors"
                     >
-                      Spin off annotation
+                      Ask about the document instead
                     </button>
                   )}
                 </div>
@@ -191,7 +183,8 @@ export function ConversationThread({ messages, annotationId, isStreaming = false
             </div>
           )}
         </div>
-      ))}
+        )
+      })}
     </div>
   )
 }

--- a/src/components/Annotations/__tests__/annotationPanel.depth.pure.test.ts
+++ b/src/components/Annotations/__tests__/annotationPanel.depth.pure.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest'
+import { buildPanelRows } from '../AnnotationPanel'
+import { annotationLabel } from '@/lib/annotations/subject'
+import type { Annotation } from '@/lib/annotations/types'
+
+// Depth used to be drawn as `marginLeft: min(depth,5)rem` inside a ~400px rail.
+// Readable prose runs 45-75 characters and degrades below about 45, so five
+// levels of indent did not merely look cramped — it pushed the text column
+// under the legibility floor. These tests pin the replacement: fold anything
+// past MAX_INLINE_DEPTH into one row rather than rendering it inline.
+
+function ann(id: string, parentId: string | null): Annotation {
+  return {
+    id,
+    documentId: 'doc',
+    locationGroupKey: 'doc:10:31',
+    type: 'ask',
+    status: 'resolved',
+    transcript: `question ${id}`,
+    anchor: { from: 10, to: 31, scope: 'sentence', text: 'What is tokenization?' },
+    resolution: null,
+    conversation: [],
+    parentId,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+  }
+}
+
+/** A straight chain root → c1 → c2 → ... of `n` links, DFS-ordered. */
+function chain(n: number): { annotations: Annotation[]; depths: Map<string, number> } {
+  const annotations: Annotation[] = [ann('root', null)]
+  const depths = new Map<string, number>([['root', 0]])
+  let parent = 'root'
+  for (let i = 1; i <= n; i++) {
+    const id = `c${i}`
+    annotations.push(ann(id, parent))
+    depths.set(id, i)
+    parent = id
+  }
+  return { annotations, depths }
+}
+
+describe('buildPanelRows', () => {
+  it('renders a shallow thread entirely inline', () => {
+    const { annotations, depths } = chain(3)
+    const rows = buildPanelRows(annotations, depths)
+    expect(rows).toHaveLength(4)
+    expect(rows.every((r) => r.kind === 'card')).toBe(true)
+  })
+
+  it('renders depth 5 inline and folds everything past it', () => {
+    const { annotations, depths } = chain(8)
+    const rows = buildPanelRows(annotations, depths)
+    const cards = rows.filter((r) => r.kind === 'card')
+    const folds = rows.filter((r) => r.kind === 'fold')
+
+    // root + depths 1..5 stay inline; 6, 7, 8 collapse into a single row.
+    expect(cards).toHaveLength(6)
+    expect(folds).toHaveLength(1)
+    expect(folds[0]).toMatchObject({ count: 3 })
+  })
+
+  it('anchors the fold on the deepest still-inline ancestor, so entering it re-roots there', () => {
+    const { annotations, depths } = chain(7)
+    const fold = buildPanelRows(annotations, depths).find((r) => r.kind === 'fold')
+    expect(fold).toBeDefined()
+    if (fold?.kind === 'fold') expect(fold.anchorId).toBe('c5')
+  })
+
+  it('does not let a deep subtree bleed into a following sibling', () => {
+    // root ─┬─ a (1) ── deep chain to 6
+    //       └─ b (1)
+    const annotations = [
+      ann('root', null),
+      ann('a1', 'root'),
+      ann('a2', 'a1'),
+      ann('a3', 'a2'),
+      ann('a4', 'a3'),
+      ann('a5', 'a4'),
+      ann('a6', 'a5'),
+      ann('b1', 'root'),
+    ]
+    const depths = new Map<string, number>([
+      ['root', 0], ['a1', 1], ['a2', 2], ['a3', 3], ['a4', 4], ['a5', 5], ['a6', 6], ['b1', 1],
+    ])
+    const rows = buildPanelRows(annotations, depths)
+    const last = rows[rows.length - 1]
+    expect(last.kind).toBe('card')
+    if (last.kind === 'card') expect(last.annotation.id).toBe('b1')
+    expect(rows.filter((r) => r.kind === 'fold')).toHaveLength(1)
+  })
+
+  it('treats a missing depth as a root rather than dropping the card', () => {
+    const rows = buildPanelRows([ann('orphan', null)], new Map())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ kind: 'card', depth: 0 })
+  })
+
+  it('handles an empty thread list', () => {
+    expect(buildPanelRows([], new Map())).toEqual([])
+  })
+})
+
+describe('annotationLabel', () => {
+  it("prefers the reader's own question, which is what locates you in a breadcrumb", () => {
+    const a = ann('x', 'root')
+    a.transcript = 'is the token in this context a hash value?'
+    const label = annotationLabel(a)
+    expect(label.startsWith('is the token in this context')).toBe(true)
+    expect(label.endsWith('…')).toBe(true)
+    expect(label.length).toBeLessThanOrEqual(40)
+  })
+
+  it('falls back to the quote, then the anchor', () => {
+    const quoted = ann('x', 'root')
+    quoted.transcript = ''
+    quoted.sourceQuote = 'Workload Identity Federation'
+    expect(annotationLabel(quoted)).toBe('Workload Identity Federation')
+
+    const bare = ann('y', null)
+    bare.transcript = '   '
+    expect(annotationLabel(bare)).toBe('What is tokenization?')
+  })
+
+  it('collapses whitespace so a crumb never wraps on stray newlines', () => {
+    const a = ann('x', 'root')
+    a.transcript = 'what   is\n\ntokenization'
+    expect(annotationLabel(a)).toBe('what is tokenization')
+  })
+})

--- a/src/lib/annotations/__tests__/drill.test.ts
+++ b/src/lib/annotations/__tests__/drill.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useAnnotationStore } from '@/stores/annotationStore'
+import type { Annotation } from '../types'
+
+const capture = vi.fn()
+vi.mock('@/lib/voice/pipeline', () => ({
+  captureAndResolveInBackground: (...args: unknown[]) => capture(...args),
+}))
+
+import { drillFromAnswer } from '../drill'
+
+function ann(over: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'parent',
+    documentId: 'doc',
+    locationGroupKey: 'doc:10:31',
+    type: 'ask',
+    status: 'resolved',
+    transcript: 'what is tokenization in this context?',
+    anchor: { from: 10, to: 31, scope: 'sentence', text: 'What is tokenization?' },
+    resolution: null,
+    conversation: [],
+    parentId: null,
+    childIds: [],
+    createdAt: 0,
+    resolvedAt: null,
+    verbosity: 'normal',
+    ...over,
+  }
+}
+
+beforeEach(() => {
+  capture.mockClear()
+  useAnnotationStore.setState({ annotations: [ann()] })
+})
+
+describe('drillFromAnswer', () => {
+  it('anchors the child at the parent position but keeps the quote as its subject', () => {
+    // The deliberate split: there is no document position for text that only
+    // exists inside an answer, so position is inherited while subject is not.
+    drillFromAnswer('parent', {
+      blockText: 'Workload Identity Federation',
+      quote: 'Workload Identity Federation',
+      transcript: 'explain this in plain language',
+      suggestedIntent: 'dig',
+    })
+
+    expect(capture).toHaveBeenCalledTimes(1)
+    const [type, transcript, from, to, opts] = capture.mock.calls[0]
+    expect(type).toBe('dig')
+    expect(transcript).toBe('explain this in plain language')
+    expect(from).toBe(10)
+    expect(to).toBe(31)
+    expect(opts).toMatchObject({
+      parentId: 'parent',
+      quote: 'Workload Identity Federation',
+    })
+  })
+
+  it('defaults to dig when no intent was suggested', () => {
+    drillFromAnswer('parent', {
+      blockText: 'x',
+      quote: 'x',
+      transcript: 'say more',
+      suggestedIntent: null,
+    })
+    expect(capture.mock.calls[0][0]).toBe('dig')
+  })
+
+  it('forwards skipClassify so a one-click action does not pay for a classify round-trip', () => {
+    drillFromAnswer('parent', {
+      blockText: 'x',
+      quote: 'x',
+      transcript: 'Define this.',
+      suggestedIntent: 'ask',
+      skipClassify: true,
+    })
+    expect(capture.mock.calls[0][4]).toMatchObject({ skipClassify: true })
+  })
+
+  it('falls back to position 0 when the parent has gone', () => {
+    // A card can outlive its annotation if the store was cleared underneath it;
+    // capturing at 0 is survivable, throwing inside a click handler is not.
+    useAnnotationStore.setState({ annotations: [] })
+    drillFromAnswer('missing', {
+      blockText: 'x',
+      quote: 'x',
+      transcript: 'q',
+      suggestedIntent: 'dig',
+    })
+    expect(capture.mock.calls[0][2]).toBe(0)
+    expect(capture.mock.calls[0][3]).toBe(0)
+  })
+})

--- a/src/lib/annotations/drill.ts
+++ b/src/lib/annotations/drill.ts
@@ -1,0 +1,44 @@
+import { useAnnotationStore } from '@/stores/annotationStore'
+import { useToastStore } from '@/stores/toastStore'
+import { captureAndResolveInBackground } from '@/lib/voice/pipeline'
+import type { AnnotationType } from './types'
+
+export interface DrillPayload {
+  /** @deprecated kept alongside `quote` for callers not yet migrated — always equal to `quote`. */
+  blockText: string
+  /** The exact highlighted answer text the sub-chat was spun off from. */
+  quote: string
+  transcript: string
+  suggestedIntent: AnnotationType | null
+  /** Preset intent from a one-click action — skip the classify round-trip. */
+  skipClassify?: boolean
+}
+
+/**
+ * Create a sub-annotation from text the reader highlighted inside an AI answer.
+ *
+ * Deliberate split, unchanged from where this logic used to live inline in
+ * ConversationThread: the DOCUMENT position comes from the parent's anchor
+ * (there is no document position for text that only exists inside an answer),
+ * while the SUBJECT MATTER comes from `quote` — the exact answer text the
+ * reader highlighted. Do not "fix" this to derive both from the same source.
+ *
+ * Extracted so the two render paths in AnnotationCard cannot diverge. The
+ * legacy path (a `resolution` with an empty `conversation`) rendered
+ * AgentMarkdown with no `interactive`/`onDrill` at all, so highlighting inside
+ * those answers silently did nothing — which is why highlight-to-ask read as
+ * "I have to click Spin off annotation first".
+ */
+export function drillFromAnswer(annotationId: string, payload: DrillPayload): void {
+  const parent = useAnnotationStore.getState().getById(annotationId)
+  const from = parent?.anchor.from ?? 0
+  const to = parent?.anchor.to ?? 0
+
+  captureAndResolveInBackground(payload.suggestedIntent ?? 'dig', payload.transcript, from, to, {
+    parentId: annotationId,
+    suggestedType: payload.suggestedIntent,
+    skipClassify: payload.skipClassify,
+    quote: payload.quote,
+  })
+  useToastStore.getState().addToast('Sub-annotation created', 'success')
+}

--- a/src/lib/annotations/subject.ts
+++ b/src/lib/annotations/subject.ts
@@ -44,3 +44,25 @@ export function annotationSubject(annotation: Annotation): string {
 
   return annotation.anchor.text
 }
+
+/** Longest a breadcrumb crumb or a collapsed one-line preview may run. */
+const LABEL_CHARS = 40
+
+/**
+ * A short human label for an annotation — what a breadcrumb crumb or a
+ * collapsed deep-thread preview shows.
+ *
+ * Nothing derived one before, because depth was communicated purely by
+ * indentation and a card was never reduced to a single line. Prefers the
+ * reader's own words (the transcript) over the quote, because in a breadcrumb
+ * "is the token a hash value?" locates you in the thread and the quoted span
+ * does not.
+ */
+export function annotationLabel(annotation: Annotation): string {
+  const raw =
+    annotation.transcript.trim() ||
+    annotation.sourceQuote?.trim() ||
+    annotation.anchor.text.trim()
+  const clean = raw.replace(/\s+/g, ' ')
+  return clean.length <= LABEL_CHARS ? clean : `${clean.slice(0, LABEL_CHARS - 1)}…`
+}

--- a/src/stores/layoutStore.ts
+++ b/src/stores/layoutStore.ts
@@ -63,6 +63,21 @@ interface LayoutState {
    * is persisted so a reload doesn't silently re-expand every thread.
    */
   collapsedAnnotationIds: string[]
+  /**
+   * Deep threads (depth >= 3) render COLLAPSED by default — indentation stopped
+   * carrying depth and a wall of open nested cards is what made a sub-of-a-sub
+   * unreadable. Their explicit expansions are recorded here rather than
+   * pre-filling `collapsedAnnotationIds` with every deep id the reader never
+   * touched, which would grow that list without bound.
+   */
+  expandedAnnotationIds: string[]
+  /**
+   * The subtree the panel is focused on, or null for the whole list. Past
+   * depth 5 a thread stops rendering inline and is entered like a folder, with
+   * a breadcrumb back out — you navigate by crumb, never by scrolling back up
+   * through levels.
+   */
+  focusedSubtreeId: string | null
   setAnswerPlacement: (placement: AnswerPlacement) => void
   setSidebarWidth: (width: number) => void
   toggleAnswerPlacement: () => void
@@ -70,6 +85,8 @@ interface LayoutState {
   resetFloatingOffset: () => void
   toggleAnnotationCollapsed: (id: string) => void
   setAnnotationCollapsed: (id: string, collapsed: boolean) => void
+  toggleAnnotationExpanded: (id: string) => void
+  setFocusedSubtree: (id: string | null) => void
 }
 
 export const ZERO_OFFSET = { dx: 0, dy: 0 }
@@ -81,6 +98,8 @@ export const useLayoutStore = create<LayoutState>()(
       sidebarWidth: SIDEBAR_DEFAULT_WIDTH,
       floatingOffset: ZERO_OFFSET,
       collapsedAnnotationIds: [],
+      expandedAnnotationIds: [],
+      focusedSubtreeId: null,
       // Changing placement always re-parks the panel: the offset was chosen
       // against the old layout and means nothing in the new one.
       setAnswerPlacement: (placement) =>
@@ -99,6 +118,13 @@ export const useLayoutStore = create<LayoutState>()(
             ? s.collapsedAnnotationIds.filter((x) => x !== id)
             : [...s.collapsedAnnotationIds, id],
         })),
+      toggleAnnotationExpanded: (id) =>
+        set((s) => ({
+          expandedAnnotationIds: s.expandedAnnotationIds.includes(id)
+            ? s.expandedAnnotationIds.filter((x) => x !== id)
+            : [...s.expandedAnnotationIds, id],
+        })),
+      setFocusedSubtree: (id) => set({ focusedSubtreeId: id }),
       setAnnotationCollapsed: (id, collapsed) =>
         set((s) => ({
           collapsedAnnotationIds: collapsed
@@ -114,6 +140,10 @@ export const useLayoutStore = create<LayoutState>()(
         answerPlacement: s.answerPlacement,
         sidebarWidth: s.sidebarWidth,
         collapsedAnnotationIds: s.collapsedAnnotationIds,
+        expandedAnnotationIds: s.expandedAnnotationIds,
+        // focusedSubtreeId is deliberately NOT persisted: it is navigation
+        // state, and a reload should land back on the whole list rather than
+        // inside a subtree the reader has no memory of entering.
       }),
       onRehydrateStorage: () => (state) => {
         // A snapshot from an older build may carry a placement this one has
@@ -123,6 +153,8 @@ export const useLayoutStore = create<LayoutState>()(
           state.sidebarWidth = clampSidebarWidth(state.sidebarWidth)
           state.floatingOffset = ZERO_OFFSET
           state.collapsedAnnotationIds = normalizeCollapsedAnnotationIds(state.collapsedAnnotationIds)
+          state.expandedAnnotationIds = normalizeCollapsedAnnotationIds(state.expandedAnnotationIds)
+          state.focusedSubtreeId = null
         }
       },
     },


### PR DESCRIPTION
Second of four tracks on the reading loop. Follows #148.

## 1. Highlight-to-ask was already built — and silently dead on one path

`AgentMarkdown` has handled drag-selection inside an answer since it was written: `handleMouseUp` opens a composer at the selection rect. But `AnnotationCard`'s **legacy render path** — a `resolution` with an empty `conversation` — passed neither `interactive` nor `onDrill`, so highlighting there did nothing at all, with no feedback of any kind. And `ConversationThread` gated the affordance on the **thread-wide** `isStreaming`, killing it on every finished answer in a thread while any one message streamed.

That is why the feature reads as *"I have to click Spin off annotation first"*: the button was the only thing that visibly worked.

- The drill handler moves to `annotations/drill.ts`, so the two render paths cannot diverge again.
- The streaming gate narrows to the one message actually streaming — line 101 already computed that expression.
- **"Spin off annotation" → "Ask about the document instead."** It is not redundant with highlighting: it anchors to the **document** selection where highlighting anchors to the **answer** text. Nothing said so.

## 2. Depth was drawn as indentation, inside a 400px rail

`marginLeft: min(depth, 5)rem` cost up to 80px before card padding. Readable prose runs 45–75 characters and degrades below about 45, so this did not merely look cramped — it pushed the text column under the legibility floor.

Every team that has publicly reasoned about deep threading landed in the same place. Slack capped replies at **one level**; the nested version was "very complicated", people "didn't understand it at all", and the cap was "an instant success on all fronts". Discourse rejected nesting outright, its third stated objection being that indentation eats horizontal space as depth grows. NN/g finds more than two disclosure levels loses users moving between the levels.

So depth is no longer a margin:

| Depth | Rendering |
|---|---|
| 0 | Full width, no rail |
| 1–2 | One fixed **14px** indent — the only indent that ever applies — with a left rail carrying depth by weight and shade |
| 3–5 | Same indent, darker rail, a `↳N` badge, and **collapsed by default** |
| 6+ | Not inline. A `N replies deeper · view thread` row opens a focused view, left by breadcrumb |

Breadcrumbs rather than scroll position, because in a narrow rail they are the only way back that does not require retracing every level — and NN/g's finding is that breadcrumbs "never cause problems in user testing".

Two state decisions worth flagging for review:

- Deep-thread expansions live in a new `expandedAnnotationIds` rather than pre-filling `collapsedAnnotationIds` with every deep id the reader never touched — which would grow that persisted list without bound.
- `focusedSubtreeId` is deliberately **not** persisted. A reload should land on the whole list, not inside a subtree the reader has no memory of entering.

## Verification

- `typecheck`, `lint`, full unit suite: **1440 passed**, 10 skipped, 0 failed.
- 13 new tests covering `buildPanelRows` (fold boundary, fold anchoring, sibling bleed, missing depth, empty list) and `annotationLabel`.
- **Verified in the running app** against the reported four-deep thread: depth 3 now shows `↳3`, renders collapsed, and keeps full text width. The legitimate case still fires correctly too — a sibling thread on "idempotency key" still reports the document does not define it, which is true and useful.
- No existing test weakened or skipped.

## Not done here, deliberately

The plan called for also passing `quote` from the spin-off path. On reading it more closely that is wrong: `sourceQuote` means "quoted out of an AI answer", and the spin-off path anchors to a fresh *document* selection, so setting it would mislabel the provenance. #148's `annotationSubject` already handles that path correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
