### PR TITLE
fix(editor): let the reader copy their own text

### DIFF
--- a/src/components/Annotations/AnnotationComposer.tsx
+++ b/src/components/Annotations/AnnotationComposer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { startVoiceCapture, stopVoiceCaptureForTranscript } from '@/lib/voice/pipeline'
 import { useVoiceStore } from '@/stores/voiceStore'
 import type { AnnotationType, Scope } from '@/lib/annotations/types'
@@ -36,6 +36,18 @@ interface AnnotationComposerProps {
   }) => Promise<void> | void
   onCancel?: () => void
   className?: string
+  /**
+   * Focus the input on mount, and again whenever this flips true.
+   *
+   * Default true for the thread/inline composers, which the reader opened by
+   * clicking — focusing there is what they asked for. The SELECTION composer
+   * passes false: an autofocused input steals the document selection the moment
+   * a highlight finishes, which is what made Cmd+C copy nothing. It focuses
+   * later, on the first typed character.
+   */
+  autoFocus?: boolean
+  /** When given, renders a Copy chip first in the offers row. */
+  onCopy?: () => void
 }
 
 /**
@@ -53,12 +65,22 @@ export function AnnotationComposer({
   onSubmit,
   onCancel,
   className = '',
+  autoFocus = true,
+  onCopy,
 }: AnnotationComposerProps) {
   const isRecording = useVoiceStore((s) => s.isRecording)
   const voiceError = useVoiceStore((s) => s.error)
   const [value, setValue] = useState(initialText)
   const [activeIntent, setActiveIntent] = useState<SuggestedIntent | null>(suggestedIntent)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus on mount when asked, and again when the flag flips — the selection
+  // composer starts unfocused and is focused later by the first keystroke, so a
+  // mount-only `autoFocus` attribute would never fire for it.
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus()
+  }, [autoFocus])
 
   const quoted = selectionAnchor?.text?.trim() ?? ''
   const offers = useMemo<Offer[]>(() => {
@@ -129,6 +151,7 @@ export function AnnotationComposer({
       )}
       <div className="flex items-center gap-2 px-3 py-2">
         <input
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -145,7 +168,6 @@ export function AnnotationComposer({
           }}
           placeholder={mode === 'selection' ? "What's on your mind?" : 'Add a note or follow-up'}
           className="flex-1 text-sm bg-transparent border-none focus:outline-none placeholder:text-muted-foreground/60"
-          autoFocus
         />
 
         <button
@@ -181,6 +203,15 @@ export function AnnotationComposer({
       </div>
 
       <div className="flex flex-wrap gap-1 px-3 pb-2">
+        {onCopy && (
+          <button
+            onClick={onCopy}
+            title="Copy the selected text (Cmd/Ctrl+C also works)"
+            className="px-2 py-1 text-[10px] font-mono rounded-full border border-border text-muted-foreground transition-colors hover:bg-warm/70 hover:text-ink"
+          >
+            Copy
+          </button>
+        )}
         {offers.map((action) => (
           <button
             key={action.label}

--- a/src/components/Editor/FloatingIconBar.tsx
+++ b/src/components/Editor/FloatingIconBar.tsx
@@ -17,6 +17,9 @@ export function FloatingIconBar() {
   const contextMenu = useEditorStore((s) => s.contextMenu)
   const view = useEditorStore((s) => s.view)
   const clearContextMenu = useEditorStore((s) => s.clearContextMenu)
+  // null until the reader types — while it is null, focus stays in the document
+  // and Cmd+C, Cmd+X and caret keys all behave natively over the selection.
+  const composerSeed = useEditorStore((s) => s.composerSeed)
   const barRef = useRef<HTMLDivElement>(null)
 
   // Click outside + escape handler
@@ -69,6 +72,15 @@ export function FloatingIconBar() {
       <AnnotationComposer
         mode="selection"
         className="w-[360px]"
+        // Deliberately unfocused until the first keystroke. An autofocused
+        // input took the document selection the instant a highlight finished,
+        // which is why copying your own text did not work.
+        autoFocus={composerSeed !== null}
+        initialText={composerSeed ?? ''}
+        onCopy={() => {
+          void navigator.clipboard?.writeText(contextMenu.text)
+          clearContextMenu()
+        }}
         selectionAnchor={{
           from: contextMenu.from,
           to: contextMenu.to,

--- a/src/lib/prosemirror/plugins/__tests__/contextMenuPlugin.typeThrough.test.ts
+++ b/src/lib/prosemirror/plugins/__tests__/contextMenuPlugin.typeThrough.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import type { EditorView } from 'prosemirror-view'
+import { schema } from '@/lib/prosemirror/schema'
+import { useEditorStore } from '@/stores/editorStore'
+import { createContextMenuPlugin } from '../contextMenuPlugin'
+
+// The reported bug: you could not copy text out of your own document. The
+// selection composer autofocused, which took the document selection the instant
+// a highlight finished, so Cmd+C had nothing to copy.
+//
+// The fix keeps focus in the editor and captures the first printable keystroke
+// instead, so typing a question still costs zero clicks. These tests pin the
+// half that has to be exactly right: which keys are swallowed and which are
+// handed straight back to the browser.
+
+const plugin = createContextMenuPlugin()
+const handleKeyDown = plugin.props.handleKeyDown as (
+  view: EditorView,
+  event: KeyboardEvent,
+) => boolean
+
+function view(): EditorView {
+  const state = EditorState.create({
+    schema,
+    doc: schema.node('doc', null, [
+      schema.node('paragraph', { blockId: 'a' }, [schema.text('Cody owns the runbook.')]),
+    ]),
+  })
+  return { state } as unknown as EditorView
+}
+
+function key(k: string, mods: Partial<KeyboardEvent> = {}): KeyboardEvent {
+  return {
+    key: k,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...mods,
+  } as unknown as KeyboardEvent
+}
+
+/** The state after a highlight: bar open, nothing typed yet. */
+function openBar() {
+  useEditorStore.getState().setContextMenu({
+    x: 0, y: 0, from: 1, to: 5, text: 'Cody', scope: 'phrase',
+  })
+}
+
+beforeEach(() => {
+  useEditorStore.setState({ contextMenu: null, composerSeed: null })
+})
+
+describe('contextMenuPlugin — type-through', () => {
+  it('captures the first printable character and swallows it', () => {
+    openBar()
+    const event = key('w')
+    expect(handleKeyDown(view(), event)).toBe(true)
+    expect(useEditorStore.getState().composerSeed).toBe('w')
+    // Swallowed on purpose: this character opens the question, it must not also
+    // overwrite the passage that is currently selected.
+    expect(event.preventDefault).toHaveBeenCalled()
+  })
+
+  it('lets Cmd+C through — this is the whole point', () => {
+    openBar()
+    const event = key('c', { metaKey: true })
+    expect(handleKeyDown(view(), event)).toBe(false)
+    expect(useEditorStore.getState().composerSeed).toBeNull()
+    expect(event.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('lets Ctrl+C and Alt-combinations through too', () => {
+    openBar()
+    for (const mods of [{ ctrlKey: true }, { altKey: true }]) {
+      useEditorStore.getState().setComposerSeed(null)
+      const event = key('c', mods)
+      expect(handleKeyDown(view(), event)).toBe(false)
+      expect(useEditorStore.getState().composerSeed).toBeNull()
+    }
+  })
+
+  it('ignores non-printable keys, so caret and selection keys still work', () => {
+    openBar()
+    for (const k of ['ArrowRight', 'Backspace', 'Escape', 'Home', 'Tab', 'Enter']) {
+      const event = key(k)
+      expect(handleKeyDown(view(), event)).toBe(false)
+      expect(useEditorStore.getState().composerSeed).toBeNull()
+    }
+  })
+
+  it('does nothing when no selection bar is open', () => {
+    const event = key('w')
+    expect(handleKeyDown(view(), event)).toBe(false)
+    expect(useEditorStore.getState().composerSeed).toBeNull()
+  })
+
+  it('captures only the FIRST character — the composer owns the rest', () => {
+    openBar()
+    handleKeyDown(view(), key('w'))
+    const second = key('h')
+    // Once seeded, focus has moved to the composer; the plugin must not keep
+    // eating keystrokes behind it.
+    expect(handleKeyDown(view(), second)).toBe(false)
+    expect(useEditorStore.getState().composerSeed).toBe('w')
+  })
+})
+
+describe('editorStore — seed lifecycle', () => {
+  it('clears the seed when the bar closes', () => {
+    openBar()
+    useEditorStore.getState().setComposerSeed('w')
+    useEditorStore.getState().clearContextMenu()
+    expect(useEditorStore.getState().composerSeed).toBeNull()
+  })
+
+  it('does not let a new selection inherit the previous keystroke', () => {
+    openBar()
+    useEditorStore.getState().setComposerSeed('w')
+    openBar()
+    expect(useEditorStore.getState().composerSeed).toBeNull()
+  })
+})

--- a/src/lib/prosemirror/plugins/contextMenuPlugin.ts
+++ b/src/lib/prosemirror/plugins/contextMenuPlugin.ts
@@ -55,6 +55,30 @@ export function createContextMenuPlugin(): Plugin {
         },
       },
       handleKeyDown(view, event) {
+        // Type-through: the selection bar does not take focus, so the reader
+        // keeps every native clipboard and caret shortcut over their own
+        // selection. The cost of that is that the composer is not listening —
+        // so the first printable keystroke is captured here and handed to it.
+        //
+        // Guarded on the modifier keys, which is the whole point: Cmd/Ctrl+C
+        // must reach the browser as a copy, not be swallowed as the first
+        // letter of a question.
+        const store = useEditorStore.getState()
+        if (
+          store.contextMenu &&
+          store.composerSeed === null &&
+          event.key.length === 1 &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey
+        ) {
+          store.setComposerSeed(event.key)
+          // Swallowed deliberately: this character opens the question, it must
+          // not also overwrite the passage the reader just selected.
+          event.preventDefault()
+          return true
+        }
+
         // Trigger on keyboard selection (Shift+arrow/Home/End)
         if (event.shiftKey && /^Arrow|Home|End/.test(event.key)) {
           requestAnimationFrame(() => {

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -21,6 +21,21 @@ interface EditorStoreState {
   contextMenu: ContextMenuState | null
   setContextMenu: (menu: ContextMenuState | null) => void
   clearContextMenu: () => void
+  /**
+   * The first character typed after a selection, while focus is still in the
+   * editor.
+   *
+   * The selection bar deliberately does NOT take focus — an autofocused input
+   * stole the document selection the instant you finished highlighting, which
+   * is why Cmd+C copied nothing. Focus stays in the document; the first
+   * printable keystroke is captured here, and the composer picks it up, focuses
+   * itself, and carries on. Typing a question still costs zero clicks.
+   *
+   * null means "the reader has not started typing" — the state in which every
+   * clipboard and caret shortcut behaves natively.
+   */
+  composerSeed: string | null
+  setComposerSeed: (seed: string | null) => void
 }
 
 export const useEditorStore = create<EditorStoreState>()((set, get) => ({
@@ -28,6 +43,10 @@ export const useEditorStore = create<EditorStoreState>()((set, get) => ({
   setView: (view) => set({ view }),
   getState: () => get().view?.state ?? null,
   contextMenu: null,
-  setContextMenu: (menu) => set({ contextMenu: menu }),
-  clearContextMenu: () => set({ contextMenu: null }),
+  // Opening a new selection bar always starts un-typed, so the next selection
+  // never inherits the previous one's first keystroke.
+  setContextMenu: (menu) => set({ contextMenu: menu, composerSeed: null }),
+  clearContextMenu: () => set({ contextMenu: null, composerSeed: null }),
+  composerSeed: null,
+  setComposerSeed: (composerSeed) => set({ composerSeed }),
 }))

--- a/tests/reading-quality.spec.ts
+++ b/tests/reading-quality.spec.ts
@@ -293,3 +293,53 @@ test.describe('threads can be closed', () => {
     await expect(page.getByText('Dismissed').first()).toBeVisible()
   })
 })
+
+test.describe('selecting text leaves the document usable', () => {
+  // The reported bug: you could not copy a sentence out of your own document.
+  // The selection composer autofocused, which took the document selection the
+  // instant the highlight finished, so Cmd+C had nothing to copy. Notion,
+  // Medium and Google Docs all show a selection toolbar WITHOUT taking focus,
+  // for exactly this reason.
+
+  test('the composer appears without stealing focus from the editor', async ({ page }) => {
+    await interceptLlm(page)
+    await loadDocument(page, LINKED_DOC)
+
+    await page.locator('.ProseMirror p', { hasText: 'Funding for the Pilot Program' }).first()
+      .click({ clickCount: 3 })
+    await expect(page.getByPlaceholder("What's on your mind?")).toBeVisible({ timeout: 30_000 })
+
+    // The invariant that makes copy work at all: focus is still inside the
+    // editor, so the live selection is still the one the browser will copy.
+    // This assertion fails before the fix.
+    const focusIsInEditor = await page.evaluate(
+      () => !!document.activeElement?.closest('.ProseMirror'),
+    )
+    expect(focusIsInEditor).toBe(true)
+
+    // And the selection itself survived.
+    const selected = await page.evaluate(() => window.getSelection()?.toString() ?? '')
+    expect(selected).toContain('Pilot Program')
+  })
+
+  test('typing straight after selecting still goes into the composer', async ({ page }) => {
+    // Keeping focus in the editor must not cost the core move: highlight, then
+    // immediately type. The first keystroke seeds the composer and focuses it.
+    await interceptLlm(page)
+    await loadDocument(page, LINKED_DOC)
+
+    const target = page.locator('.ProseMirror p', { hasText: 'Funding for the Pilot Program' }).first()
+    const before = (await target.textContent()) ?? ''
+    await target.click({ clickCount: 3 })
+
+    const composer = page.getByPlaceholder("What's on your mind?")
+    await composer.waitFor({ state: 'visible', timeout: 30_000 })
+    await page.keyboard.press('w')
+
+    await expect(composer).toBeFocused()
+    await expect(composer).toHaveValue('w')
+    // The keystroke opened a question; it must not also have overwritten the
+    // passage that was selected.
+    expect(await target.textContent()).toBe(before)
+  })
+})


### PR DESCRIPTION
First of five tracks on the round-two reading-loop failures.

## You could not copy a sentence out of your own document

`triggerFloatingBar` fires on every mouseup with a selection, and the selection composer's input carried `autoFocus`. Focus therefore left the editor **the instant a highlight finished** — the document selection stopped being the focused selection, and Cmd+C copied nothing. No modifier would have helped; the selection was gone before one could be pressed.

This is also the real story behind the hyperlink report. The floater appearing wasn't the problem — the floater then *blocking the copy* was.

## The fix: keep focus in the editor, type through to the composer

Notion, Medium and Google Docs all show a selection toolbar **without** taking focus, for exactly this reason. But simply dropping `autoFocus` would cost this tool its core move — highlight, then immediately type. So both:

- **The selection composer renders unfocused.** Cmd+C, Cmd+X, caret and shift-selection keys all behave natively over the selection again.
- **`contextMenuPlugin.handleKeyDown` captures the first printable keystroke**, guarded on meta/ctrl/alt — which is the whole point, since Cmd+C must reach the browser as a copy rather than be swallowed as the first letter of a question. The composer picks the character up, focuses itself, and carries on. **Typing a question still costs zero clicks.**
- That character is `preventDefault`'d: it opens the question, it must not *also* overwrite the passage that is selected.
- An explicit **Copy** chip, because a keyboard behaviour nobody announces is a behaviour nobody finds.

`autoFocus` stays the default for the thread and inline composers — the reader opened those by clicking, so focusing there is what they asked for. Only the selection composer opts out.

## Verification

- `typecheck`, `lint`, unit suite: **121 files passed**, 0 failed.
- 8 new unit tests pinning the half that must be exactly right — which keys are swallowed and which are handed back: Cmd+C, Ctrl+C and Alt-combinations pass through untouched; non-printable keys ignored; only the *first* character is captured; a new selection never inherits the previous one's keystroke.
- 2 new e2e tests asserting the real invariant: after selecting, `document.activeElement` is still inside `.ProseMirror` and `window.getSelection()` still holds the passage — which is what makes native copy work by definition.
- **Falsified before claiming**: restoring `autoFocus` fails the focus test and nothing else.
- **Full e2e re-run** for regressions: 14 passed, 6 self-skipped, none broken — including the two existing dismissal tests.

## Unrelated housekeeping note

The working tree contains ~30 untracked sync-duplicate files (`parser.test 2.ts`, `intentContext 2.ts`, `reading-quality.spec 2.ts`, …). They are **not** from this branch and are not committed here. Verified they are not picked up by either runner — vitest matches `*.test.ts` and Playwright `*.spec.ts`, and `test 2.ts` / `spec 2.ts` match neither — but they are worth deleting before one of them drifts into something that does match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
