### PR TITLE
feat(cascade): notice a rename, and offer the mentions it left behind

### DIFF
--- a/src/components/Editor/EditorShell.tsx
+++ b/src/components/Editor/EditorShell.tsx
@@ -24,6 +24,7 @@ import { UncertaintyTooltip } from './UncertaintyTooltip'
 import { ProposedEditControl } from './ProposedEditControl'
 import { FormattingToolbar } from './FormattingToolbar'
 import { DirectEditCascadeChip } from './DirectEditCascadeChip'
+import { RenameReview } from './RenameReview'
 
 const AUTOSAVE_DELAY = 5000 // 5 seconds idle
 
@@ -239,6 +240,7 @@ export function EditorShell() {
       <UncertaintyTooltip />
       <ProposedEditControl />
       <DirectEditCascadeChip />
+      <RenameReview />
     </div>
   )
 }

--- a/src/components/Editor/RenameReview.tsx
+++ b/src/components/Editor/RenameReview.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useCallback, useMemo, useState } from 'react'
+import { useDirectEditOfferStore } from '@/stores/directEditOfferStore'
+import { useEditorStore } from '@/stores/editorStore'
+import { useSettingsStore } from '@/stores/settingsStore'
+import { useToastStore } from '@/stores/toastStore'
+import { findBlockById } from '@/lib/prosemirror/blockIds'
+import { applySingleEdit } from '@/lib/prosemirror/applyProposedEdits'
+import { judgeRenameOccurrences, type RenameVerdict } from '@/lib/ai/judgeRenameOccurrences'
+import { generateId } from '@/lib/utils/id'
+
+/**
+ * Review the mentions a rename left behind — one at a time, with the sentence.
+ *
+ * Nothing here auto-applies. Prose has no compiler: coreference resolution runs
+ * at roughly F1 78-81% on curated benchmarks and worse on real documents, and
+ * its failure cases are exactly the ones that matter (a different person with
+ * the same name, a product, a quotation). Every tool that does this well —
+ * IntelliJ's rename preview, Vale, Acrolinx, textlint — suggests and never
+ * silently commits, because one wrong rewrite costs more trust than one extra
+ * confirmation click.
+ *
+ * One at a time rather than a grid of checkboxes, for the reason `git add -p`
+ * is tolerable and a wall of N decisions is not: each item is judged in its own
+ * context, the common case is a single keystroke, and the ambiguous ones are
+ * the only ones that cost real attention.
+ */
+
+interface ReviewItem {
+  blockId: string
+  index: number
+  sentence: string
+  verdict?: RenameVerdict
+}
+
+export function RenameReview() {
+  const offer = useDirectEditOfferStore((s) => s.renameOffer)
+  const clearRenameOffer = useDirectEditOfferStore((s) => s.clearRenameOffer)
+  const [items, setItems] = useState<ReviewItem[] | null>(null)
+  const [cursor, setCursor] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [applied, setApplied] = useState(0)
+
+  const flattened = useMemo<ReviewItem[]>(() => {
+    if (!offer) return []
+    return offer.targets.flatMap((target) =>
+      target.occurrences.map((o) => ({
+        blockId: target.blockId,
+        index: o.index,
+        sentence: o.sentence,
+      })),
+    )
+  }, [offer])
+
+  const close = useCallback(() => {
+    setItems(null)
+    setCursor(0)
+    setApplied(0)
+    clearRenameOffer()
+  }, [clearRenameOffer])
+
+  const startReview = useCallback(async () => {
+    if (!offer || busy) return
+    setBusy(true)
+    try {
+      // The judge is opt-in in the same way the related-passage second opinion
+      // is. With it off, every candidate is simply reviewed unjudged — the
+      // reader still decides, they just get no hint.
+      if (useSettingsStore.getState().judgeEnabled) {
+        const config = useSettingsStore.getState().llmConfig
+        const verdicts = await judgeRenameOccurrences(
+          { from: offer.from, to: offer.to },
+          flattened.map((i) => ({ sentence: i.sentence })),
+          config,
+        )
+        setItems(flattened.map((item, i) => ({ ...item, verdict: verdicts.get(i) })))
+      } else {
+        setItems(flattened)
+      }
+    } catch {
+      // A judge failure must never destroy the first opinion — show every
+      // candidate unjudged rather than deciding for the reader.
+      setItems(flattened)
+    } finally {
+      setBusy(false)
+    }
+  }, [offer, flattened, busy])
+
+  const applyCurrent = useCallback(
+    (item: ReviewItem) => {
+      const view = useEditorStore.getState().view
+      if (!view || !offer) return false
+      const block = findBlockById(view.state.doc, item.blockId)
+      if (!block) return false
+      const from = block.pos + 1 + item.index
+      const result = applySingleEdit(view, {
+        id: generateId(),
+        from,
+        to: from + offer.from.length,
+        newText: offer.to,
+        // Fail closed: applySingleEdit re-verifies this text at the range and
+        // recovers by block-scoped fingerprint if the document moved under us.
+        targetText: offer.from,
+        blockId: item.blockId,
+      })
+      if (!result.ok) {
+        useToastStore.getState().addToast(result.reason, 'error')
+        return false
+      }
+      return result.applied.length > 0
+    },
+    [offer],
+  )
+
+  const decide = useCallback(
+    (rename: boolean) => {
+      if (!items) return
+      const item = items[cursor]
+      if (rename && item && applyCurrent(item)) setApplied((n) => n + 1)
+      if (cursor + 1 >= items.length) {
+        useToastStore
+          .getState()
+          .addToast(
+            `${applied + (rename ? 1 : 0)} of ${items.length} renamed`,
+            'success',
+          )
+        close()
+        return
+      }
+      setCursor((n) => n + 1)
+    },
+    [items, cursor, applyCurrent, applied, close],
+  )
+
+  if (!offer) return null
+
+  // ── The quiet offer chip ──────────────────────────────────────────────────
+  if (!items) {
+    const noun = offer.occurrenceCount === 1 ? 'other mention' : 'other mentions'
+    return (
+      <div
+        role="status"
+        aria-label={`You renamed ${offer.from} to ${offer.to} — offer to review ${offer.occurrenceCount} ${noun}`}
+        className="fixed bottom-20 right-6 z-40 flex max-w-md items-center gap-2 rounded-full border border-stone-200 bg-white/95 px-4 py-2 text-sm text-stone-700 shadow-md backdrop-blur"
+      >
+        {busy ? (
+          <span className="italic text-stone-500">Checking other mentions…</span>
+        ) : (
+          <>
+            <span className="truncate">
+              {offer.from} → {offer.to}: {offer.occurrenceCount} {noun}
+            </span>
+            <button
+              type="button"
+              onClick={startReview}
+              aria-label={`Review ${offer.occurrenceCount} ${noun}`}
+              className="shrink-0 rounded-full bg-stone-800 px-3 py-1 text-xs font-medium text-white hover:bg-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-500"
+            >
+              Review
+            </button>
+            <button
+              type="button"
+              onClick={close}
+              aria-label="Dismiss this rename suggestion"
+              className="shrink-0 rounded-full px-2 py-1 text-xs text-stone-500 hover:bg-stone-100 hover:text-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-400"
+            >
+              Dismiss
+            </button>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  // ── One mention at a time, with its sentence ──────────────────────────────
+  const item = items[cursor]
+  if (!item) return null
+  const confident = item.verdict?.sameReferent === true
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Rename review, mention ${cursor + 1} of ${items.length}`}
+      className="fixed bottom-20 right-6 z-40 w-[26rem] max-w-[calc(100vw-3rem)] rounded-xl border border-stone-200 bg-white/98 p-4 text-sm shadow-lg backdrop-blur"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-medium text-stone-800">
+          {offer.from} → {offer.to}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-stone-500">
+          {cursor + 1} of {items.length}
+        </span>
+      </div>
+
+      <p className="mt-3 rounded-md bg-stone-50 px-3 py-2 leading-relaxed text-stone-700">
+        {item.sentence}
+      </p>
+
+      {item.verdict && (
+        <p className={`mt-2 text-xs ${confident ? 'text-stone-600' : 'text-amber-700'}`}>
+          {confident ? '✓ ' : '⚠ '}
+          {item.verdict.reason}
+        </p>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => decide(true)}
+          className="rounded-md bg-stone-800 px-3 py-1.5 text-xs font-medium text-white hover:bg-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-500"
+        >
+          Rename this
+        </button>
+        <button
+          type="button"
+          onClick={() => decide(false)}
+          className="rounded-md px-3 py-1.5 text-xs text-stone-600 hover:bg-stone-100 focus:outline-none focus:ring-2 focus:ring-stone-400"
+        >
+          Leave it
+        </button>
+        <button
+          type="button"
+          onClick={close}
+          className="ml-auto rounded-md px-2 py-1.5 text-xs text-stone-500 hover:bg-stone-100 hover:text-stone-700 focus:outline-none focus:ring-2 focus:ring-stone-400"
+        >
+          Stop
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/ai/__tests__/judgeRenameOccurrences.test.ts
+++ b/src/lib/ai/__tests__/judgeRenameOccurrences.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { judgeRenameOccurrences } from '../judgeRenameOccurrences'
+import type { LLMConfig } from '@/stores/settingsStore'
+import type { StructuredRequest } from '@/lib/ai/structuredClient'
+
+// Whole-word matching finds every "Cody". It cannot tell the Cody who owns the
+// runbook from the Cody Framework, and no amount of string matching will.
+// Coreference resolution runs at roughly F1 78-81% on curated benchmarks and
+// worse on real prose, so the asymmetry is deliberate everywhere here: an
+// unclear mention comes back as "needs a human", never as "rename it anyway".
+
+const config = { provider: 'claude', model: 'm', apiKey: 'k' } as unknown as LLMConfig
+
+function verdicts(calls: Array<{ index: number; same_referent: boolean; reason?: string }>) {
+  return vi.fn(async (_req: StructuredRequest, _config: LLMConfig) => ({
+    toolCalls: calls.map((input) => ({ name: 'verdict', input })),
+  }))
+}
+
+const occurrences = [
+  { sentence: 'Cody owns the runbook.' },
+  { sentence: 'The Cody Framework ships with its own linter.' },
+]
+
+describe('judgeRenameOccurrences', () => {
+  it('separates the same referent from a different thing with the same name', async () => {
+    const call = verdicts([
+      { index: 1, same_referent: true, reason: 'the person who owns the runbook' },
+      { index: 2, same_referent: false, reason: 'a product name, not the person' },
+    ])
+    const result = await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+
+    expect(result.get(0)).toMatchObject({ sameReferent: true })
+    expect(result.get(1)).toMatchObject({ sameReferent: false })
+  })
+
+  it('returns a verdict for every index, defaulting a skipped one to needs-a-human', async () => {
+    const call = verdicts([{ index: 1, same_referent: true, reason: 'clear' }])
+    const result = await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+
+    expect(result.size).toBe(2)
+    expect(result.get(1)?.sameReferent).toBe(false)
+    expect(result.get(1)?.reason).toContain('needs a human')
+  })
+
+  it('ignores out-of-range and duplicate indices rather than mis-assigning them', async () => {
+    const call = verdicts([
+      { index: 99, same_referent: true, reason: 'nonsense index' },
+      { index: 1, same_referent: true, reason: 'first' },
+      { index: 1, same_referent: false, reason: 'contradicts itself' },
+    ])
+    const result = await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+
+    // First verdict for an index wins; the contradicting duplicate is dropped.
+    expect(result.get(0)).toMatchObject({ sameReferent: true, reason: 'first' })
+    expect(result.get(1)?.sameReferent).toBe(false)
+  })
+
+  it('treats a non-boolean same_referent as not confident', async () => {
+    const call = vi.fn(async (_req: StructuredRequest, _config: LLMConfig) => ({
+      toolCalls: [{ name: 'verdict', input: { index: 1, same_referent: 'yes', reason: 'sloppy' } }],
+    }))
+    const result = await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+    expect(result.get(0)?.sameReferent).toBe(false)
+  })
+
+  it('throws when a transport-successful call yields no usable verdict', async () => {
+    // The prompt gives the model no legitimate silent path, so silence is a
+    // protocol malfunction. The caller keeps every candidate unjudged rather
+    // than letting an empty answer read as a decision.
+    const call = vi.fn(async (_req: StructuredRequest, _config: LLMConfig) => ({
+      toolCalls: [{ name: 'chatter', input: {} }],
+    }))
+    await expect(
+      judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call),
+    ).rejects.toThrow(/no usable verdicts/)
+  })
+
+  it('makes no call at all for an empty candidate list', async () => {
+    const call = vi.fn(async (_req: StructuredRequest, _config: LLMConfig) => ({
+      toolCalls: [] as Array<{ name: string; input: unknown }>,
+    }))
+    const result = await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, [], config, call)
+    expect(result.size).toBe(0)
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('puts both names and every numbered sentence in front of the model', async () => {
+    const call = verdicts([{ index: 1, same_referent: true }, { index: 2, same_referent: false }])
+    await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+
+    const prompt = call.mock.calls[0][0].messages[1].content as string
+    expect(prompt).toContain('"Cody"')
+    expect(prompt).toContain('"Joe"')
+    expect(prompt).toContain('[1] "Cody owns the runbook."')
+    expect(prompt).toContain('[2] "The Cody Framework')
+  })
+
+  it('routes to the cheap utility model — verdict checking is utility work', async () => {
+    const call = verdicts([{ index: 1, same_referent: true }, { index: 2, same_referent: false }])
+    await judgeRenameOccurrences({ from: 'Cody', to: 'Joe' }, occurrences, config, call)
+    expect(call.mock.calls[0][1]).toMatchObject({ provider: 'claude' })
+  })
+})

--- a/src/lib/ai/judgeRenameOccurrences.ts
+++ b/src/lib/ai/judgeRenameOccurrences.ts
@@ -1,0 +1,157 @@
+import type { LLMConfig } from '@/stores/settingsStore'
+import { fetchStructured, type CallStructuredFn } from '@/lib/ai/structuredClient'
+import { pickUtilityModel } from '@/lib/ai/modelCapabilities'
+
+/**
+ * LLM second opinion on which remaining mentions of a renamed name are the
+ * same referent.
+ *
+ * `renameDetect.ts` is deterministic and local: whole-word matching, minus the
+ * cases that are categorically not narrative reference (quotations, email
+ * addresses, URLs). That is a good first pass and a bad last one — the string
+ * "Cody" can be a different Cody, a product, a place, or a codename, and no
+ * amount of string matching separates those.
+ *
+ * This is the judgement pass, and it runs ONLY after the reader clicks Check.
+ * Nothing here applies an edit; it labels candidates so a human reviews the
+ * ambiguous ones with their sentence in front of them.
+ *
+ * Mirrors judgeRelatedPassages deliberately — same verdict-tool shape, same
+ * skeptical default, same trust boundary. A missing verdict means "ask the
+ * human", never "rename it anyway": the asymmetry matters because a wrong
+ * silent rewrite costs far more trust than one extra confirmation click.
+ */
+
+export interface RenameVerdict {
+  /** True only when this mention is confidently the same thing being renamed. */
+  sameReferent: boolean
+  reason: string
+}
+
+export interface RenameOccurrenceInput {
+  /** The sentence the mention sits in — the context a judgement needs. */
+  sentence: string
+}
+
+export type JudgeRenameFn = (
+  rename: { from: string; to: string },
+  occurrences: RenameOccurrenceInput[],
+  config: LLMConfig,
+) => Promise<Map<number, RenameVerdict>>
+
+const VERDICT_TOOL = {
+  name: 'verdict',
+  description:
+    'Deliver your verdict for ONE listed mention. Call this tool exactly once per mention, using the [n] index shown in brackets.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      index: {
+        type: 'number',
+        description: 'The [n] index of the mention this verdict is for.',
+      },
+      same_referent: {
+        type: 'boolean',
+        description:
+          'true only when this mention clearly refers to the same thing the reader just renamed.',
+      },
+      reason: {
+        type: 'string',
+        description: 'One short sentence justifying the verdict.',
+      },
+    },
+    required: ['index', 'same_referent', 'reason'],
+  },
+}
+
+const JUDGE_SYSTEM = [
+  'A reader renamed something in a document. You decide which remaining mentions of the OLD name refer to the same thing and should follow, and which are a different thing that must be left alone.',
+  'Be skeptical. The same string very often names different things in one document: a different person with the same name, a product or codename, a place, a team, a file or variable name, or a word being discussed rather than used.',
+  'Say same_referent only when the sentence makes it clear. When the sentence is ambiguous, answer false — a human will look at it, which is cheap, whereas a wrong rewrite of the wrong thing is expensive.',
+  'For each numbered mention, call verdict exactly once with its index.',
+].join(' ')
+
+/** Ask the human. Never "rename it anyway". */
+const NO_VERDICT: RenameVerdict = {
+  sameReferent: false,
+  reason: 'no verdict returned — needs a human',
+}
+
+interface VerdictInput {
+  index?: unknown
+  same_referent?: unknown
+  reason?: unknown
+}
+
+const SENTENCE_MAX_CHARS = 300
+
+function truncateForPrompt(text: string): string {
+  return text.length <= SENTENCE_MAX_CHARS ? text : `${text.slice(0, SENTENCE_MAX_CHARS - 1)}…`
+}
+
+/**
+ * One batched structured call over every candidate mention. Returns a verdict
+ * for EVERY index: anything the model skipped, duplicated away or garbled comes
+ * back as "needs a human".
+ *
+ * Throws when the structured call fails, or when a transport-successful call
+ * produces zero valid verdicts — a protocol malfunction, since the prompt
+ * allows no silent path. The caller treats both as "show every candidate
+ * unjudged" rather than silently deciding for the reader.
+ */
+export async function judgeRenameOccurrences(
+  rename: { from: string; to: string },
+  occurrences: RenameOccurrenceInput[],
+  config: LLMConfig,
+  call: CallStructuredFn = fetchStructured,
+): Promise<Map<number, RenameVerdict>> {
+  const verdicts = new Map<number, RenameVerdict>()
+  if (occurrences.length === 0) return verdicts
+
+  const userPrompt = [
+    `RENAME: the reader changed "${rename.from}" to "${rename.to}".`,
+    '',
+    `MENTIONS of "${rename.from}" still in the document (decide which refer to the same thing):`,
+    ...occurrences.map((o, i) => `[${i + 1}] "${truncateForPrompt(o.sentence)}"`),
+  ].join('\n')
+
+  const { toolCalls } = await call(
+    {
+      messages: [
+        { role: 'system', content: JUDGE_SYSTEM },
+        { role: 'user', content: userPrompt },
+      ],
+      tools: [VERDICT_TOOL],
+      // Each verdict block costs roughly 60-120 output tokens; a flat cap
+      // truncates the tail of a large batch into silent "needs a human".
+      maxTokens: Math.min(8000, 400 + 200 * occurrences.length),
+      temperature: 0,
+    },
+    // Verdict checking is utility work — route it to the cheap model.
+    { ...config, model: pickUtilityModel(config) },
+  )
+
+  let valid = 0
+  for (const tc of toolCalls) {
+    if (tc.name !== 'verdict') continue
+    const input = tc.input as VerdictInput
+    const n = typeof input?.index === 'number' ? Math.trunc(input.index) : NaN
+    const zeroBased = n - 1
+    if (!Number.isFinite(zeroBased) || zeroBased < 0 || zeroBased >= occurrences.length) continue
+    if (verdicts.has(zeroBased)) continue
+    verdicts.set(zeroBased, {
+      sameReferent: input.same_referent === true,
+      reason: typeof input.reason === 'string' && input.reason.trim() ? input.reason.trim() : '—',
+    })
+    valid++
+  }
+
+  if (valid === 0) {
+    throw new Error('rename judge returned no usable verdicts')
+  }
+
+  for (let i = 0; i < occurrences.length; i++) {
+    if (!verdicts.has(i)) verdicts.set(i, NO_VERDICT)
+  }
+  return verdicts
+}

--- a/src/lib/annotations/__tests__/directEditTrigger.test.ts
+++ b/src/lib/annotations/__tests__/directEditTrigger.test.ts
@@ -9,6 +9,7 @@ import { AI_APPLY_META } from '@/lib/prosemirror/applyProposedEdits'
 import { invalidateDocGraphCache } from '@/lib/graphrag/docGraph'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useDirectEditOfferStore } from '@/stores/directEditOfferStore'
+import { useSettingsStore } from '@/stores/settingsStore'
 import {
   acceptSettledOffer,
   observeTransaction,
@@ -62,6 +63,8 @@ beforeEach(() => {
   fetchSpy.mockClear()
   useDocumentStore.setState({ activeDocumentId: 'doc-A' })
   useDirectEditOfferStore.getState().clearOffer()
+  useDirectEditOfferStore.getState().clearRenameOffer()
+  useSettingsStore.getState().setConsistencyCheckMode('commit')
 })
 
 afterEach(() => {
@@ -75,7 +78,7 @@ describe('settleDirectEdits — offer path', () => {
 
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
 
-    const offer = await settleDirectEdits(state)
+    const offer = (await settleDirectEdits(state)).dependentOffer
     expect(offer).not.toBeNull()
     const o = offer as DirectEditOffer
     expect(o.blockId).toBe('b1')
@@ -95,15 +98,15 @@ describe('settleDirectEdits — offer path', () => {
     resetDirectEditBaseline(state.doc)
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
 
-    expect(await settleDirectEdits(state)).not.toBeNull()
-    expect(await settleDirectEdits(state)).toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).not.toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).toBeNull()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
   it('returns null with no pending touches (and just refreshes the baseline)', async () => {
     const state = stateOf(fixtureDoc())
     resetDirectEditBaseline(state.doc)
-    expect(await settleDirectEdits(state)).toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).toBeNull()
   })
 })
 
@@ -127,7 +130,7 @@ describe('settleDirectEdits — skip contract (changeTrackingPlugin parity + AI 
       const next = state.apply(tr)
       observeTransaction(tr, next.doc)
 
-      expect(await settleDirectEdits(next)).toBeNull()
+      expect((await settleDirectEdits(next)).dependentOffer).toBeNull()
       expect(fetchSpy).not.toHaveBeenCalled()
     })
   }
@@ -145,7 +148,7 @@ describe('settleDirectEdits — skip contract (changeTrackingPlugin parity + AI 
     const next = state.apply(tr)
     observeTransaction(tr, next.doc)
 
-    expect(await settleDirectEdits(next)).toBeNull()
+    expect((await settleDirectEdits(next)).dependentOffer).toBeNull()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
@@ -167,7 +170,7 @@ describe('settleDirectEdits — skip contract (changeTrackingPlugin parity + AI 
 
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
 
-    const offer = await settleDirectEdits(state)
+    const offer = (await settleDirectEdits(state)).dependentOffer
     expect(offer?.blockId).toBe('b1')
     expect(fetchSpy).not.toHaveBeenCalled()
   })
@@ -180,7 +183,7 @@ describe('settleDirectEdits — graph gating and reset', () => {
 
     state = humanEdit(state, 'iso', 'alternating Tuesdays', 'even-numbered Fridays')
 
-    expect(await settleDirectEdits(state)).toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).toBeNull()
     expect(fetchSpy).not.toHaveBeenCalled()
   })
 
@@ -191,7 +194,7 @@ describe('settleDirectEdits — graph gating and reset', () => {
     state = humanEdit(state, 'b2', 'ten', 'six')
     state = humanEdit(state, 'b1', '$50,000 allocated', '$75,000 provisionally earmarked')
 
-    const offer = await settleDirectEdits(state)
+    const offer = (await settleDirectEdits(state)).dependentOffer
     expect(offer?.blockId).toBe('b1')
   })
 
@@ -202,7 +205,7 @@ describe('settleDirectEdits — graph gating and reset', () => {
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
     resetDirectEditBaseline(state.doc)
 
-    expect(await settleDirectEdits(state)).toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).toBeNull()
   })
 
   it('a touched block whose text is unchanged by settle time (edit typed then reverted) is not offered', async () => {
@@ -212,7 +215,7 @@ describe('settleDirectEdits — graph gating and reset', () => {
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
     state = humanEdit(state, 'b1', '$75,000', '$50,000') // hand-reverted
 
-    expect(await settleDirectEdits(state)).toBeNull()
+    expect((await settleDirectEdits(state)).dependentOffer).toBeNull()
   })
 })
 
@@ -221,14 +224,14 @@ describe('acceptSettledOffer — doc-switch race + stale-offer invalidation', ()
     let state = stateOf(fixtureDoc())
     resetDirectEditBaseline(state.doc)
     state = humanEdit(state, 'b1', '$50,000', '$75,000')
-    const offer = await settleDirectEdits(state)
+    const offer = (await settleDirectEdits(state)).dependentOffer
     expect(offer).not.toBeNull()
     return offer as DirectEditOffer
   }
 
   it('surfaces an offer stamped for the still-active document', async () => {
     const offer = await settledOffer()
-    acceptSettledOffer(offer)
+    acceptSettledOffer({ dependentOffer: offer, renameOffer: null })
     expect(useDirectEditOfferStore.getState().offer).toBe(offer)
   })
 
@@ -236,17 +239,151 @@ describe('acceptSettledOffer — doc-switch race + stale-offer invalidation', ()
     const offer = await settledOffer() // stamped doc-A
     // The user switches documents before the async settle result lands.
     useDocumentStore.setState({ activeDocumentId: 'doc-B' })
-    acceptSettledOffer(offer)
+    acceptSettledOffer({ dependentOffer: offer, renameOffer: null })
     expect(useDirectEditOfferStore.getState().offer).toBeNull()
   })
 
   it('a null settle clears a previously surfaced offer instead of leaving it up (stale-offer invalidation)', async () => {
     const offer = await settledOffer()
-    acceptSettledOffer(offer)
+    acceptSettledOffer({ dependentOffer: offer, renameOffer: null })
     expect(useDirectEditOfferStore.getState().offer).not.toBeNull()
 
     // Next settle window produces nothing — the old chip must come down.
-    acceptSettledOffer(null)
+    acceptSettledOffer({ dependentOffer: null, renameOffer: null })
     expect(useDirectEditOfferStore.getState().offer).toBeNull()
+  })
+})
+
+
+describe('settleDirectEdits — the rename arm', () => {
+  // A bare name mention creates no cross-reference, no defined term and no
+  // duplicated sentence, so it produces no graph edge at all. That is why
+  // changing "Cody" to "Joe" used to raise nothing: the only arm that existed
+  // required graph dependents.
+
+  function renameDoc(): PMNode {
+    return docOf(
+      p('r1', 'Cody owns the runbook.'),
+      p('r2', 'Ask Cody about IAM before shipping.'),
+      p('r3', 'The reviewer wrote "Cody signed this off" in the margin.'),
+      p('big', 'Office plants are watered on alternating Tuesdays.'),
+    )
+  }
+
+  it('offers a rename that the graph could never have seen', () => {
+    let state = stateOf(renameDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'r1', 'Cody', 'Joe')
+
+    return settleDirectEdits(state).then((result) => {
+      expect(result.renameOffer).toMatchObject({ from: 'Cody', to: 'Joe' })
+      // r2 only. r3's mention sits inside a quotation and is never offered.
+      expect(result.renameOffer?.occurrenceCount).toBe(1)
+      expect(result.renameOffer?.targets.map((t) => t.blockId)).toEqual(['r2'])
+    })
+  })
+
+  it('finds a rename in a block that did NOT win the biggest-delta race', async () => {
+    // The regression. settleDirectEdits picks a single winner by edit size for
+    // the dependent arm; a rename arm bolted onto that selection would be
+    // masked by any larger unrelated edit in the same settle window — and a
+    // window containing more than one edit is the normal case.
+    let state = stateOf(renameDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'r1', 'Cody', 'Joe')
+    state = humanEdit(
+      state,
+      'big',
+      'Office plants are watered on alternating Tuesdays.',
+      'Office plants are watered on alternating Tuesdays, except during the winter shutdown when the facilities team handles them instead.',
+    )
+
+    const result = await settleDirectEdits(state)
+    expect(result.renameOffer).toMatchObject({ from: 'Cody', to: 'Joe' })
+  })
+
+  it('treats the same rename made twice before the settle as one rename', async () => {
+    // The other regression: a character-level prefix/suffix diff would span
+    // both edits plus everything between them and reject this as a rewrite —
+    // exactly when the reader has already shown they expect propagation.
+    let state = stateOf(
+      docOf(
+        p('m1', 'Cody owns the runbook. Ask Cody before changing it.'),
+        p('m2', 'Escalate to Cody when the pipeline stalls.'),
+      ),
+    )
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(
+      state,
+      'm1',
+      'Cody owns the runbook. Ask Cody before changing it.',
+      'Joe owns the runbook. Ask Joe before changing it.',
+    )
+
+    const result = await settleDirectEdits(state)
+    expect(result.renameOffer).toMatchObject({ from: 'Cody', to: 'Joe', occurrenceCount: 1 })
+  })
+
+  it('stays quiet on ordinary rewriting', async () => {
+    let state = stateOf(renameDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'r2', 'before shipping', 'before the release goes out')
+
+    const result = await settleDirectEdits(state)
+    expect(result.renameOffer).toBeNull()
+  })
+
+  it('stays quiet when the renamed name appears nowhere else', async () => {
+    let state = stateOf(docOf(p('s1', 'Cody owns the runbook.'), p('s2', 'Unrelated text.')))
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 's1', 'Cody', 'Joe')
+
+    const result = await settleDirectEdits(state)
+    expect(result.renameOffer).toBeNull()
+  })
+
+  it('makes no network call before the reader consents', async () => {
+    // The module's existing data-egress guarantee must survive the new arm.
+    let state = stateOf(renameDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'r1', 'Cody', 'Joe')
+
+    await settleDirectEdits(state)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the rename offer through acceptSettledOffer, and drops it after a doc switch', async () => {
+    let state = stateOf(renameDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'r1', 'Cody', 'Joe')
+    const result = await settleDirectEdits(state)
+
+    acceptSettledOffer(result)
+    expect(useDirectEditOfferStore.getState().renameOffer).toMatchObject({ from: 'Cody' })
+
+    useDocumentStore.setState({ activeDocumentId: 'doc-B' })
+    acceptSettledOffer(result)
+    expect(useDirectEditOfferStore.getState().renameOffer).toBeNull()
+  })
+})
+
+describe('settleDirectEdits — consistencyCheckMode gate', () => {
+  it('produces nothing at all when background checking is off', async () => {
+    useSettingsStore.getState().setConsistencyCheckMode('off')
+    let state = stateOf(fixtureDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'b1', '$50,000', '$75,000')
+
+    const result = await settleDirectEdits(state)
+    expect(result).toEqual({ dependentOffer: null, renameOffer: null })
+  })
+
+  it('produces nothing on demand-only, where checks are explicit', async () => {
+    useSettingsStore.getState().setConsistencyCheckMode('demand')
+    let state = stateOf(fixtureDoc())
+    resetDirectEditBaseline(state.doc)
+    state = humanEdit(state, 'b1', '$50,000', '$75,000')
+
+    expect(await settleDirectEdits(state)).toEqual({ dependentOffer: null, renameOffer: null })
   })
 })

--- a/src/lib/annotations/__tests__/renameDetect.test.ts
+++ b/src/lib/annotations/__tests__/renameDetect.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  detectRename,
+  findOccurrences,
+  looksLikeProperNoun,
+  offerableOccurrences,
+  sentenceAround,
+  tokenize,
+} from '../renameDetect'
+
+// The reported case: the reader changes "Cody" to "Joe" in one place and
+// nothing asks whether the other Codys should follow. The hard part is not
+// finding the other Codys — it is firing ONLY on a rename, since ordinary
+// rewriting is the overwhelming majority of edits and a false-positive
+// avalanche would get this switched off in a week.
+
+describe('detectRename', () => {
+  it('fires on a single name swapped for another', () => {
+    expect(detectRename('Ask Cody about IAM.', 'Ask Joe about IAM.')).toEqual({
+      from: 'Cody',
+      to: 'Joe',
+      replaced: 1,
+    })
+  })
+
+  it('treats the same swap made twice in one block as ONE rename', () => {
+    // This is the case a prefix/suffix character diff gets wrong: the differing
+    // region would span both edits plus everything between them, and the edit
+    // would be rejected as a rewrite — precisely when the reader has already
+    // shown they expect the change to propagate.
+    const before = 'Cody owns the runbook. Ask Cody before changing it.'
+    const after = 'Joe owns the runbook. Ask Joe before changing it.'
+    expect(detectRename(before, after)).toEqual({ from: 'Cody', to: 'Joe', replaced: 2 })
+  })
+
+  it('does not fire on ordinary rewriting', () => {
+    expect(detectRename('The retention period is 30 days.', 'The retention period is 90 days.')).toBeNull()
+    expect(detectRename('This is clear.', 'This is not clear.')).toBeNull()
+    expect(
+      detectRename('We store the token securely.', 'We store the token in an HSM.'),
+    ).toBeNull()
+  })
+
+  it('does not fire when two different substitutions happened', () => {
+    // Two distinct swaps is a rewrite, whatever the tokens look like.
+    expect(detectRename('Cody met Dana.', 'Joe met Sam.')).toBeNull()
+  })
+
+  it('does not fire on a lowercase word swap', () => {
+    expect(detectRename('the server is warm', 'the server is cold')).toBeNull()
+  })
+
+  it('does not fire when the token count changes', () => {
+    expect(detectRename('Ask Cody.', 'Ask Joe Smith.')).toBeNull()
+    expect(detectRename('Ask Cody.', 'Ask.')).toBeNull()
+  })
+
+  it('does not fire on an unchanged block', () => {
+    expect(detectRename('Ask Cody.', 'Ask Cody.')).toBeNull()
+  })
+
+  it('ignores a pure case change, which is not a rename', () => {
+    expect(detectRename('Ask CODY today.', 'Ask Cody today.')).toBeNull()
+  })
+
+  it('keeps hyphenated and apostrophised names whole', () => {
+    expect(detectRename("Ask O'Neill first.", 'Ask Okafor first.')).toMatchObject({
+      from: "O'Neill",
+      to: 'Okafor',
+    })
+    expect(detectRename('Ask Anne-Marie first.', 'Ask Joe first.')).toMatchObject({
+      from: 'Anne-Marie',
+    })
+  })
+})
+
+describe('looksLikeProperNoun', () => {
+  it('accepts names and rejects ordinary words', () => {
+    expect(looksLikeProperNoun('Cody')).toBe(true)
+    expect(looksLikeProperNoun('cody')).toBe(false)
+    expect(looksLikeProperNoun('X')).toBe(false)
+  })
+
+  it('rejects words that merely start a sentence', () => {
+    // A capital at the head of a sentence tells you nothing.
+    expect(looksLikeProperNoun('The')).toBe(false)
+    expect(looksLikeProperNoun('This')).toBe(false)
+    expect(looksLikeProperNoun('When')).toBe(false)
+  })
+
+  it('rejects a shouted heading word but keeps a short acronym', () => {
+    expect(looksLikeProperNoun('IMPLEMENTATION')).toBe(false)
+    expect(looksLikeProperNoun('AWS')).toBe(true)
+  })
+})
+
+describe('findOccurrences', () => {
+  const text = [
+    'Cody owns the runbook.',
+    'Reach him at cody@example.com or see https://cody.example.com/docs.',
+    'The reviewer wrote "Cody signed this off" in the margin.',
+    'Ask Cody about IAM.',
+    'Codyville is a town and must not match.',
+  ].join(' ')
+
+  it('finds whole-word occurrences only', () => {
+    const found = findOccurrences(text, 'Cody')
+    expect(found.every((o) => !text.slice(o.index).startsWith('Codyville'))).toBe(true)
+  })
+
+  it('excludes a name inside a quotation as reported speech', () => {
+    const quoted = findOccurrences(text, 'Cody').filter((o) => o.excluded === 'quoted')
+    expect(quoted).toHaveLength(1)
+    expect(quoted[0].sentence).toContain('in the margin')
+  })
+
+  it('excludes a name inside an email address or a URL', () => {
+    const identifiers = findOccurrences(text, 'cody').filter((o) => o.excluded)
+    expect(identifiers.length).toBeGreaterThan(0)
+  })
+
+  it('offers only the real narrative references', () => {
+    const offerable = offerableOccurrences(text, 'Cody')
+    expect(offerable).toHaveLength(2)
+    expect(offerable[0].sentence).toContain('owns the runbook')
+    expect(offerable[1].sentence).toContain('about IAM')
+  })
+
+  it('carries the surrounding sentence, which is what makes a judgement possible', () => {
+    // A bare list of positions cannot be reviewed; a sentence can be judged in
+    // about two seconds, which is what makes a per-occurrence flow tolerable.
+    for (const o of offerableOccurrences(text, 'Cody')) {
+      expect(o.sentence.length).toBeGreaterThan(5)
+    }
+  })
+
+  it('returns nothing for an empty name', () => {
+    expect(findOccurrences(text, '')).toEqual([])
+  })
+})
+
+describe('sentenceAround', () => {
+  it('trims to the sentence containing the index', () => {
+    const text = 'One thing. Cody owns it. Another thing.'
+    expect(sentenceAround(text, text.indexOf('Cody'))).toBe('Cody owns it.')
+  })
+
+  it('handles the first and last sentence', () => {
+    const text = 'Cody starts here. Then more.'
+    expect(sentenceAround(text, 0)).toBe('Cody starts here.')
+    const tail = 'Something. Ends with Cody'
+    expect(sentenceAround(tail, tail.indexOf('Cody'))).toBe('Ends with Cody')
+  })
+})
+
+describe('tokenize', () => {
+  it('alternates word and non-word runs so a swap stays aligned', () => {
+    expect(tokenize('Ask Cody.')).toEqual(['Ask', ' ', 'Cody', '.'])
+  })
+})

--- a/src/lib/annotations/directEditTrigger.ts
+++ b/src/lib/annotations/directEditTrigger.ts
@@ -8,6 +8,7 @@ import { getDocGraph, getNeighborhood } from '@/lib/graphrag/docGraph'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useDocumentStore } from '@/stores/documentStore'
 import { useDirectEditOfferStore } from '@/stores/directEditOfferStore'
+import { detectRename, offerableOccurrences, type Occurrence } from './renameDetect'
 
 /**
  * Direct-edit cascade trigger (Flow v1 P4, issue #17).
@@ -123,36 +124,123 @@ function textDelta(before: string, after: string): number {
 }
 
 /**
+ * A rename the reader made, and everywhere the old name still stands.
+ *
+ * Separate from DirectEditOffer because it is found a different way: the
+ * dependent-section offer needs the doc graph, while a rename is visible in the
+ * text alone. A bare name mention creates no cross-reference, no defined term
+ * and no duplicated sentence, so it produces NO graph edge — which is exactly
+ * why changing "Cody" to "Joe" used to raise nothing at all.
+ */
+export interface RenameTarget {
+  blockId: string
+  occurrences: Occurrence[]
+}
+
+export interface RenameOffer {
+  documentId: string
+  /** The block the reader actually edited. */
+  blockId: string
+  from: string
+  to: string
+  /** Blocks elsewhere that still carry the old name, with their sentences. */
+  targets: RenameTarget[]
+  occurrenceCount: number
+}
+
+export interface SettleResult {
+  dependentOffer: DirectEditOffer | null
+  renameOffer: RenameOffer | null
+}
+
+const EMPTY_SETTLE: SettleResult = { dependentOffer: null, renameOffer: null }
+
+/**
+ * Scan EVERY touched block for a rename.
+ *
+ * Deliberately not folded into the biggest-delta selection below. That
+ * selection picks one winner across all touched blocks, so a large unrelated
+ * rewrite in one block would mask a small rename in another — and a settle
+ * window containing more than one edit is the normal case, not an edge case.
+ *
+ * Pure and synchronous: text in, offer out. No graph, no network.
+ */
+function scanForRename(
+  documentId: string,
+  touched: Set<string>,
+  prior: Map<string, string>,
+  current: Map<string, string>,
+): RenameOffer | null {
+  for (const blockId of touched) {
+    const beforeText = prior.get(blockId)
+    const text = current.get(blockId)
+    if (beforeText === undefined || text === undefined || beforeText === text) continue
+
+    const candidate = detectRename(beforeText, text)
+    if (!candidate) continue
+
+    const targets: RenameTarget[] = []
+    let occurrenceCount = 0
+    for (const [otherId, otherText] of current) {
+      if (otherId === blockId) continue
+      const occurrences = offerableOccurrences(otherText, candidate.from)
+      if (occurrences.length === 0) continue
+      targets.push({ blockId: otherId, occurrences })
+      occurrenceCount += occurrences.length
+    }
+    // The reader renamed the only mention there was. Nothing to offer.
+    if (occurrenceCount === 0) continue
+
+    // One offer at a time — the chip says one thing, and two competing renames
+    // in a single settle window is not a case worth a queue.
+    return { documentId, blockId, from: candidate.from, to: candidate.to, targets, occurrenceCount }
+  }
+  return null
+}
+
+/**
  * Settle point (autosave flush): diff touched blocks against the baseline and
- * offer the biggest changed block IF it has deterministic-graph dependents.
+ * produce up to two independent offers —
+ *
+ *   - a RENAME offer, from any touched block whose edit was a name swap;
+ *   - a DEPENDENT-SECTION offer, from the single biggest changed block, when
+ *     the deterministic graph says it has dependents.
+ *
  * Always refreshes the baseline and clears the touch set — each settle window
  * is independent. Deterministic graph only; zero network by construction.
  */
-export async function settleDirectEdits(state: EditorState): Promise<DirectEditOffer | null> {
+export async function settleDirectEdits(state: EditorState): Promise<SettleResult> {
   const doc = state.doc
   const touched = humanTouchedBlockIds
   const prior = baseline
   // Stamp the settle-time document — the graph await below can race a doc
-  // switch, and the offer must carry the document it was computed against.
+  // switch, and an offer must carry the document it was computed against.
   const documentId = useDocumentStore.getState().activeDocumentId ?? 'unknown'
 
   // Every settle starts the next window fresh, whatever we return.
-  baseline = snapshot(doc)
+  const current = snapshot(doc)
+  baseline = current
   humanTouchedBlockIds = new Set()
 
   // No baseline yet (fresh module) or nothing human-touched → nothing to offer.
-  if (!prior || touched.size === 0) return null
+  if (!prior || touched.size === 0) return EMPTY_SETTLE
+
+  // The reader can switch background checking off entirely. Checked here rather
+  // than at the call site so no arm can be added later that forgets to ask.
+  if (useSettingsStore.getState().consistencyCheckMode !== 'commit') return EMPTY_SETTLE
+
+  const renameOffer = scanForRename(documentId, touched, prior, current)
 
   let best: { blockId: string; beforeText: string; text: string; delta: number } | null = null
   for (const blockId of touched) {
     const beforeText = prior.get(blockId)
-    const text = baseline.get(blockId)
+    const text = current.get(blockId)
     // Block is new since baseline, vanished, or unchanged → not offerable.
     if (beforeText === undefined || text === undefined || beforeText === text) continue
     const delta = textDelta(beforeText, text)
     if (!best || delta > best.delta) best = { blockId, beforeText, text, delta }
   }
-  if (!best) return null
+  if (!best) return { dependentOffer: null, renameOffer }
 
   // Deterministic graph only — matches what scheduleDocGraphRebuild primes,
   // so this is usually a warm cache hit and NEVER a network call.
@@ -163,34 +251,46 @@ export async function settleDirectEdits(state: EditorState): Promise<DirectEditO
     skipGraphiti: true,
   })
   const dependentCount = getNeighborhood(graph, best.blockId, 2).size - 1
-  if (dependentCount <= 0) return null
+  if (dependentCount <= 0) return { dependentOffer: null, renameOffer }
 
   const live = findBlockById(doc, best.blockId)
-  if (!live || !live.node.isTextblock) return null
+  if (!live || !live.node.isTextblock) return { dependentOffer: null, renameOffer }
 
   return {
-    documentId,
-    blockId: best.blockId,
-    blockText: best.text,
-    beforeText: best.beforeText,
-    from: live.pos + 1,
-    to: live.pos + 1 + live.node.content.size,
-    dependentCount,
+    dependentOffer: {
+      documentId,
+      blockId: best.blockId,
+      blockText: best.text,
+      beforeText: best.beforeText,
+      from: live.pos + 1,
+      to: live.pos + 1 + live.node.content.size,
+      dependentCount,
+    },
+    renameOffer,
   }
 }
 
 /**
- * Resolution-time sink for a settled offer (EditorShell's autosave callback).
- * ALWAYS writes the store from the settle result: a real offer for the still-
+ * Resolution-time sink for a settled result (EditorShell's autosave callback).
+ * ALWAYS writes the stores from the settle result: a real offer for the still-
  * active document is surfaced; a null settle or an offer stamped for another
  * document (settle resolved after a doc switch) CLEARS any offer instead of
  * leaving a stale chip up.
  */
-export function acceptSettledOffer(offer: DirectEditOffer | null): void {
+export function acceptSettledOffer(result: SettleResult): void {
   const store = useDirectEditOfferStore.getState()
-  if (offer && offer.documentId === useDocumentStore.getState().activeDocumentId) {
-    store.setOffer(offer)
+  const activeId = useDocumentStore.getState().activeDocumentId
+
+  const { dependentOffer, renameOffer } = result
+  if (dependentOffer && dependentOffer.documentId === activeId) {
+    store.setOffer(dependentOffer)
   } else {
     store.clearOffer()
+  }
+
+  if (renameOffer && renameOffer.documentId === activeId) {
+    store.setRenameOffer(renameOffer)
+  } else {
+    store.clearRenameOffer()
   }
 }

--- a/src/lib/annotations/renameDetect.ts
+++ b/src/lib/annotations/renameDetect.ts
@@ -1,0 +1,202 @@
+/**
+ * Detecting that an edit was a RENAME, not a rewrite — and finding where else
+ * the old name still stands.
+ *
+ * Why this is narrow on purpose. An IDE can rename a symbol everywhere because
+ * a compiler already resolved the references; the occurrence list is a closed,
+ * verifiably correct set. Prose has no such oracle. Coreference resolution runs
+ * at roughly F1 78-81% on curated benchmarks and worse on real documents, and
+ * its failure cases are exactly the ones that matter here: the same string
+ * referring to different people, metonymy, quoted speech, product names that
+ * happen to match. So nothing here auto-applies, and the detector fires only on
+ * a shape that ordinary rewriting cannot produce.
+ *
+ * Everything in this module is pure and synchronous. No network — the trigger
+ * that calls it guarantees zero egress before the reader consents.
+ */
+
+/**
+ * Split into alternating word / non-word runs, so two texts that differ by a
+ * word-for-word swap stay positionally aligned. Keeping hyphens and apostrophes
+ * inside a token means "Anne-Marie" and "O'Neill" survive as single names.
+ */
+const TOKEN_PATTERN = /[\p{L}\p{N}_'’-]+|[^\p{L}\p{N}_'’-]+/gu
+
+export function tokenize(text: string): string[] {
+  return text.match(TOKEN_PATTERN) ?? []
+}
+
+const WORD_ONLY = /^[\p{L}\p{N}_'’-]+$/u
+
+/**
+ * Words that begin a sentence often enough that a capital tells you nothing.
+ * Deliberately short: this is a cheap guard against the most common false
+ * positives, not a part-of-speech tagger.
+ */
+const COMMON_CAPITALISED = new Set([
+  'the', 'a', 'an', 'this', 'that', 'these', 'those', 'it', 'we', 'i', 'you',
+  'they', 'he', 'she', 'there', 'here', 'if', 'when', 'while', 'and', 'but',
+  'or', 'so', 'for', 'to', 'in', 'on', 'at', 'by', 'as', 'is', 'are', 'was',
+  'were', 'do', 'does', 'did', 'not', 'no', 'yes', 'all', 'some', 'any',
+])
+
+/** Does this token look like a proper noun rather than an ordinary word? */
+export function looksLikeProperNoun(token: string): boolean {
+  if (!WORD_ONLY.test(token)) return false
+  if (token.length < 2) return false
+  if (COMMON_CAPITALISED.has(token.toLowerCase())) return false
+  const first = token[0]
+  // An uppercase first letter, and not a SHOUTED word (which is more often an
+  // acronym heading or emphasis than a name being renamed).
+  if (first !== first.toUpperCase() || first === first.toLowerCase()) return false
+  return token !== token.toUpperCase() || token.length <= 5
+}
+
+export interface RenameCandidate {
+  /** The name as it stood before the edit. */
+  from: string
+  /** The name the reader typed in its place. */
+  to: string
+  /** How many times the reader replaced it within this block. */
+  replaced: number
+}
+
+/**
+ * Decide whether `before` → `after` is a single name being renamed.
+ *
+ * Fires only when every differing token position carries the SAME (from, to)
+ * pair. That definition is what makes the two-places-at-once case work: a
+ * reader who changed "Cody" to "Joe" twice in one paragraph before the settle
+ * fired still produced one rename, not a rewrite. A prefix/suffix character
+ * diff would have spanned both edits plus everything between them and rejected
+ * exactly the case where the reader has already shown they expect propagation.
+ *
+ * Returns null for ordinary rewriting, for anything that changes the token
+ * count, and for anything where more than one distinct substitution happened.
+ */
+export function detectRename(before: string, after: string): RenameCandidate | null {
+  if (before === after) return null
+
+  const a = tokenize(before)
+  const b = tokenize(after)
+  // A word-for-word swap preserves the token count. Insertions, deletions and
+  // restructuring do not — and none of those are renames.
+  if (a.length !== b.length) return null
+
+  let from: string | null = null
+  let to: string | null = null
+  let replaced = 0
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] === b[i]) continue
+    if (from === null) {
+      from = a[i]
+      to = b[i]
+    } else if (a[i] !== from || b[i] !== to) {
+      // A second, different substitution. That is a rewrite.
+      return null
+    }
+    replaced++
+  }
+
+  if (from === null || to === null) return null
+  if (!looksLikeProperNoun(from) || !looksLikeProperNoun(to)) return null
+  if (from.toLowerCase() === to.toLowerCase()) return null
+
+  return { from, to, replaced }
+}
+
+export type ExclusionReason = 'quoted' | 'email' | 'url'
+
+export interface Occurrence {
+  /** Character index of the name within the text it was found in. */
+  index: number
+  /** The sentence around it — what a reader needs to judge it in two seconds. */
+  sentence: string
+  /** Set when this occurrence is categorically not a narrative reference. */
+  excluded?: ExclusionReason
+}
+
+const EMAIL_OR_URL = /(?:https?:\/\/|www\.)\S+|[\w.+-]+@[\w-]+\.[\w.-]+/gu
+
+/** Character ranges covered by an email address or a URL. */
+function protectedRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = []
+  for (const m of text.matchAll(EMAIL_OR_URL)) {
+    if (m.index !== undefined) ranges.push([m.index, m.index + m[0].length])
+  }
+  return ranges
+}
+
+/**
+ * Character ranges inside quotation marks. Straight and curly pairs both count.
+ * Text inside quotes is REPORTED speech — renaming there rewrites somebody's
+ * words, which is categorically different from updating the document's own
+ * references, so it is never offered rather than merely ranked lower.
+ */
+function quotedRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = []
+  const pairs: Array<[string, string]> = [['"', '"'], ['“', '”'], ['‘', '’'], ["'", "'"]]
+  for (const [open, close] of pairs) {
+    let i = 0
+    while (i < text.length) {
+      const start = text.indexOf(open, i)
+      if (start === -1) break
+      const end = text.indexOf(close, start + 1)
+      if (end === -1) break
+      ranges.push([start, end + 1])
+      i = end + 1
+    }
+  }
+  return ranges
+}
+
+function within(index: number, ranges: Array<[number, number]>): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end)
+}
+
+/** The sentence containing `index`, trimmed — the context a judgement needs. */
+export function sentenceAround(text: string, index: number): string {
+  let start = 0
+  for (const m of text.slice(0, index).matchAll(/[.!?]\s+/g)) {
+    if (m.index !== undefined) start = m.index + m[0].length
+  }
+  const rest = text.slice(index)
+  const endMatch = /[.!?](\s|$)/.exec(rest)
+  const end = endMatch ? index + endMatch.index + 1 : text.length
+  return text.slice(start, end).trim()
+}
+
+/**
+ * Every whole-word occurrence of `name` in `text`, each carrying its sentence
+ * and, where it applies, the reason it is not a candidate.
+ *
+ * Exclusions are computed by construction rather than judged, because these are
+ * not close calls: a name inside a quotation is reported speech, and a name
+ * inside an email address or URL is an identifier, not a reference.
+ */
+export function findOccurrences(text: string, name: string): Occurrence[] {
+  if (!name) return []
+  const quoted = quotedRanges(text)
+  const identifiers = protectedRanges(text)
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  // Word boundaries by lookaround, so a name inside "Codyville" never matches.
+  const pattern = new RegExp(`(?<![\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`, 'gu')
+
+  const out: Occurrence[] = []
+  for (const m of text.matchAll(pattern)) {
+    if (m.index === undefined) continue
+    const excluded: ExclusionReason | undefined = within(m.index, identifiers)
+      ? (/@/.test(text.slice(Math.max(0, m.index - 40), m.index + 40)) ? 'email' : 'url')
+      : within(m.index, quoted)
+        ? 'quoted'
+        : undefined
+    out.push({ index: m.index, sentence: sentenceAround(text, m.index), excluded })
+  }
+  return out
+}
+
+/** Occurrences worth putting in front of the reader. */
+export function offerableOccurrences(text: string, name: string): Occurrence[] {
+  return findOccurrences(text, name).filter((o) => !o.excluded)
+}

--- a/src/stores/directEditOfferStore.ts
+++ b/src/stores/directEditOfferStore.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { create } from 'zustand'
-import type { DirectEditOffer } from '@/lib/annotations/directEditTrigger'
+import type { DirectEditOffer, RenameOffer } from '@/lib/annotations/directEditTrigger'
 
 /**
  * The current direct-edit cascade OFFER (Flow v1 P4) — the quiet chip's state.
@@ -9,17 +9,28 @@ import type { DirectEditOffer } from '@/lib/annotations/directEditTrigger'
  */
 interface DirectEditOfferState {
   offer: DirectEditOffer | null
+  /**
+   * A rename the reader made that still stands elsewhere. Independent of
+   * `offer` — a rename produces no graph edge, so the two arms find different
+   * things and either can fire without the other.
+   */
+  renameOffer: RenameOffer | null
   /** True while the user-consented cascade call is in flight. */
   running: boolean
   setOffer: (offer: DirectEditOffer) => void
   clearOffer: () => void
+  setRenameOffer: (offer: RenameOffer) => void
+  clearRenameOffer: () => void
   setRunning: (running: boolean) => void
 }
 
 export const useDirectEditOfferStore = create<DirectEditOfferState>()((set) => ({
   offer: null,
+  renameOffer: null,
   running: false,
   setOffer: (offer) => set({ offer }),
   clearOffer: () => set({ offer: null }),
+  setRenameOffer: (renameOffer) => set({ renameOffer }),
+  clearRenameOffer: () => set({ renameOffer: null }),
   setRunning: (running) => set({ running }),
 }))

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -146,6 +146,22 @@ interface SettingsState {
    */
   invariantEntailmentEnabled: boolean
   /**
+   * When consistency and ripple checks run.
+   *
+   * 'commit'  — at the existing autosave settle point, buffered and batched.
+   * 'demand'  — never in the background; only when explicitly asked.
+   * 'off'     — not at all.
+   *
+   * Default 'commit', and NEVER on keystroke. Published contradiction detectors
+   * run at roughly 16% precision for NLI-only pairwise detection and about 89%
+   * for the best hybrid; legal redlining products treat under 15% false
+   * positives as the bar for adoption. At keystroke cadence a checker that is
+   * wrong one time in three to six is a feature switched off within a week.
+   * Deferring to a settle point also matches the interruption-cost evidence:
+   * coarser breakpoints cost less to resume from than finer ones.
+   */
+  consistencyCheckMode: ConsistencyCheckMode
+  /**
    * Anonymous severity-calibration telemetry (default OFF — public repo,
    * other users). When on, cascade accept/reject decisions send metadata-only
    * events (severity × action, never document content or ids) to PostHog if
@@ -162,9 +178,21 @@ interface SettingsState {
   setEmbeddingsEnabled: (enabled: boolean) => void
   setJudgeEnabled: (enabled: boolean) => void
   setInvariantEntailmentEnabled: (enabled: boolean) => void
+  setConsistencyCheckMode: (mode: ConsistencyCheckMode) => void
   setTelemetryEnabled: (enabled: boolean) => void
   setGraphEnrichment: (setting: GraphEnrichmentSetting) => void
   hasKeys: () => boolean
+}
+
+export type ConsistencyCheckMode = 'commit' | 'demand' | 'off'
+
+const CONSISTENCY_CHECK_MODES: ConsistencyCheckMode[] = ['commit', 'demand', 'off']
+
+/** A snapshot from an older build carries no mode at all; fall back to the default. */
+export function normalizeConsistencyCheckMode(value: unknown): ConsistencyCheckMode {
+  return CONSISTENCY_CHECK_MODES.includes(value as ConsistencyCheckMode)
+    ? (value as ConsistencyCheckMode)
+    : 'commit'
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -182,6 +210,7 @@ export const useSettingsStore = create<SettingsState>()(
       embeddingsEnabled: true,
       judgeEnabled: true,
       invariantEntailmentEnabled: false,
+      consistencyCheckMode: 'commit' as ConsistencyCheckMode,
       telemetryEnabled: false,
       graphEnrichment: 'local-only',
       setLLMConfig: (config) =>
@@ -193,6 +222,7 @@ export const useSettingsStore = create<SettingsState>()(
       setEmbeddingsEnabled: (enabled) => set({ embeddingsEnabled: enabled }),
       setJudgeEnabled: (enabled) => set({ judgeEnabled: enabled }),
       setInvariantEntailmentEnabled: (enabled) => set({ invariantEntailmentEnabled: enabled }),
+      setConsistencyCheckMode: (mode) => set({ consistencyCheckMode: normalizeConsistencyCheckMode(mode) }),
       setTelemetryEnabled: (enabled) => set({ telemetryEnabled: enabled }),
       setGraphEnrichment: (setting) => set({ graphEnrichment: setting }),
       hasKeys: () => {
@@ -226,6 +256,14 @@ export const useSettingsStore = create<SettingsState>()(
         }
         if (state && typeof (state as { judgeEnabled?: unknown }).judgeEnabled !== 'boolean') {
           state.setJudgeEnabled(true)
+        }
+        // A snapshot from before the mode existed has none; normalize rather
+        // than leave it undefined, which would read as neither 'commit' nor
+        // 'off' at every call site.
+        if (state) {
+          state.setConsistencyCheckMode(
+            normalizeConsistencyCheckMode((state as { consistencyCheckMode?: unknown }).consistencyCheckMode),
+          )
         }
         // Snapshots written before the native-Ollama dialect carry no context
         // size. Backfilling the raised default (rather than leaving it unset)


### PR DESCRIPTION
Last of four tracks on the reading loop. Independent of #150 — no shared files.

## Why "Cody → Joe" raised nothing

The direct-edit trigger had one arm, and it required the changed block to have dependents in the deterministic doc graph. A bare name mention creates no cross-reference, no defined term and no duplicated sentence — **it produces no graph edge at all**, so a rename scored `dependentCount === 0` every single time.

## A second, independent arm

`settleDirectEdits` now returns `{ dependentOffer, renameOffer }` and scans **every** touched block for a rename. Deliberately *not* folded into the existing biggest-delta selection: that selection picks one winner across all touched blocks, so a rename in one block would be masked by any larger unrelated edit in another — and a settle window containing more than one edit is the normal case, not an edge case. There's a regression test for exactly that.

## Detecting a rename rather than a rewrite

`detectRename` compares token arrays positionally and fires only when every differing position carries the **same** `(from, to)` pair, both sides look like proper nouns, and the token count is unchanged.

That definition is what makes the two-places-at-once case work. A reader who changed "Cody" to "Joe" *twice* in one paragraph before the settle fired still made one rename — but a character-level prefix/suffix diff (all `textDelta` could offer) would have spanned both edits plus everything between them and rejected it as a rewrite. That is precisely the case where the reader has already demonstrated they expect propagation, so rejecting it would have been the worst possible miss.

**Exclusions are by construction, not by judgement.** A mention inside a quotation is reported speech — renaming there rewrites somebody's words. A mention inside an email address or URL is an identifier. Neither is ever offered as a candidate.

## Nothing auto-applies

Prose has no compiler. Coreference resolution runs at roughly **F1 78-81%** on curated benchmarks and worse on real documents, and its failure cases are exactly the ones that matter here: a different person with the same name, a product, a place, a codename, metonymy. Every tool that does this well suggests and never commits — IntelliJ shows a rename preview with per-occurrence opt-out; Vale, Acrolinx and textlint flag without fixing. One wrong silent rewrite costs more trust than one extra confirmation click.

The flow:

1. **Deterministic find** — zero network, preserving the module's existing data-egress guarantee (there's a test that fails the suite on any `fetch` before consent).
2. Reader clicks **Review**.
3. **One batched judge call** labels each mention same-referent or not, modelled on `judgeRelatedPassages` — same verdict-tool shape, same skepticism.
4. Reader decides **one at a time, with the sentence in view**. One at a time rather than a checkbox grid, for the reason `git add -p` is tolerable and a wall of N decisions is not: each item is judged in its own context, the common case is one click, and only the ambiguous ones cost attention.

Applying goes through `applySingleEdit`, so it re-verifies the text at the range and recovers by block-scoped fingerprint if the document moved underneath. A missing or garbled verdict means **"ask the human"**, never "rename it anyway".

## `consistencyCheckMode`

`'commit' | 'demand' | 'off'`, default `'commit'`, read **inside** `settleDirectEdits` rather than at the call site so a future arm cannot forget to ask.

Never on keystroke. Published contradiction detectors run at about **16% precision** for NLI-only pairwise detection and about 89% for the best hybrid; legal redlining products treat **under 15% false positives** as the adoption bar. A checker that is wrong one time in three to six, firing mid-sentence, is a feature switched off within a week. Deferring to the settle point also matches the interruption-cost evidence — coarser breakpoints cost less to resume from.

## Verification

- `typecheck`, `lint`, full unit suite: **120 test files**, 0 failed.
- 38 new tests: the detector (rename vs rewrite, two-at-once, token-count changes, case-only changes, hyphens and apostrophes, proper-noun heuristics, quote/email/URL exclusion, sentence extraction), the trigger's new arm, the mode gate, and the judge (skipped/duplicate/out-of-range indices, non-boolean fields, protocol malfunction, empty list).
- **Falsified before claiming**: bolting the rename arm onto the biggest-delta winner instead of scanning every touched block fails exactly the non-largest-block regression test and nothing else.
- Existing settle tests updated to the new return shape — behaviour under test unchanged, none removed or skipped.

## Note on CI

`tests/cascade-review.spec.ts:284` (`getByText('Created')`, the version-history root row) has now failed and then passed on re-run **twice** on unrelated branches. It is a genuine flake, not a regression from any of these tracks — the `AI change` row above it is polled with retries while `Created` is asserted once. Fixing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
