### PR TITLE
feat(intent): tell a question about the highlight from a thought it sparked

### DIFF
--- a/src/app/api/classify/route.ts
+++ b/src/app/api/classify/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { CLASSIFICATION_PROMPT } from '@/lib/ai/prompts'
+import { parseClassification } from '@/lib/ai/classification'
 import {
   buildChatBody,
   extractContent,
   readProviderCtx,
   resolveChatUrlAndHeaders,
 } from '@/lib/server/llmProvider'
-
-const VALID_TYPES = ['ask', 'edit', 'dig', 'flag']
 
 export const maxDuration = 60
 
@@ -30,7 +29,8 @@ export async function POST(request: NextRequest) {
     const { url, headers, kind } = resolveChatUrlAndHeaders(ctx)
     const body = buildChatBody(ctx, {
       messages: [{ role: 'user', content: prompt }],
-      maxTokens: 50,
+      // Room for a small JSON object; the old single-word budget could clip it.
+      maxTokens: 100,
       temperature: 0,
     })
 
@@ -48,11 +48,11 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await response.json()
-    const type = extractContent(kind, data).content.trim().toLowerCase()
-
-    // Extract just the type word (model might add punctuation)
-    const matched = VALID_TYPES.find((t) => type.includes(t))
-    return NextResponse.json({ type: matched || 'flag' })
+    const raw = extractContent(kind, data).content
+    // Never throws: a malformed reply degrades to a substring-matched type and
+    // relation 'about', which is exactly what this route returned before the
+    // relation axis existed.
+    return NextResponse.json(parseClassification(raw, suggestedType ?? null))
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : 'Classification failed' },

--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -382,6 +382,37 @@ export function AnnotationCard({
   const label = ANNOTATION_LABELS[annotation.type]
   const defaultVerbosity = getDefaultVerbosity(annotation.anchor.scope, annotation.type)
   const currentVerbosity = annotation.verbosity || defaultVerbosity
+  const relation = annotation.relation ?? 'about'
+  // Show the correction affordance in exactly two places: when the answer was
+  // framed as a sparked-by tangent (so the reader knows why it went outside the
+  // document), and when the undefined-term guard actually fired on an "about"
+  // reading (the one moment a wrong "about" is visible and worth correcting).
+  // A chip on every ordinary answer would be pure noise.
+  const guardFired = (annotation.resolution?.content ?? '')
+    .trimStart()
+    .startsWith('This document does not define')
+  const showRelationChip = Boolean(annotation.resolution) && (relation === 'sparked_by' || guardFired)
+
+  async function reresolve(patch?: Partial<Annotation>) {
+    if (!view) return
+    if (patch) updateAnnotation(annotation.id, patch)
+    // Read fresh from the store so the patch above is part of what resolves.
+    const current = useAnnotationStore.getState().getById(annotation.id)
+    if (!current || current.status === 'resolving') return
+    updateAnnotation(annotation.id, { status: 'resolving', conversation: [] })
+    const msgId = generateId()
+    useAnnotationStore.getState().addMessage(annotation.id, {
+      id: msgId, role: 'agent', content: '', suggestedEdit: null, timestamp: Date.now(),
+    })
+    const resolution = await streamResolveAnnotation(current, view.state, (partial) => {
+      useAnnotationStore.getState().updateMessage(annotation.id, msgId, { content: partial })
+    })
+    useAnnotationStore.getState().updateMessage(annotation.id, msgId, {
+      content: resolution.content, suggestedEdit: resolution.suggestedEdit,
+    })
+    updateAnnotation(annotation.id, { status: 'resolved', resolution, resolvedAt: Date.now() })
+  }
+
   const showRegenerate = currentVerbosity !== defaultVerbosity
 
   return (
@@ -517,6 +548,34 @@ export function AnnotationCard({
         </div>
       )}
 
+      {/* Anchor relation: is the highlight the subject, or just where the
+          thought struck? Correctable in one click — the classifier guesses, and
+          a guess with an escape hatch beats a clarifying question when the
+          correction costs a click. */}
+      {showDetail && !held && showRelationChip && (
+        <div
+          className="mt-2 flex flex-wrap items-center gap-2 rounded-md bg-warm/40 px-2 py-1.5"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="text-[10px] text-muted-foreground">
+            {relation === 'sparked_by'
+              ? 'Answered as a thought this passage sparked — not as a question about it.'
+              : 'Answered as a question about the highlighted text.'}
+          </span>
+          <button
+            onClick={() =>
+              reresolve({ relation: relation === 'sparked_by' ? 'about' : 'sparked_by' })
+            }
+            disabled={annotation.status === 'resolving'}
+            className="text-[10px] font-medium text-accent hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {relation === 'sparked_by'
+              ? 'Ask about the highlight instead'
+              : "That wasn't my question — answer what I asked"}
+          </button>
+        </div>
+      )}
+
       {/* Verbosity toggle (when active and resolved; hidden while the answer is held) */}
       {showDetail && !held && annotation.resolution && (
         <div className="mt-2 flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
@@ -538,24 +597,7 @@ export function AnnotationCard({
           ))}
           {showRegenerate && (
             <button
-              onClick={async () => {
-                if (!view) return
-                // Read fresh from store to avoid stale closure
-                const current = useAnnotationStore.getState().getById(annotation.id)
-                if (!current || current.status === 'resolving') return
-                updateAnnotation(annotation.id, { status: 'resolving', conversation: [] })
-                const msgId = generateId()
-                useAnnotationStore.getState().addMessage(annotation.id, {
-                  id: msgId, role: 'agent', content: '', suggestedEdit: null, timestamp: Date.now(),
-                })
-                const resolution = await streamResolveAnnotation(current, view.state, (partial) => {
-                  useAnnotationStore.getState().updateMessage(annotation.id, msgId, { content: partial })
-                })
-                useAnnotationStore.getState().updateMessage(annotation.id, msgId, {
-                  content: resolution.content, suggestedEdit: resolution.suggestedEdit,
-                })
-                updateAnnotation(annotation.id, { status: 'resolved', resolution, resolvedAt: Date.now() })
-              }}
+              onClick={() => reresolve()}
               disabled={annotation.status === 'resolving'}
               className="px-2 py-0.5 text-[10px] font-mono text-accent hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
             >

--- a/src/lib/ai/__tests__/classification.test.ts
+++ b/src/lib/ai/__tests__/classification.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { parseClassification } from '../classification'
+
+// The classifier now answers on two axes in one round-trip. It runs against
+// whatever provider the reader configured, including small local models that
+// will cheerfully answer "DIG" to a request for a JSON object — so the parse
+// has to degrade in a chosen direction rather than throw or guess.
+//
+// The chosen direction: type degrades to the old substring match, relation
+// degrades to 'about'. A wrong 'sparked_by' silently suppresses the
+// undefined-term guard; a wrong 'about' merely reproduces what the tool did
+// before this axis existed, and the reader can correct either in one click.
+
+describe('parseClassification', () => {
+  it('reads a clean JSON answer', () => {
+    expect(parseClassification('{"type":"dig","relation":"sparked_by"}')).toEqual({
+      type: 'dig',
+      relation: 'sparked_by',
+    })
+  })
+
+  it('survives a code fence and surrounding prose', () => {
+    const raw = 'Sure! Here you go:\n```json\n{"type":"ask","relation":"about"}\n```'
+    expect(parseClassification(raw)).toEqual({ type: 'ask', relation: 'about' })
+  })
+
+  it('falls back to the old substring match when the model answers a bare word', () => {
+    // Exactly what this route returned before the relation axis existed.
+    expect(parseClassification('EDIT')).toEqual({ type: 'edit', relation: 'about' })
+    expect(parseClassification('  Dig.  ')).toEqual({ type: 'dig', relation: 'about' })
+  })
+
+  it('degrades relation to about rather than guessing, when only relation is bad', () => {
+    expect(parseClassification('{"type":"ask","relation":"tangent"}')).toEqual({
+      type: 'ask',
+      relation: 'about',
+    })
+    expect(parseClassification('{"type":"ask"}')).toEqual({ type: 'ask', relation: 'about' })
+  })
+
+  it('recovers the type from the raw text when the JSON names an invalid one', () => {
+    expect(parseClassification('{"type":"clarify","relation":"about"}').relation).toBe('about')
+  })
+
+  it('uses the suggested type when nothing is recoverable', () => {
+    expect(parseClassification('¯\\_(ツ)_/¯', 'dig')).toEqual({ type: 'dig', relation: 'about' })
+  })
+
+  it('falls back to flag when there is no suggestion either', () => {
+    expect(parseClassification('')).toEqual({ type: 'flag', relation: 'about' })
+  })
+
+  it('never throws on malformed JSON', () => {
+    expect(() => parseClassification('{"type":"ask",')).not.toThrow()
+    expect(parseClassification('{"type":"ask",')).toEqual({ type: 'ask', relation: 'about' })
+  })
+
+  it('ignores case and whitespace the model adds', () => {
+    expect(parseClassification('{"type":" ASK ","relation":" Sparked_By "}')).toEqual({
+      type: 'ask',
+      relation: 'sparked_by',
+    })
+  })
+})

--- a/src/lib/ai/__tests__/intentContextUndefinedTerm.test.ts
+++ b/src/lib/ai/__tests__/intentContextUndefinedTerm.test.ts
@@ -220,3 +220,43 @@ describe('buildIntentContext — a heading carried down a thread', () => {
     expect(ctx.undefinedTerm).toBeNull()
   })
 })
+
+
+describe('buildIntentContext — the anchor as provenance, not subject', () => {
+  // The reported failure: the reader highlighted "AWS-heavy." and typed "I need
+  // to provide context on the different AWS modules". They did not ask what
+  // "AWS-heavy" means, so whether the document defines it is not a fact worth
+  // opening with — but the guard read the selection and never the question.
+  it('stays silent when the anchor is only where the thought struck', async () => {
+    useDocGraphStore.setState({ graph: graphOf([{ blockId: 'a', text: 'My background is AWS-heavy.' }]) })
+    const ctx = await buildIntentContext(
+      stateWith('My background is AWS-heavy.'),
+      1,
+      'phrase',
+      undefined,
+      'AWS-heavy',
+      'sparked_by',
+    )
+    expect(ctx.undefinedTerm).toBeNull()
+  })
+
+  it('still fires on the same term when the anchor IS the subject', async () => {
+    // The guard is suppressed by the relation, not disabled outright.
+    useDocGraphStore.setState({ graph: graphOf([{ blockId: 'a', text: 'My background is AWS-heavy.' }]) })
+    const ctx = await buildIntentContext(
+      stateWith('My background is AWS-heavy.'),
+      1,
+      'phrase',
+      undefined,
+      'AWS-heavy',
+      'about',
+    )
+    expect(ctx.undefinedTerm).toBe('AWS-heavy')
+  })
+
+  it("defaults to 'about', so an omitted relation keeps the old behaviour", async () => {
+    useDocGraphStore.setState({ graph: graphOf([{ blockId: 'a', text: 'Terraform / Atlantis sniff test' }]) })
+    const ctx = await buildIntentContext(stateWith('Terraform / Atlantis sniff test'), 1, 'section', undefined, 'Atlantis')
+    expect(ctx.undefinedTerm).toBe('Atlantis')
+  })
+})

--- a/src/lib/ai/__tests__/prompts.test.ts
+++ b/src/lib/ai/__tests__/prompts.test.ts
@@ -7,11 +7,20 @@ import {
 } from '../prompts'
 
 describe('Classification prompt', () => {
+  // The prompt now answers on TWO axes in one round-trip: what the reader wants
+  // done, and whether the highlighted span is the subject of what they said or
+  // only where the thought struck. Type names are lowercase now because the
+  // reply is a JSON object rather than a single shouted word.
   it('includes all 4 annotation types', () => {
-    expect(CLASSIFICATION_PROMPT).toContain('ASK')
-    expect(CLASSIFICATION_PROMPT).toContain('EDIT')
-    expect(CLASSIFICATION_PROMPT).toContain('DIG')
-    expect(CLASSIFICATION_PROMPT).toContain('FLAG')
+    expect(CLASSIFICATION_PROMPT).toContain('ask:')
+    expect(CLASSIFICATION_PROMPT).toContain('edit:')
+    expect(CLASSIFICATION_PROMPT).toContain('dig:')
+    expect(CLASSIFICATION_PROMPT).toContain('flag:')
+  })
+
+  it('includes both anchor relations', () => {
+    expect(CLASSIFICATION_PROMPT).toContain('about:')
+    expect(CLASSIFICATION_PROMPT).toContain('sparked_by:')
   })
 
   it('frames the classifier as a document review tool', () => {
@@ -23,8 +32,16 @@ describe('Classification prompt', () => {
     expect(CLASSIFICATION_PROMPT).toContain('{{anchoredText}}')
   })
 
-  it('instructs to respond with only the type name', () => {
-    expect(CLASSIFICATION_PROMPT).toContain('ONLY the type name')
+  it('demands a bare JSON object carrying both axes', () => {
+    expect(CLASSIFICATION_PROMPT).toContain('ONLY a JSON object')
+    expect(CLASSIFICATION_PROMPT).toContain('no code fence')
+    expect(CLASSIFICATION_PROMPT).toContain('{"type":"ask","relation":"about"}')
+  })
+
+  it('breaks the tie toward about, the safer default', () => {
+    // A wrong 'sparked_by' silently suppresses the undefined-term guard; a
+    // wrong 'about' just reproduces the old behaviour.
+    expect(CLASSIFICATION_PROMPT).toContain('answer about')
   })
 })
 

--- a/src/lib/ai/classification.ts
+++ b/src/lib/ai/classification.ts
@@ -1,0 +1,58 @@
+import type { AnchorRelation, AnnotationType } from '@/lib/annotations/types'
+
+export const VALID_TYPES: AnnotationType[] = ['ask', 'edit', 'dig', 'flag']
+const VALID_RELATIONS: AnchorRelation[] = ['about', 'sparked_by']
+
+export interface Classification {
+  type: AnnotationType
+  relation: AnchorRelation
+}
+
+/**
+ * Parse the classifier's reply into a type and an anchor relation.
+ *
+ * The prompt asks for strict JSON, but this runs against whatever provider the
+ * reader configured — including small local models that will happily answer
+ * "DIG" to a request for an object, or wrap the object in a code fence. So the
+ * parse degrades in a specific direction:
+ *
+ *   1. a real JSON object with valid fields wins;
+ *   2. failing that, the old substring match recovers the type, exactly as
+ *      before this second axis existed;
+ *   3. relation falls back to 'about', which is both the common case and the
+ *      pre-existing behaviour.
+ *
+ * Degrading relation to 'about' rather than guessing is the point: a wrong
+ * 'sparked_by' silently suppresses the undefined-term guard, whereas a wrong
+ * 'about' merely reproduces what the tool did before, and the reader has a
+ * one-click correction either way.
+ */
+export function parseClassification(
+  raw: string,
+  suggestedType?: AnnotationType | null,
+): Classification {
+  const fallbackType = (): AnnotationType => {
+    const lower = raw.toLowerCase()
+    return VALID_TYPES.find((t) => lower.includes(t)) ?? suggestedType ?? 'flag'
+  }
+
+  // Take the outermost brace pair, so a code fence or a stray "Here you go:"
+  // preamble doesn't defeat the parse.
+  const open = raw.indexOf('{')
+  const close = raw.lastIndexOf('}')
+  if (open !== -1 && close > open) {
+    try {
+      const parsed = JSON.parse(raw.slice(open, close + 1)) as Record<string, unknown>
+      const type = String(parsed.type ?? '').trim().toLowerCase() as AnnotationType
+      const relation = String(parsed.relation ?? '').trim().toLowerCase() as AnchorRelation
+      return {
+        type: VALID_TYPES.includes(type) ? type : fallbackType(),
+        relation: VALID_RELATIONS.includes(relation) ? relation : 'about',
+      }
+    } catch {
+      // Malformed JSON — fall through to the substring path below.
+    }
+  }
+
+  return { type: fallbackType(), relation: 'about' }
+}

--- a/src/lib/ai/classifier.ts
+++ b/src/lib/ai/classifier.ts
@@ -1,32 +1,31 @@
 import type { LLMConfig } from './client'
 import { providerHeaders } from './providerHeaders'
+import { parseClassification, type Classification } from './classification'
 import type { AnnotationType } from '@/lib/annotations/types'
 
-const VALID_TYPES: AnnotationType[] = ['ask', 'edit', 'dig', 'flag']
-
-const CLASSIFICATION_PROMPT_4TYPE = `You are an annotation classifier for a document review tool. Given the user's input and the text they selected, classify their intent into exactly one of these types:
-
-- ASK: Seeking clarification ("What does this mean?", "Is this right?", "Why is this here?")
-- EDIT: Directing a change ("Change this to X", "Make it shorter", "Fix this", "Restructure", "This is wrong, it should be Y")
-- DIG: Investigating deeper ("Tell me more", "What are the implications?", "Research this", "What evidence supports this?")
-- FLAG: Marking something problematic ("This seems off", "Something's wrong here", "Come back to this", "Not sure about this")
-
-Respond with ONLY the type name in uppercase: ASK, EDIT, DIG, or FLAG.
-
-User said: "{{transcript}}"
-Selected text: "{{anchoredText}}"
-
-Type:`
-
+/**
+ * Classify an annotation: what the reader wants done, and whether the
+ * highlighted span is the subject of what they said or only where the thought
+ * struck them.
+ *
+ * Both judgements come out of ONE round-trip — the one that already existed.
+ * `/api/classify` has always received the transcript and the anchored text
+ * together, so the relation costs no extra call and adds no second point of
+ * failure.
+ *
+ * This file previously carried its own copy of the classification prompt,
+ * built into a local `prompt` variable that was never sent anywhere: the
+ * request body has always been `{transcript, anchoredText, suggestedType}` and
+ * the route builds the prompt itself. That dead copy is gone, so there is now
+ * exactly one classification prompt, in prompts.ts.
+ */
 export async function classifyAnnotation(
   transcript: string,
   anchoredText: string,
   config: LLMConfig,
   suggestedType?: AnnotationType | null,
-): Promise<AnnotationType> {
-  const prompt = CLASSIFICATION_PROMPT_4TYPE
-    .replace('{{transcript}}', transcript)
-    .replace('{{anchoredText}}', anchoredText)
+): Promise<Classification> {
+  const fallback: Classification = { type: suggestedType ?? 'flag', relation: 'about' }
 
   try {
     const response = await fetch('/api/classify', {
@@ -40,19 +39,18 @@ export async function classifyAnnotation(
 
     if (!response.ok) {
       console.error('Classification failed, defaulting to flag')
-      return suggestedType ?? 'flag'
+      return fallback
     }
 
     const data = await response.json()
-    const type = data.type?.trim().toLowerCase() as AnnotationType
-
-    if (VALID_TYPES.includes(type)) {
-      return type
-    }
-
-    return suggestedType ?? 'flag'
+    // The route parses already; re-reading its answer through the same parser
+    // keeps this correct if a provider or an older route ever hands back a
+    // bare word instead of the pair.
+    return parseClassification(JSON.stringify(data ?? {}), suggestedType ?? null)
   } catch (err) {
     console.error('Classification error:', err)
-    return suggestedType ?? 'flag'
+    return fallback
   }
 }
+
+export type { Classification, AnnotationType }

--- a/src/lib/ai/intentContext.ts
+++ b/src/lib/ai/intentContext.ts
@@ -1,5 +1,5 @@
 import type { EditorState } from 'prosemirror-state'
-import type { Scope } from '@/lib/annotations/types'
+import type { AnchorRelation, Scope } from '@/lib/annotations/types'
 import { getBlockText, getSectionText } from '@/lib/prosemirror/helpers'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import {
@@ -343,6 +343,7 @@ export async function buildIntentContext(
   scope: Scope,
   quoteScope?: Scope,
   selectedText?: string,
+  relation: AnchorRelation = 'about',
 ): Promise<IntentContext> {
   const budget = BUDGET[quoteScope ?? scope] ?? BUDGET.paragraph
 
@@ -377,8 +378,13 @@ export async function buildIntentContext(
   // (see looksLikeTerm -- a sentence, heading or question is not a term the
   // document could define) and impossible on a cold graph, where
   // `graphUnavailable` already tells callers not to read silence as an answer.
+  //
+  // Only asked when the anchor IS the subject. A reader who highlighted
+  // "AWS-heavy" and typed "I need to provide context on the different AWS
+  // modules" did not ask what "AWS-heavy" means, so whether the document
+  // defines it is not a fact worth opening with.
   const term = selectedText?.trim() ?? ''
-  if (term && looksLikeTerm(term) && !documentDefines(graph, term)) {
+  if (relation === 'about' && term && looksLikeTerm(term) && !documentDefines(graph, term)) {
     ctx.undefinedTerm = term
   }
 

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,17 +1,36 @@
-// 4-type classification prompt (used by /api/classify)
-export const CLASSIFICATION_PROMPT = `You are an annotation classifier for a document review tool. Given the user's input and the text they selected, classify their intent into exactly one of these types:
+// Classification prompt (used by /api/classify). Returns TWO judgements:
+// what the reader wants done, and what the highlighted span is to what they
+// said. The second axis rides along here rather than in a separate call --
+// this round-trip already receives both the transcript and the anchored text,
+// so inferring scope inside a call that already happens costs no latency and
+// adds no second point of failure. (The same reason self-query retrievers
+// parse a query's filters inside one call instead of routing beforehand.)
+export const CLASSIFICATION_PROMPT = `You are an annotation classifier for a document review tool. A reader highlighted a span of a document and said something. Judge two things.
 
-- ASK: Seeking clarification ("What does this mean?", "Is this right?", "Why is this here?")
-- EDIT: Directing a change ("Change this to X", "Make it shorter", "Fix this", "Restructure", "This is wrong, it should be Y", "Reword this")
-- DIG: Investigating deeper ("Tell me more", "What are the implications?", "Research this", "What evidence supports this?")
-- FLAG: Marking something problematic ("This seems off", "Something's wrong here", "Come back to this", "Not sure about this")
+TYPE - what the reader wants done:
+- ask: Seeking clarification ("What does this mean?", "Is this right?", "Why is this here?")
+- edit: Directing a change ("Change this to X", "Make it shorter", "Fix this", "Restructure", "This is wrong, it should be Y", "Reword this")
+- dig: Investigating deeper ("Tell me more", "What are the implications?", "Research this", "What evidence supports this?")
+- flag: Marking something problematic ("This seems off", "Something's wrong here", "Come back to this", "Not sure about this")
 
-Respond with ONLY the type name in uppercase: ASK, EDIT, DIG, or FLAG.
+RELATION - what the highlighted text IS to what the reader said:
+- about: they are asking about the highlighted text itself. It is the subject.
+- sparked_by: the highlighted text triggered a thought that is NOT about it. It is where they were reading, not what they are asking about.
 
-User said: "{{transcript}}"
-Selected text: "{{anchoredText}}"
+Examples of sparked_by:
+- Highlighted "AWS-heavy." and said "I need to provide context on the different AWS modules" - they want the AWS modules explained, not the phrase "AWS-heavy" defined.
+- Highlighted any sentence and said "remind me to check whether we still support this" - the thought is a task, not a question about the span.
+Examples of about:
+- Highlighted "Bucket Lock" and said "what is this?"
+- Highlighted a paragraph and said "make this shorter"
 
-Type:`
+When genuinely torn, answer about.
+
+Respond with ONLY a JSON object, no prose and no code fence:
+{"type":"ask","relation":"about"}
+
+Reader said: "{{transcript}}"
+Highlighted text: "{{anchoredText}}"`
 
 // Sub-agent system prompts per annotation type
 export const RESOLVER_SYSTEM_PROMPT = `You are a scoped review agent for Intent IDE, a professional document review tool. You think like a lawyer examining a contract, an auditor verifying claims, or a PM stress-testing a PRD.

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -198,6 +198,7 @@ export async function resolveAnnotation(
     // it is anchored. A child inherits its parent's document POSITION on
     // purpose, but never its subject -- see annotationSubject.
     annotationSubject(annotation),
+    annotation.relation ?? 'about',
   )
   const contextSummary = sessionContext.annotationHistory || 'No prior context.'
 
@@ -271,7 +272,9 @@ export async function resolveAnnotation(
   Type: ${annotation.type}
   Scope: ${scope}
   User said: "${annotation.transcript}"
-  Selected text: "${annotation.anchor.text}"${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
+  ${(annotation.relation ?? 'about') === 'sparked_by'
+    ? `Prompted by (context only, NOT the subject -- do not define or explain it, and do not remark on whether the document defines it): "${annotation.anchor.text}"\n  Answer what the reader actually said, on its own terms.`
+    : `Selected text: "${annotation.anchor.text}"`}${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
 
 ${formatIntentContext(intentContext)}${branchChain}
 ${reviewProgress}
@@ -387,6 +390,7 @@ export async function streamResolveAnnotation(
     // it is anchored. A child inherits its parent's document POSITION on
     // purpose, but never its subject -- see annotationSubject.
     annotationSubject(annotation),
+    annotation.relation ?? 'about',
   )
   const contextSummary = sessionContext.annotationHistory || 'No prior context.'
 
@@ -461,7 +465,9 @@ export async function streamResolveAnnotation(
   Type: ${annotation.type}
   Scope: ${scope}
   User said: "${annotation.transcript}"
-  Selected text: "${annotation.anchor.text}"${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
+  ${(annotation.relation ?? 'about') === 'sparked_by'
+    ? `Prompted by (context only, NOT the subject -- do not define or explain it, and do not remark on whether the document defines it): "${annotation.anchor.text}"\n  Answer what the reader actually said, on its own terms.`
+    : `Selected text: "${annotation.anchor.text}"`}${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
 
 ${formatIntentContext(intentContext)}${branchChain}
 ${reviewProgress}
@@ -621,6 +627,7 @@ export async function continueThread(
     // it is anchored. A child inherits its parent's document POSITION on
     // purpose, but never its subject -- see annotationSubject.
     annotationSubject(annotation),
+    annotation.relation ?? 'about',
   )
   const contextSummary = sessionContext.annotationHistory || 'No prior context.'
 
@@ -659,7 +666,9 @@ export async function continueThread(
   Type: ${annotation.type}
   Scope: ${scope}
   User said: "${annotation.transcript}"
-  Selected text: "${annotation.anchor.text}"${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
+  ${(annotation.relation ?? 'about') === 'sparked_by'
+    ? `Prompted by (context only, NOT the subject -- do not define or explain it, and do not remark on whether the document defines it): "${annotation.anchor.text}"\n  Answer what the reader actually said, on its own terms.`
+    : `Selected text: "${annotation.anchor.text}"`}${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
 
 ${formatIntentContext(intentContext)}${branchChain}
 ${reviewProgress}

--- a/src/lib/annotations/types.ts
+++ b/src/lib/annotations/types.ts
@@ -24,6 +24,26 @@ export function mapLegacyType(type: string): AnnotationType {
   }
 }
 
+/**
+ * What the highlighted span IS to the annotation: its subject, or only where
+ * the thought happened to strike.
+ *
+ * A reader who highlights "AWS-heavy" and types "I need to learn the different
+ * AWS modules" has not asked what "AWS-heavy" means. The span is provenance,
+ * not subject — so answering "this document does not define AWS-heavy" is
+ * true, and useless.
+ *
+ * No shipping tool models this as one explicit toggle. The nearest precedents
+ * are Hypothes.is (an anchored annotation vs an unanchored Page Note) and
+ * Zettelkasten (a literature note about a source vs a fleeting note the source
+ * merely triggered); both split along exactly this line.
+ *
+ * Two states, deliberately. Native intent-selection accuracy falls off sharply
+ * as the option set grows, and a four-way scope picker would be one more
+ * decision on every annotation for a distinction that is binary in practice.
+ */
+export type AnchorRelation = 'about' | 'sparked_by'
+
 export type AnnotationStatus = 'pending' | 'classified' | 'resolving' | 'resolved' | 'applied' | 'dismissed'
 
 export type Scope = 'phrase' | 'sentence' | 'paragraph' | 'section'
@@ -81,6 +101,12 @@ export interface Annotation {
   createdAt: number
   resolvedAt: number | null
   verbosity: Verbosity
+  /**
+   * Whether the anchor is this annotation's subject or only its provenance.
+   * Absent on anything persisted before this field existed — migrateAnnotations
+   * backfills 'about', which is both the old behaviour and the common case.
+   */
+  relation?: AnchorRelation
   /** For a sub-chat spun off an AI answer: the exact quoted span that produced it. The document `anchor` stays the parent's positions so gutter/map/cascade keep working; this records what the branch is actually about. */
   sourceQuote?: string
   /**

--- a/src/lib/voice/pipeline.ts
+++ b/src/lib/voice/pipeline.ts
@@ -22,7 +22,7 @@ import { extractMermaidFence, ensureRenderableMermaid } from '@/lib/ai/mermaidGu
 import { ingestAnnotationEpisode } from '@/lib/graphrag/episodeIngestion'
 import { generateId } from '@/lib/utils/id'
 import { getDefaultVerbosity } from '@/lib/annotations/types'
-import type { Annotation, AnnotationType, TextAnchor } from '@/lib/annotations/types'
+import type { AnchorRelation, Annotation, AnnotationType, TextAnchor } from '@/lib/annotations/types'
 import { inferScopeFromText } from '@/lib/annotations/selectionOffers'
 
 const recorder = new AudioRecorder()
@@ -123,6 +123,12 @@ interface CreateAnnotationOptions {
   notify?: 'panel' | 'quiet'
   /** The exact quoted span from an AI answer this annotation was spun off from — see Annotation.sourceQuote. */
   quote?: string
+  /**
+   * Preset anchor relation. One-click offers know their own relation and set
+   * `skipClassify`, so there is no classifier round-trip to infer it from —
+   * without this the skipClassify path would silently always be 'about'.
+   */
+  relation?: AnchorRelation
 }
 
 /**
@@ -195,6 +201,7 @@ export function captureAnnotationFromText(
     childIds: [],
     createdAt: Date.now(),
     resolvedAt: null,
+    relation: options.relation ?? 'about',
     // A quoted sub-chat's subject matter is the quote itself, not the
     // parent's (possibly much larger) document anchor — a two-word quote
     // should get a two-word-sized budget, not the paragraph the parent was
@@ -258,18 +265,23 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
 
     const provisionalType = annotation.type
     let classifiedType = provisionalType
+    // A preset relation always wins: an offer that declares itself sparked_by
+    // knows better than a classifier that never saw the button.
+    let classifiedRelation: AnchorRelation = options.relation ?? annotation.relation ?? 'about'
 
     if (options.skipClassify) {
       classifiedType = options.suggestedType ?? provisionalType
     } else {
       try {
         const config = useSettingsStore.getState().llmConfig
-        classifiedType = await classifyAnnotation(
+        const classified = await classifyAnnotation(
           annotation.transcript,
           annotation.anchor.text,
           config,
           options.suggestedType ?? provisionalType,
         )
+        classifiedType = classified.type
+        if (!options.relation) classifiedRelation = classified.relation
       } catch {
         // Classification failed — use the provided type as fallback
         classifiedType = options.suggestedType ?? provisionalType
@@ -286,10 +298,11 @@ async function resolveCapturedAnnotation(id: string): Promise<void> {
       annotationStore.update(id, {
         type: classifiedType,
         status: 'classified',
+        relation: classifiedRelation,
         verbosity: getDefaultVerbosity(annotation.anchor.scope, classifiedType),
       })
     } else {
-      annotationStore.update(id, { status: 'classified' })
+      annotationStore.update(id, { status: 'classified', relation: classifiedRelation })
     }
 
     // Create a placeholder conversation message for streaming content

--- a/src/stores/__tests__/annotationStore.migration.test.ts
+++ b/src/stores/__tests__/annotationStore.migration.test.ts
@@ -306,3 +306,30 @@ describe('normalizeProposedEdit — legacy multi-region edits', () => {
     expect(edit.targetText).toBe('old')
   })
 })
+
+
+describe('migrateAnnotations — anchor relation backfill', () => {
+  // A TypeScript field default does nothing to an object rehydrated from
+  // localStorage. Without an explicit backfill every annotation already on a
+  // reader's machine would carry `relation === undefined`, so the
+  // `relation === 'about'` gate would read false and silently DISABLE the
+  // undefined-term guard for the whole existing corpus — the exact opposite of
+  // what adding the relation was for.
+  it("backfills 'about' on a snapshot written before the field existed", () => {
+    const [migrated] = migrateAnnotations([makeAnnotation({ type: 'ask' })])
+    expect(migrated.relation).toBe('about')
+  })
+
+  it('leaves an explicit relation alone', () => {
+    const [migrated] = migrateAnnotations([
+      makeAnnotation({ type: 'ask', relation: 'sparked_by' }),
+    ])
+    expect(migrated.relation).toBe('sparked_by')
+  })
+
+  it('backfills alongside the legacy type migration rather than instead of it', () => {
+    const [migrated] = migrateAnnotations([makeAnnotation({ type: 'question' })])
+    expect(migrated.type).toBe('ask')
+    expect(migrated.relation).toBe('about')
+  })
+})

--- a/src/stores/annotationStore.ts
+++ b/src/stores/annotationStore.ts
@@ -33,6 +33,12 @@ export function migrateAnnotations(annotations: Annotation[]): Annotation[] {
     documentId: a.documentId ?? LEGACY_DOCUMENT_ID,
     locationGroupKey: a.locationGroupKey ?? `${a.documentId ?? LEGACY_DOCUMENT_ID}:${a.anchor.from}:${a.anchor.to}`,
     type: mapLegacyType(a.type),
+    // A TypeScript default does nothing to an object rehydrated from
+    // localStorage. Without this backfill every existing annotation would have
+    // `relation === undefined`, so the `relation === 'about'` gate would read
+    // false and silently DISABLE the undefined-term guard for the entire
+    // existing corpus — the exact opposite of the intent.
+    relation: a.relation ?? 'about',
     resolution: a.resolution
       ? {
           ...a.resolution,


### PR DESCRIPTION
Third of four tracks on the reading loop. Follows #148 and #149.

## The case

A reader highlights `AWS-heavy` and types *"I need to provide context on the different AWS modules"*. They have not asked what "AWS-heavy" means — the span is **provenance**, not subject. The answer opened with *"This document does not define AWS-heavy"*: true, and useless.

Nothing could tell those apart, because the undefined-term guard read the selection and never the question.

Annotations now carry an **anchor relation**: `'about' | 'sparked_by'`.

Two states, deliberately. Native intent-selection accuracy falls off sharply as the option set grows, and a four-way scope picker would be one more decision on every annotation for something binary in practice. The closest precedents split on the same line — Hypothes.is (anchored annotation vs unanchored Page Note) and Zettelkasten (a literature note *about* a source vs a fleeting note it merely *triggered*).

The judgement rides on a round-trip that already happens: `/api/classify` has always received the transcript and the anchored text together, so this costs no extra latency and adds no second point of failure. Same reason a self-query retriever parses a query's filters inside one call rather than routing beforehand.

## Three things a type signature doesn't show

**The route was never the consumer.** `classifyAnnotation()` discarded everything but `.type` and returned a bare string, so extending the route's JSON alone would have changed nothing. It also carried a **dead second copy** of the classification prompt — built into a local variable that was never sent anywhere, since the body has always been `{transcript, anchoredText, suggestedType}`. Deleted; there is now one prompt.

**The parse degrades in a chosen direction.** This runs against whatever provider the reader configured, including small local models that answer `DIG` to a request for an object. `parseClassification` takes the outermost brace pair (a code fence doesn't defeat it) and on any failure falls back to the old substring match for type and to `'about'` for relation. A wrong `sparked_by` silently suppresses the guard; a wrong `about` merely reproduces the previous behaviour — and the reader can correct either in one click.

**Migration is mandatory, not automatic.** A TypeScript field default does nothing to an object rehydrated from localStorage. Without an explicit backfill every existing annotation would carry `relation === undefined`, so `=== 'about'` reads false and the guard switches **off** for the entire existing corpus — the exact opposite of the intent. `migrateAnnotations` now backfills alongside `documentId` / `locationGroupKey` / `type`, and there's a regression test pinning it.

## Details worth reviewing

- **All three** `ANNOTATION:` prompt blocks are relation-aware (`resolveAnnotation`, `streamResolveAnnotation`, `continueThread`). They're triplicated; touching only the first would leave streaming and follow-ups saying `Selected text:` regardless.
- **The chip appears in exactly two places**: when the answer was framed as a tangent (so the reader knows why it went outside the document), and when the guard actually fired on an `about` reading — the one moment a wrong `about` is visible and worth correcting. A chip on every ordinary answer would be noise.
- **`relation` is set once and inherited** by follow-ups in `continueThread`. A follow-up continues the same enquiry; re-classifying mid-thread would let the frame flip under the reader. Stated explicitly so it doesn't get "fixed" into an inconsistency.

## Deliberately not done

`Offer.relation` plumbing. Every canned offer — "Define", "Explain", "Summarize" — is genuinely `about`, and the `skipClassify` path already defaults there. An unused field would be a mechanism without a demonstrated need.

## Verification

- `typecheck`, `lint`, full unit suite: **1457 passed**, 10 skipped, 0 failed.
- 17 new tests: parser degradation (code fences, bare words, invalid relation, malformed JSON, garbage), the relation gate both ways, the migration backfill.
- **Falsified before claiming**: reverting the relation gate or the migration backfill fails exactly three of the new tests and no others.
- Two obsolete assertions in `prompts.test.ts` were **updated, not removed or skipped** — the reply is a JSON object now, so "ONLY the type name" and uppercase type names no longer describe the contract. Coverage went up: both axes and the tie-break are now asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
