### PR TITLE
test(e2e): stop the history import write racing its own route compile

### DIFF
--- a/tests/cascade-review.spec.ts
+++ b/tests/cascade-review.spec.ts
@@ -174,7 +174,22 @@ async function interceptLlmEndpoints(page: Page) {
 test.describe('cascade review flow', () => {
   test('annotate → cascade → per-change review → apply → history', async ({ page }) => {
     await interceptLlmEndpoints(page)
+
+    // Every version write goes through recordCommit, which is fire-and-forget
+    // and swallows failures with a console.warn (commits.ts:237-242) — a lost
+    // write is lost permanently, not late. That is why polling for the row does
+    // not rescue it, and why this assertion has failed intermittently.
+    //
+    // The import commit is the FIRST request this spec makes to /api/history,
+    // so it races that route's first-hit dev compile. Warming the route before
+    // the document exists takes the compile off the write's critical path.
+    const historyWarnings: string[] = []
+    page.on('console', (msg) => {
+      if (msg.text().includes('[history]')) historyWarnings.push(msg.text())
+    })
+
     await page.goto('/')
+    await page.request.get('/api/history?documentId=warmup&limit=1')
 
     // 1. First-run DocInputModal: paste the seeded document.
     await expect(page.getByRole('heading', { name: 'Load Document' })).toBeVisible({
@@ -287,9 +302,14 @@ test.describe('cascade review flow', () => {
       })
       await expect(page.getByText('AI + you').first()).toBeVisible({ timeout: 2_000 })
       // The version chain also holds the root 'import' version from the paste.
-      await expect(page.getByText('Created', { exact: true })).toBeVisible({
-        timeout: 2_000,
-      })
+      await expect(
+        page.getByText('Created', { exact: true }),
+        // Surface the swallowed warning in the failure message: without it a
+        // lost write looks like a mysteriously missing row.
+        historyWarnings.length
+          ? `history writes reported failures: ${historyWarnings.join(' | ')}`
+          : 'no [history] console warnings were emitted',
+      ).toBeVisible({ timeout: 2_000 })
     }).toPass({ timeout: 20_000 })
   })
 })

--- a/tests/cascade-review.spec.ts
+++ b/tests/cascade-review.spec.ts
@@ -273,14 +273,23 @@ test.describe('cascade review flow', () => {
     // crowding the overflow menu removes, so a real click works again.
     await page.getByRole('button', { name: /more panels/i }).click()
     await page.getByRole('menuitem', { name: 'History' }).click()
+    // BOTH rows are polled behind the same Refresh. They are written by two
+    // separate fire-and-forget commits — the 'apply' version after the cascade,
+    // and the root 'import' version back at the paste — so there is no order
+    // guarantee between them. Asserting 'Created' once, outside the retry that
+    // 'AI change' already had, made this flake: it failed and then passed on
+    // re-run twice on unrelated branches. Same assertions, same timeout; only
+    // the retry boundary moved.
     await expect(async () => {
       await page.getByRole('button', { name: 'Refresh' }).click()
       await expect(page.getByText('AI change', { exact: true })).toBeVisible({
         timeout: 2_000,
       })
+      await expect(page.getByText('AI + you').first()).toBeVisible({ timeout: 2_000 })
+      // The version chain also holds the root 'import' version from the paste.
+      await expect(page.getByText('Created', { exact: true })).toBeVisible({
+        timeout: 2_000,
+      })
     }).toPass({ timeout: 20_000 })
-    await expect(page.getByText('AI + you').first()).toBeVisible()
-    // The version chain also holds the root 'import' version from the paste.
-    await expect(page.getByText('Created', { exact: true })).toBeVisible()
   })
 })


### PR DESCRIPTION
> **Correction.** The first commit on this branch had the wrong diagnosis. It moved the `Created` assertion inside the existing retry on the theory that the row simply arrived late. This branch's own CI run then failed the same assertion after a **full 20 seconds of polling with Refresh** — which disproves it. Second commit has the real mechanism.

## The real mechanism

Every version write goes through `recordCommit`, which is fire-and-forget and swallows failures with a `console.warn` ([`commits.ts:237-242`](../blob/main/src/lib/history/commits.ts)). A failed write is therefore **lost permanently, not delayed** — which is exactly why polling could never rescue it, and is the strongest evidence that the row is *absent* rather than slow.

What makes it fail only sometimes: the import commit is the **first request this spec makes to `/api/history`**, so it races that route's first-hit dev compile. The spec already allows 60s for the *page's* first compile; the API route compiles separately, on its first hit — which is this write.

Position in the run doesn't discriminate, which is what ruled out the simpler explanations: cascade-review ran at index 1 in both a failing run (#150, 39.1s) and a passing one (#149, 29.5s).

## Changes

- **Warm `/api/history` before the document exists**, taking the route compile off the write's critical path.
- **Capture `[history]` console warnings** and attach them to the assertion message. A lost write currently looks like a mysteriously missing row; if this ever fails again, the failure will say *why* rather than needing another round of guessing.

The retry-boundary change from the first commit is kept — the three history assertions are genuinely more consistent polled together — but it is **not** the fix and is not claimed as one.

## Verification

Locally: 1 passed. Note that local passes were also true of the wrong fix, so the honest claim here is "mechanism identified and mitigated, plus instrumented so the next failure is diagnosable" — not "proven fixed". CI over the next few runs is the real test.

## Worth a separate decision, not fixed here

This is an **EU AI Act Art. 12 record chain whose root commit can be silently dropped**. The route's own header says writes "degrade gracefully", so it is by design — but a compliance chain that can lose its `import` row seems worth a deliberate decision rather than an inherited default. Touching that path is out of scope for a test fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
