### PR TITLE
feat(editor): make links in the document real, and openable

### DIFF
--- a/src/components/Annotations/AnnotationComposer.tsx
+++ b/src/components/Annotations/AnnotationComposer.tsx
@@ -48,6 +48,8 @@ interface AnnotationComposerProps {
   autoFocus?: boolean
   /** When given, renders a Copy chip first in the offers row. */
   onCopy?: () => void
+  /** When the selection is a link, renders an Open-link chip beside Copy. */
+  onOpenLink?: () => void
 }
 
 /**
@@ -67,6 +69,7 @@ export function AnnotationComposer({
   className = '',
   autoFocus = true,
   onCopy,
+  onOpenLink,
 }: AnnotationComposerProps) {
   const isRecording = useVoiceStore((s) => s.isRecording)
   const voiceError = useVoiceStore((s) => s.error)
@@ -210,6 +213,15 @@ export function AnnotationComposer({
             className="px-2 py-1 text-[10px] font-mono rounded-full border border-border text-muted-foreground transition-colors hover:bg-warm/70 hover:text-ink"
           >
             Copy
+          </button>
+        )}
+        {onOpenLink && (
+          <button
+            onClick={onOpenLink}
+            title="Open in a new tab (Cmd/Ctrl+click the link also works)"
+            className="px-2 py-1 text-[10px] font-mono rounded-full border border-accent/40 text-accent transition-colors hover:bg-warm/70"
+          >
+            Open link
           </button>
         )}
         {offers.map((action) => (

--- a/src/components/Editor/FloatingIconBar.tsx
+++ b/src/components/Editor/FloatingIconBar.tsx
@@ -5,6 +5,7 @@ import { useEditorStore } from '@/stores/editorStore'
 import { captureAndResolveInBackground } from '@/lib/voice/pipeline'
 import { AnnotationComposer } from '@/components/Annotations/AnnotationComposer'
 import { peekRelatedCount } from '@/lib/ai/intentContext'
+import { detectUrl } from '@/lib/annotations/selectionOffers'
 
 const BAR_HEIGHT = 48
 const GAP = 8
@@ -57,6 +58,9 @@ export function FloatingIconBar() {
   // in the document about this", which is the difference between a generic
   // offer and one worth clicking.
   const relatedCount = view ? peekRelatedCount(view.state, contextMenu.from) : 0
+  // Cmd/Ctrl+click opens a link, but a modifier nobody announces is a modifier
+  // nobody finds — so a highlighted URL also gets a visible way out.
+  const selectedUrl = detectUrl(contextMenu.text)
 
   // Position above selection, clamped to viewport
   const barWidth = 360
@@ -77,6 +81,14 @@ export function FloatingIconBar() {
         // which is why copying your own text did not work.
         autoFocus={composerSeed !== null}
         initialText={composerSeed ?? ''}
+        onOpenLink={
+          selectedUrl
+            ? () => {
+                window.open(selectedUrl, '_blank', 'noopener,noreferrer')
+                clearContextMenu()
+              }
+            : undefined
+        }
         onCopy={() => {
           void navigator.clipboard?.writeText(contextMenu.text)
           clearContextMenu()

--- a/src/lib/annotations/selectionOffers.ts
+++ b/src/lib/annotations/selectionOffers.ts
@@ -75,12 +75,44 @@ export interface OfferContext {
  * phrase-scoped "30 days" is more useful offered "Why this figure?" than
  * "Define" — shape beats size once both apply.
  */
+/**
+ * The URL a selection points at, or null.
+ *
+ * Used to keep the selection bar useful when a reader highlights a link: the
+ * generic phrase offers ("Define", "Why this word?") are noise on a URL, and
+ * what they actually want is to open or copy it.
+ */
+export function detectUrl(text: string): string | null {
+  const trimmed = text.trim()
+  const match = /\bhttps?:\/\/[^\s<>"')\]]+/i.exec(trimmed)
+  if (match) return match[0]
+  // A bare domain, only when it is the WHOLE selection — otherwise ordinary
+  // prose containing a full stop starts looking like a hostname.
+  if (/^[\w-]+(\.[\w-]+)+(\/\S*)?$/.test(trimmed) && /\.[a-z]{2,}/i.test(trimmed)) {
+    return `https://${trimmed}`
+  }
+  return null
+}
+
 export function deriveOffers(
   anchor: { text: string; scope: Scope; nodeType?: string },
   ctx?: OfferContext,
 ): Offer[] {
   const text = truncate(anchor.text, MAX_PROMPT_TEXT)
   const offers: Offer[] = []
+
+  // A highlighted URL gets one offer, not four. "Why this word?" on a link is
+  // noise; opening and copying it are handled by their own chips, which are
+  // local actions rather than prompts and so cost none of the MAX_OFFERS slots.
+  if (detectUrl(anchor.text)) {
+    return [
+      {
+        label: 'What is this?',
+        intent: 'ask',
+        prompt: `What is at "${text}", and why is it referenced here?`,
+      },
+    ]
+  }
 
   if (ctx?.hasInvariant) {
     offers.push({

--- a/src/lib/docInput/__tests__/parserLinks.test.ts
+++ b/src/lib/docInput/__tests__/parserLinks.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { parseTextToDoc, parseHtmlToDoc, safeHref } from '../parser'
+import type { Node as PMNode } from 'prosemirror-model'
+
+// A document full of `[open resource](https://www.iso.org/standard/42001)`
+// rendered as those literal characters. The schema always had the `link` mark —
+// nothing ever created one, because this hand-rolled parser only understood
+// bold, italic and code, and its "next special character" scan did not include
+// `[`, so the opening bracket was never even a candidate.
+
+/** Every (text, href) pair carrying a link mark, in document order. */
+function links(doc: PMNode): Array<{ text: string; href: string }> {
+  const out: Array<{ text: string; href: string }> = []
+  doc.descendants((node) => {
+    if (!node.isText) return
+    const mark = node.marks.find((m) => m.type.name === 'link')
+    if (mark) out.push({ text: node.text ?? '', href: mark.attrs.href as string })
+  })
+  return out
+}
+
+describe('parseTextToDoc — markdown links', () => {
+  it('turns [text](url) into a real link mark', () => {
+    const doc = parseTextToDoc('See [open resource](https://www.iso.org/standard/42001) for detail.')
+    expect(links(doc)).toEqual([
+      { text: 'open resource', href: 'https://www.iso.org/standard/42001' },
+    ])
+  })
+
+  it('keeps the surrounding prose as ordinary text', () => {
+    const doc = parseTextToDoc('See [the spec](https://example.com/a) for detail.')
+    expect(doc.textContent).toBe('See the spec for detail.')
+  })
+
+  it('handles several links in one line', () => {
+    const doc = parseTextToDoc('[one](https://a.example) and [two](https://b.example)')
+    expect(links(doc).map((l) => l.href)).toEqual(['https://a.example', 'https://b.example'])
+  })
+
+  it('keeps marks inside the link label', () => {
+    const doc = parseTextToDoc('[**bold** link](https://example.com)')
+    const bolded = links(doc).find((l) => l.text === 'bold')
+    expect(bolded).toBeDefined()
+    doc.descendants((node) => {
+      if (node.isText && node.text === 'bold') {
+        expect(node.marks.map((m) => m.type.name).sort()).toEqual(['link', 'strong'])
+      }
+    })
+  })
+
+  it('refuses a javascript: URL, keeping it as visible text', () => {
+    // A pasted document is untrusted input; an href is a script-execution
+    // vector, so an unsafe scheme must never become a live link.
+    const doc = parseTextToDoc('[click me](javascript:alert(1))')
+    expect(links(doc)).toEqual([])
+    expect(doc.textContent).toContain('[click me](javascript:alert(1))')
+  })
+
+  it('refuses a data: URL too', () => {
+    const doc = parseTextToDoc('[x](data:text/html,<script>alert(1)</script>)')
+    expect(links(doc)).toEqual([])
+  })
+
+  it('does not break on a bare bracket', () => {
+    // The scan now stops at `[`, so text that merely contains one must still
+    // come through whole rather than being truncated at the bracket.
+    const doc = parseTextToDoc('An array [0] and a note [see below] with no link.')
+    expect(doc.textContent).toBe('An array [0] and a note [see below] with no link.')
+    expect(links(doc)).toEqual([])
+  })
+
+  it('leaves an unclosed link alone', () => {
+    const doc = parseTextToDoc('An [unfinished link with no paren')
+    expect(doc.textContent).toBe('An [unfinished link with no paren')
+  })
+
+  it('still parses bold, italic and code beside links', () => {
+    const doc = parseTextToDoc('**b** *i* `c` and [l](https://example.com)')
+    expect(doc.textContent).toBe('b i c and l')
+    expect(links(doc)).toHaveLength(1)
+  })
+})
+
+describe('parseHtmlToDoc — anchors', () => {
+  it('keeps the href instead of dropping it', () => {
+    // Previously every <a href> was swallowed by the generic tag strip.
+    const doc = parseHtmlToDoc('<p>See <a href="https://example.com/spec">the spec</a> here.</p>')
+    expect(links(doc)).toEqual([{ text: 'the spec', href: 'https://example.com/spec' }])
+  })
+
+  it('drops an anchor with no visible text rather than emitting empty brackets', () => {
+    const doc = parseHtmlToDoc('<p>Before<a href="https://example.com"></a>After</p>')
+    expect(doc.textContent).not.toContain('[]')
+  })
+})
+
+describe('safeHref', () => {
+  it('allows the schemes a document link legitimately uses', () => {
+    expect(safeHref('https://example.com')).toBe('https://example.com')
+    expect(safeHref('http://example.com')).toBe('http://example.com')
+    expect(safeHref('mailto:someone@example.com')).toBe('mailto:someone@example.com')
+  })
+
+  it('refuses script-bearing schemes', () => {
+    expect(safeHref('javascript:alert(1)')).toBeNull()
+    expect(safeHref('JavaScript:alert(1)')).toBeNull()
+    expect(safeHref('data:text/html,x')).toBeNull()
+    expect(safeHref('vbscript:x')).toBeNull()
+  })
+
+  it('assumes https for a bare domain', () => {
+    expect(safeHref('example.com/a')).toBe('https://example.com/a')
+  })
+
+  it('passes through in-document and root-relative targets', () => {
+    expect(safeHref('#section-2')).toBe('#section-2')
+    expect(safeHref('/docs/a')).toBe('/docs/a')
+  })
+
+  it('refuses empty and protocol-relative hrefs', () => {
+    expect(safeHref('   ')).toBeNull()
+    expect(safeHref('//evil.example')).toBeNull()
+  })
+})

--- a/src/lib/docInput/parser.ts
+++ b/src/lib/docInput/parser.ts
@@ -312,6 +312,28 @@ export function parseMarkdownTable(lines: string[], start: number): ParsedTable 
   return { node: schema.nodes.table.create(null, rows), nextLine }
 }
 
+/**
+ * Only these schemes may become a live link.
+ *
+ * A pasted document is untrusted input: `javascript:` and `data:` URLs in an
+ * href are a script-execution vector, so they are kept as visible text instead.
+ * Returns the href to use, or null to refuse.
+ */
+export function safeHref(href: string): string | null {
+  const trimmed = href.trim()
+  if (!trimmed) return null
+  // Protocol-relative (`//host/...`) is refused: it carries no scheme to check
+  // and silently inherits the page's, which in a pasted document is not a
+  // decision the reader made. Checked BEFORE the root-relative branch, which
+  // would otherwise swallow it on the leading slash.
+  if (trimmed.startsWith('//')) return null
+  // Root-relative and in-document targets have no scheme to validate.
+  if (trimmed.startsWith('/') || trimmed.startsWith('#')) return trimmed
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed)
+  if (!scheme) return `https://${trimmed}`
+  return ['http', 'https', 'mailto'].includes(scheme[1].toLowerCase()) ? trimmed : null
+}
+
 function parseInlineMarks(text: string): Node[] {
   const nodes: Node[] = []
   let remaining = text
@@ -333,6 +355,35 @@ function parseInlineMarks(text: string): Node[] {
       continue
     }
 
+    // Link — [text](url)
+    //
+    // Markdown links used to fall straight through to the plain-text branch
+    // below, because the "next special character" scan did not include `[`.
+    // A document full of `[open resource](https://...)` rendered as those
+    // literal characters, while the identical syntax inside an AI answer
+    // rendered as a real link (answers go through Streamdown, which parses
+    // markdown properly). The schema always had the `link` mark; nothing ever
+    // created one.
+    const linkMatch = remaining.match(/^\[([^\]]*)\]\(([^\s)]+)\)/)
+    if (linkMatch) {
+      const [whole, label, href] = linkMatch
+      const safe = safeHref(href)
+      if (safe) {
+        // Marks inside the label still apply — `[**bold** link](url)` keeps
+        // its bold.
+        const inner = parseInlineMarks(label || safe)
+        const linkMark = schema.marks.link.create({ href: safe })
+        for (const node of inner) {
+          nodes.push(node.mark([...node.marks, linkMark]))
+        }
+      } else {
+        // An unsafe scheme is kept as visible text, never as a live link.
+        nodes.push(schema.text(whole))
+      }
+      remaining = remaining.slice(whole.length)
+      continue
+    }
+
     // Inline code
     const codeMatch = remaining.match(/^`(.+?)`/)
     if (codeMatch) {
@@ -341,8 +392,9 @@ function parseInlineMarks(text: string): Node[] {
       continue
     }
 
-    // Find next special char
-    const nextSpecial = remaining.search(/[\*`]/)
+    // Find next special char. `[` belongs here — without it the scan ran past
+    // the opening bracket of every link and the branch above never got a turn.
+    const nextSpecial = remaining.search(/[\*`[]/)
     if (nextSpecial > 0) {
       nodes.push(schema.text(remaining.slice(0, nextSpecial)))
       remaining = remaining.slice(nextSpecial)
@@ -361,6 +413,18 @@ export function parseHtmlToDoc(html: string): Node {
     // Remove script and style blocks entirely
     .replace(/<script[\s\S]*?<\/script>/gi, '')
     .replace(/<style[\s\S]*?<\/style>/gi, '')
+    // Anchors -> markdown links, BEFORE the generic tag strip below eats them.
+    // This function lowers HTML to markdown text and hands it to
+    // parseTextToDoc, so turning them into `[text](url)` here is all it takes
+    // for them to come out the other side as real link marks. Previously every
+    // href was silently dropped.
+    .replace(
+      /<a[^>]*?href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
+      (_, href, label) => {
+        const text = stripTags(label).trim()
+        return text ? `[${text}](${href})` : ''
+      },
+    )
     // Convert headings
     .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, (_, t) => `\n# ${stripTags(t)}\n`)
     .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, (_, t) => `\n## ${stripTags(t)}\n`)

--- a/src/lib/prosemirror/plugins/__tests__/linkClickPlugin.test.ts
+++ b/src/lib/prosemirror/plugins/__tests__/linkClickPlugin.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { EditorView } from 'prosemirror-view'
+import { createLinkClickPlugin } from '../linkClickPlugin'
+import { detectUrl } from '@/lib/annotations/selectionOffers'
+
+// Cmd/Ctrl+click opens; a plain click keeps placing the caret. That is Notion's
+// behaviour and the convention for EDITABLE surfaces — plain-click-navigates
+// belongs to read-only rendering. Inside a document you are editing, an
+// unmodified click has to keep meaning "put the cursor here", or selecting text
+// that happens to contain a link becomes a fight.
+
+const plugin = createLinkClickPlugin()
+const click = plugin.props.handleDOMEvents!.click as (
+  view: EditorView,
+  event: MouseEvent,
+) => boolean
+
+const view = {} as EditorView
+
+function clickOn(html: string, mods: Partial<MouseEvent> = {}) {
+  document.body.innerHTML = html
+  const target = document.querySelector('a') ?? document.body
+  const event = {
+    target,
+    metaKey: false,
+    ctrlKey: false,
+    preventDefault: vi.fn(),
+    ...mods,
+  } as unknown as MouseEvent
+  return { handled: click(view, event), event }
+}
+
+const LINK = '<p>See <a href="https://example.com/spec">the spec</a></p>'
+
+beforeEach(() => {
+  vi.stubGlobal('open', vi.fn())
+})
+
+describe('linkClickPlugin', () => {
+  it('opens the link on Cmd+click, in a new tab, severed from this one', () => {
+    const { handled, event } = clickOn(LINK, { metaKey: true })
+    expect(handled).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    // noopener stops the opened page rewriting this tab's location; a new tab
+    // also means a half-finished edit is never navigated away from.
+    expect(window.open).toHaveBeenCalledWith(
+      'https://example.com/spec',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('opens on Ctrl+click too, for Windows and Linux', () => {
+    expect(clickOn(LINK, { ctrlKey: true }).handled).toBe(true)
+    expect(window.open).toHaveBeenCalled()
+  })
+
+  it('does nothing on a plain click, so the caret still lands', () => {
+    const { handled, event } = clickOn(LINK)
+    expect(handled).toBe(false)
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it('ignores a modified click that is not on a link', () => {
+    const { handled } = clickOn('<p>ordinary prose</p>', { metaKey: true })
+    expect(handled).toBe(false)
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  it('works when the click lands on a nested mark inside the link', () => {
+    document.body.innerHTML = '<p><a href="https://example.com"><strong>bold link</strong></a></p>'
+    const target = document.querySelector('strong')
+    const event = {
+      target, metaKey: true, ctrlKey: false, preventDefault: vi.fn(),
+    } as unknown as MouseEvent
+    expect(click(view, event)).toBe(true)
+    expect(window.open).toHaveBeenCalledWith('https://example.com', '_blank', 'noopener,noreferrer')
+  })
+})
+
+describe('detectUrl', () => {
+  it('finds a URL so the selection bar can offer to open it', () => {
+    expect(detectUrl('https://github.com/Vinylfigure/aegis-sentinel')).toBe(
+      'https://github.com/Vinylfigure/aegis-sentinel',
+    )
+  })
+
+  it('treats a bare domain as https only when it is the whole selection', () => {
+    expect(detectUrl('example.com/docs')).toBe('https://example.com/docs')
+    // Ordinary prose containing a full stop must not read as a hostname.
+    expect(detectUrl('This is a sentence. It has two.')).toBeNull()
+  })
+
+  it('returns null for ordinary text', () => {
+    expect(detectUrl('AIMS operating system')).toBeNull()
+    expect(detectUrl('')).toBeNull()
+  })
+
+  it('stops at the punctuation that usually follows a URL in prose', () => {
+    expect(detectUrl('see https://example.com/a) for more')).toBe('https://example.com/a')
+  })
+})

--- a/src/lib/prosemirror/plugins/index.ts
+++ b/src/lib/prosemirror/plugins/index.ts
@@ -12,6 +12,7 @@ import { createConflictPlugin } from './conflictPlugin'
 import { createUncertaintyPlugin } from './uncertaintyPlugin'
 import { createProposedChangePlugin } from './proposedChangePlugin'
 import { createBlockIdPlugin } from './blockIdPlugin'
+import { createLinkClickPlugin } from './linkClickPlugin'
 import { columnResizing, goToNextCell, tableEditing } from 'prosemirror-tables'
 
 export function createPlugins(): Plugin[] {
@@ -35,6 +36,9 @@ export function createPlugins(): Plugin[] {
     createChangeTrackingPlugin(),
     createReadLinePlugin(),
     createContextMenuPlugin(),
+    // Before contextMenuPlugin's mouseup would matter: a Cmd+click that opens a
+    // link should not also leave a selection bar hanging over the document.
+    createLinkClickPlugin(),
     columnResizing(),
     // Keep this last: it handles broad mouse/arrow behavior after more
     // specific editor plugins and column resizing have had their turn.

--- a/src/lib/prosemirror/plugins/linkClickPlugin.ts
+++ b/src/lib/prosemirror/plugins/linkClickPlugin.ts
@@ -1,0 +1,40 @@
+import { Plugin } from 'prosemirror-state'
+
+/**
+ * Cmd/Ctrl+click opens a link; a plain click keeps placing the caret.
+ *
+ * This is Notion's behaviour, and it is the convention for EDITABLE surfaces
+ * generally — TipTap guards its own `openOnClick` on the editor's editable
+ * state for the same reason. Plain-click-navigates belongs to read-only
+ * rendering (which is why links in AI answers, rendered by Streamdown outside
+ * contenteditable, can just be clicked). Inside a document you are editing, an
+ * unmodified click has to keep meaning "put the cursor here", or selecting text
+ * that happens to contain a link becomes a fight.
+ *
+ * Implemented on the DOM event rather than `handleClickOn` because the rendered
+ * anchor already carries the href — no mark resolution needed, and it works
+ * wherever the click lands inside the link, including on nested marks.
+ */
+export function createLinkClickPlugin(): Plugin {
+  return new Plugin({
+    props: {
+      handleDOMEvents: {
+        click(_view, event) {
+          if (!event.metaKey && !event.ctrlKey) return false
+
+          const target = event.target as HTMLElement | null
+          const anchor = target?.closest?.('a[href]')
+          const href = anchor?.getAttribute('href')
+          if (!href) return false
+
+          event.preventDefault()
+          // noopener severs window.opener so the opened page cannot rewrite
+          // this tab's location; a new tab also means a half-finished edit is
+          // never navigated away from.
+          window.open(href, '_blank', 'noopener,noreferrer')
+          return true
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
Fourth of five tracks. Follows #153, #154, #155.

## Links rendered as raw text

A document full of `[open resource](https://www.iso.org/standard/42001)` showed those literal characters — while the identical syntax inside an AI answer rendered as a clickable link.

**The schema was never the problem.** `link` is retained from `prosemirror-schema-basic` with its stock `toDOM`. Nothing ever created one. `parseInlineMarks` understands `**bold**`, `*italic*` and `` `code` `` and nothing else, and its next-special-character scan was ``/[\*`]/`` — **`[` was not in it**, so the parser ran straight past the opening bracket of every link and swept the whole thing up as plain text. Answers looked different only because they render through Streamdown, which parses markdown properly.

- A `[text](url)` branch, placed **before** the italic branch so a link is never mistaken for emphasis, and `[` added to the scan so the branch gets a turn. Marks inside the label survive — `[**bold** link](url)` keeps its bold.
- `parseHtmlToDoc` lowers HTML to markdown before parsing, so converting anchors to `[text](url)` ahead of the generic tag strip is all it took; that strip used to eat every href.
- **`safeHref` allows `http`, `https` and `mailto` only.** A pasted document is untrusted input and an href is a script-execution vector, so `javascript:` and `data:` stay as visible text rather than becoming live links. Protocol-relative `//host` is refused too — it silently inherits the page's scheme, which isn't a decision the reader made.

## Clicking

**Cmd/Ctrl+click opens in a new tab; a plain click still places the caret.** Notion's exact behaviour, and the convention for editable surfaces generally — TipTap guards its own `openOnClick` on editable state for the same reason. Plain-click-navigates belongs to read-only rendering; inside a document you're editing it fights caret placement and text selection.

Opened with `noopener,noreferrer`: the new tab can't rewrite this one's location, and a half-finished edit is never navigated away from.

A modifier nobody announces is a modifier nobody finds, so a highlighted URL also gets a visible **Open link** chip, and its selection offers collapse from four generic prompts to one — "Why this word?" on a URL is noise. Open and Copy are *local actions* rather than prompts, so they cost none of the `MAX_OFFERS` slots the scope-derived offers compete for. That turned out to dissolve the offer-slot collision the plan had budgeted for.

## Verification

- `typecheck`, `lint`, unit suite: **124 files passed**. Full e2e green.
- 25 new tests across link parsing, `safeHref`, the click plugin and URL detection — including several links per line, marks inside labels, unclosed links, and bare brackets in ordinary prose (`An array [0]`), which the widened scan must not truncate.
- **Falsified**: removing `[` from the scan fails exactly five of them.
- One test caught a real ordering bug while being written: `//evil.example` matched the root-relative branch before the protocol-relative check could refuse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
