### PR TITLE
fix(ui): make Length mean something, close the popup on Got it, stop the panel blanking

### DIFF
--- a/src/components/Annotations/AnnotationCard.tsx
+++ b/src/components/Annotations/AnnotationCard.tsx
@@ -413,7 +413,11 @@ export function AnnotationCard({
     updateAnnotation(annotation.id, { status: 'resolved', resolution, resolvedAt: Date.now() })
   }
 
-  const showRegenerate = currentVerbosity !== defaultVerbosity
+  // Always offered once there is an answer to re-run. Gating this on
+  // "verbosity differs from the default" meant that switching BACK to the
+  // default hid the button — exactly when the answer on screen was still the
+  // one generated at the other length.
+  const showRegenerate = Boolean(annotation.resolution)
 
   return (
     <div
@@ -583,9 +587,15 @@ export function AnnotationCard({
           {(['concise', 'normal', 'detailed'] as const).map((v) => (
             <button
               key={v}
+              // Changing the length used to write `verbosity` to the store and
+              // nothing else, so Short and Long rendered byte-identical text
+              // until Regenerate was found and clicked. The control now does
+              // what it looks like it does.
               onClick={() => {
-                updateAnnotation(annotation.id, { verbosity: v })
+                if (v === currentVerbosity) return
+                void reresolve({ verbosity: v })
               }}
+              disabled={annotation.status === 'resolving'}
               className={`px-2 py-0.5 text-[10px] font-mono rounded transition-colors ${
                 currentVerbosity === v
                   ? 'bg-ink text-white shadow-sm'

--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -610,6 +610,10 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         // cascade-review.spec.ts caught by asserting that badge. They can
         // collapse or dismiss it afterwards, on their own timing.
         useAnnotationStore.getState().setHidden(annotation.id, true)
+        // The floating answer panel renders for whatever annotation is active,
+        // so hiding the row left the popup sitting on screen taking up space.
+        // "I am finished with this" has to mean the answer goes away.
+        useAnnotationStore.getState().setActive(null)
         if (changeSetId) {
           useChangesStore.getState().updateChangeSetStatus(changeSetId, 'rejected')
         }

--- a/src/components/ui/AgentMarkdown.tsx
+++ b/src/components/ui/AgentMarkdown.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import { Streamdown, type DiagramPlugin } from 'streamdown'
 import { AnnotationComposer } from '@/components/Annotations/AnnotationComposer'
 import { extractMermaidFence } from '@/lib/ai/mermaidGuard'
@@ -197,8 +198,18 @@ export function AgentMarkdown({ content, isStreaming = false, interactive = fals
           </div>
         </details>
       )}
-      {composer && (
+      {composer && createPortal(
         <>
+          {/* Portaled to document.body deliberately.
+              `position: fixed` resolves against the nearest ancestor with a
+              transform, filter or backdrop-filter — not the viewport. The
+              floating answer panel carries `backdrop-filter: blur(14px)`, so
+              rendered inline this click-catcher covered THAT PANEL exactly
+              rather than the screen, and at z-40 against sibling content at
+              z-auto it painted over the answer text: the panel appeared to go
+              blank the moment you highlighted anything inside it.
+              Do not "fix" this by dropping the backdrop-filter — the trap
+              returns the next time anyone adds a transform. */}
           <div className="fixed inset-0 z-40" onClick={() => setComposer(null)} />
           <div
             ref={composerRef}
@@ -226,7 +237,8 @@ export function AgentMarkdown({ content, isStreaming = false, interactive = fals
               onCancel={() => setComposer(null)}
             />
           </div>
-        </>
+        </>,
+        document.body,
       )}
     </div>
   )

--- a/tests/reading-quality.spec.ts
+++ b/tests/reading-quality.spec.ts
@@ -343,3 +343,115 @@ test.describe('selecting text leaves the document usable', () => {
     expect(await target.textContent()).toBe(before)
   })
 })
+
+test.describe('the floating answer panel', () => {
+  /** Move the answer out of the sidebar into the floating panel. */
+  async function goFloating(page: Page) {
+    await page.getByRole('button', { name: 'Floating', exact: true }).click()
+    await expect(page.getByRole('dialog', { name: /^Answer for/ })).toBeVisible({ timeout: 15_000 })
+  }
+
+  test('highlighting inside an answer does not blank the panel', async ({ page }) => {
+    // `position: fixed` resolves against the nearest ancestor with a transform,
+    // filter or backdrop-filter — not the viewport. The panel carries
+    // `backdrop-filter: blur(14px)`, so the drill composer's click-catcher
+    // covered THE PANEL exactly and painted over its own answer text.
+    await interceptLlm(page, 'Tokenization replaces sensitive data with a token.')
+    await loadDocument(page, LINKED_DOC)
+    await annotate(page, 'Funding for the Pilot Program', 'what is this?')
+    await goFloating(page)
+
+    const panel = page.getByRole('dialog', { name: /^Answer for/ })
+    await expect(panel).toContainText('Tokenization replaces sensitive data')
+
+    // Select a phrase inside the answer and fire the mouseup React listens for.
+    // A synthetic triple-click does not reliably produce a DOM Selection here,
+    // and the drill affordance keys off window.getSelection().
+    await page.evaluate(() => {
+      const body = document.querySelector('.agent-markdown')
+      if (!body) throw new Error('no answer body found in the panel')
+      const target = body.querySelector('p') ?? body
+      const range = document.createRange()
+      range.selectNodeContents(target)
+      const sel = window.getSelection()
+      sel?.removeAllRanges()
+      sel?.addRange(range)
+      body.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+    })
+
+    // Prove the composer actually opened. Without this the test passes
+    // vacuously: if no composer renders, no click-catcher renders either, and
+    // "the panel is still readable" is trivially true.
+    await expect(page.getByPlaceholder('Add a note or follow-up')).toBeVisible({ timeout: 15_000 })
+
+    // The click-catcher must NOT live inside the panel.
+    //
+    // `position: fixed` resolves against the nearest ancestor with a transform,
+    // filter or backdrop-filter rather than the viewport, and the panel carries
+    // `backdrop-filter: blur(14px)` — so rendered inline, this `inset-0`
+    // overlay covered the panel exactly and, at z-40 over sibling content at
+    // z-auto, painted out the answer. Asserting the text is still "in the DOM"
+    // does not catch that: the text was always in the DOM, just underneath.
+    await expect(panel.locator('div.fixed.inset-0')).toHaveCount(0)
+
+    // And it does exist — at the body level, where it belongs.
+    await expect(page.locator('body > div.fixed.inset-0')).toHaveCount(1)
+
+    await expect(panel).toContainText('Tokenization replaces sensitive data')
+  })
+
+  test('Got it leaves no answer open, so the popup cannot reappear', async ({ page }) => {
+    // The floating panel renders for whatever annotation is ACTIVE, so
+    // "Got it" hiding the sidebar row still left the popup on screen taking up
+    // space. Dismissing now clears the active annotation too.
+    //
+    // Asserted this way round — dismiss in the sidebar, then switch to
+    // floating — because it tests the property that matters (nothing is left
+    // active) without depending on the floating card's own render conditions.
+    await interceptLlm(page)
+    await loadDocument(page, LINKED_DOC)
+    await annotate(page, 'Funding for the Pilot Program', 'what is this?')
+
+    await page.getByRole('button', { name: /^(Got it|Dismiss|Keep it)$/ }).first().click()
+    await expect(page.getByText('0 review items')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole('button', { name: 'Floating', exact: true }).click()
+    await expect(page.getByRole('dialog', { name: /^Answer for/ })).toBeHidden()
+  })
+})
+
+test.describe('answer length', () => {
+  test('changing Length re-runs the answer instead of silently relabelling it', async ({ page }) => {
+    // Short and Long rendered byte-identical text, because the buttons only
+    // wrote `verbosity` to the store and nothing re-resolved.
+    await interceptLlm(page)
+    // Registered AFTER interceptLlm so this one wins for /api/resolve —
+    // Playwright matches the most recently registered route first. Each call
+    // answers differently, so a re-resolve is visible in the card itself.
+    let resolves = 0
+    await page.route('**/api/resolve', (route) => {
+      resolves += 1
+      const answer = `answer number ${resolves}`
+      const body = route.request().postDataJSON() as { stream?: boolean }
+      if (body.stream) {
+        return route.fulfill({
+          contentType: 'text/event-stream',
+          body:
+            `data: ${JSON.stringify({ responseId: `r${resolves}` })}\n\n` +
+            `data: ${JSON.stringify({ text: answer })}\n\n`,
+        })
+      }
+      return route.fulfill({ json: { content: answer, responseId: `r${resolves}`, logprobs: null } })
+    })
+
+    await loadDocument(page, LINKED_DOC)
+    await annotate(page, 'Funding for the Pilot Program', 'what is this?')
+    await expect(page.getByText('answer number 1')).toBeVisible({ timeout: 30_000 })
+
+    await page.getByRole('button', { name: 'Long', exact: true }).first().click()
+
+    // A second answer arrives. Before the fix, clicking Long only relabelled
+    // the store and this text never changed.
+    await expect(page.getByText('answer number 2')).toBeVisible({ timeout: 30_000 })
+  })
+})


### PR DESCRIPTION
Third of five tracks. Follows #153 and #154.

Three things that each looked like a different bug.

## Length did nothing

The Short / Normal / Long buttons wrote `verbosity` to the store and **nothing else** — the answer on screen stayed whatever had already been generated, so Short and Long rendered byte-identical text until you found and clicked the red Regenerate link. Changing the length now re-runs the answer.

`showRegenerate` also stops being gated on "differs from the default", which hid the button **precisely when you switched back to the default** and the answer on screen was still the one generated at the other length.

The settings themselves were always real — 0.5× / 1× / 2× on tokens plus an explicit instruction line. They just never got applied.

## "Got it" left the popup on screen

The floating answer panel renders for whatever annotation is **active**. Dismissing only set `hidden` on the sidebar row, so the popup went on occupying the screen. Dismiss now clears the active annotation too.

The sidebar's hide-and-uncount behaviour is deliberately unchanged. A broader "collapse instead of vanish" change collides with `computeVisibleAnnotationIds` and the review-item count, and wasn't what was asked for.

## The floating panel went blank when you highlighted inside it

**Not a visual glitch.** `position: fixed` resolves against the nearest ancestor with a `transform`, `filter` or `backdrop-filter` — not the viewport — and `.floating-answer-panel` carries `backdrop-filter: blur(14px)`. So the drill composer's `fixed inset-0 z-40` click-catcher, written on the assumption it would cover the screen, covered **that panel exactly**, and at `z-40` against sibling content at `z-auto` it painted over the answer.

The composer and its catcher now render through a portal to `document.body`. Deliberately **not** fixed by dropping the backdrop-filter — the trap returns the next time anyone adds a transform.

## Verification

- `typecheck`, `lint`, unit suite: **122 files passed**. Full e2e: **17 passed**, 6 self-skipped.
- **Falsified**: reverting all three fails exactly the three new tests.

### Two of these tests were worthless on the first attempt

Both were caught by the falsification pass, which is the entire reason to do one:

1. The panel test triple-clicked to select text. That does not reliably produce a DOM `Selection`, so the drill composer never opened — meaning "the answer is still readable" was **trivially true** and the test passed against the broken code. It now sets the selection programmatically and asserts the composer is visible *first*.
2. Even then, asserting the answer text was still present didn't catch it either: the text was always in the DOM, just painted underneath the overlay. `toContainText` reads the DOM, not the paint. It now asserts the catcher is **not a descendant of the panel**, and *is* a child of `document.body` — the structural condition that actually distinguishes fixed and broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
