### PR TITLE
feat(ai): stop a follow-up handing back the answer it just gave

### DIFF
--- a/src/components/Annotations/ResolutionActions.tsx
+++ b/src/components/Annotations/ResolutionActions.tsx
@@ -6,6 +6,7 @@ import { useEditorStore } from '@/stores/editorStore'
 import { useChangesStore } from '@/stores/changesStore'
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useToastStore } from '@/stores/toastStore'
+import { isRepeatOf } from '@/lib/ai/coveredClaims'
 import { removeAnnotationDecoration } from '@/lib/prosemirror/plugins/annotationPlugin'
 import { generateId } from '@/lib/utils/id'
 import { continueThread, simplifyThread } from '@/lib/ai/resolver'
@@ -192,7 +193,22 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
         finishFollowUp()
         return
       }
-      useAnnotationStore.getState().addMessage(ann.id, agentMsg)
+      // Backstop that does not depend on the model behaving. The prompt asks
+      // it not to repeat itself and gives it explicit permission to say there
+      // is nothing more; verbosity bias and sycophancy research both say it
+      // will sometimes produce a rephrase anyway. Flag that rather than
+      // presenting it as a fresh answer — and flag rather than discard, since
+      // a crude word-overlap measure should not be allowed to eat a real reply.
+      const priorAgent = [...freshAnnotation.conversation].reverse()
+        .find((m) => m.role === 'agent' && m.content.trim())
+      const repeated = priorAgent ? isRepeatOf(agentMsg.content, priorAgent.content) : false
+
+      useAnnotationStore.getState().addMessage(ann.id, repeated
+        ? {
+            ...agentMsg,
+            content: `_This is substantially the same as the previous answer — there may be nothing further on this._\n\n${agentMsg.content}`,
+          }
+        : agentMsg)
       finishFollowUp()
     } catch (err) {
       console.error('Follow-up failed:', err)
@@ -631,7 +647,16 @@ export function ResolutionActions({ annotation }: ResolutionActionsProps) {
 
       case 'explore':
       case 'explore-deeper': {
-        await sendFollowUp(annotation, 'Go deeper on this. Provide more detail and evidence.')
+        // "Deeper" has no single meaning — question taxonomies separate
+        // mechanism, evidence, consequence and narrower detail as genuinely
+        // different moves. Asking for "more detail and evidence" invites a
+        // shallow survey of all of them, which is how two clicks produced two
+        // near-identical answers. Ask for ONE lane, and name the alternatives
+        // so the model picks rather than hedges.
+        await sendFollowUp(
+          annotation,
+          'Go one level deeper. Pick the single most useful lane — the mechanism (how it actually works), the evidence (what supports it), or the implication (what follows from it) — and go deep on that one rather than surveying all of them. Name which lane you chose in the first few words.',
+        )
         break
       }
       case 'tweak': {

--- a/src/lib/ai/__tests__/coveredClaims.test.ts
+++ b/src/lib/ai/__tests__/coveredClaims.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  answerSimilarity,
+  buildCoveredClaims,
+  formatCoveredClaims,
+  isRepeatOf,
+  REPEAT_THRESHOLD,
+} from '../coveredClaims'
+import type { ConversationMessage } from '@/lib/annotations/types'
+
+// "Go deeper" was clicked twice and returned two near-identical answers. The
+// prior conversation WAS being passed as chat history — what was missing was
+// any instruction saying what had already been covered. Turn-level repetition
+// is a measured failure distinct from decoding-level degeneration, and the
+// pattern that works is an explicit coverage constraint rather than hoping the
+// model infers novelty from a transcript.
+
+function msg(role: 'user' | 'agent', content: string): ConversationMessage {
+  return { id: `${role}-${content.slice(0, 6)}`, role, content, suggestedEdit: null, timestamp: 0 }
+}
+
+describe('buildCoveredClaims', () => {
+  it('collects the leading sentences of each agent turn', () => {
+    const claims = buildCoveredClaims([
+      msg('user', 'what is tokenization?'),
+      msg('agent', 'Tokenization replaces sensitive data with a token. It reduces scope. Extra detail.'),
+    ])
+    expect(claims).toEqual([
+      'Tokenization replaces sensitive data with a token.',
+      'It reduces scope.',
+    ])
+  })
+
+  it('ignores the reader\'s own turns — the ledger is what the ASSISTANT said', () => {
+    const claims = buildCoveredClaims([
+      msg('user', 'a question that should not appear in the ledger'),
+      msg('agent', 'An answer.'),
+    ])
+    expect(claims).toEqual(['An answer.'])
+  })
+
+  it('keeps the most recent claims when a thread runs long', () => {
+    const long = Array.from({ length: 12 }, (_, i) => msg('agent', `Claim number ${i}.`))
+    const claims = buildCoveredClaims(long)
+    expect(claims.length).toBeLessThanOrEqual(8)
+    // A follow-up is most likely to echo what was just said.
+    expect(claims[claims.length - 1]).toBe('Claim number 11.')
+  })
+
+  it('returns nothing for an empty or user-only conversation', () => {
+    expect(buildCoveredClaims([])).toEqual([])
+    expect(buildCoveredClaims([msg('user', 'hello')])).toEqual([])
+  })
+
+  it('collapses whitespace so a wrapped answer does not produce ragged claims', () => {
+    const claims = buildCoveredClaims([msg('agent', 'One\n\n  thing   here.')])
+    expect(claims).toEqual(['One thing here.'])
+  })
+})
+
+describe('formatCoveredClaims', () => {
+  it('emits nothing when there is nothing covered', () => {
+    expect(formatCoveredClaims([])).toBe('')
+  })
+
+  it('states the constraint and gives explicit permission to decline', () => {
+    // Models default to producing something rather than admitting there is
+    // nothing left; the permission does not guarantee a clean refusal, but
+    // without it there is no legitimate path to one at all.
+    const out = formatCoveredClaims(['Tokenization replaces sensitive data.'])
+    expect(out).toContain('ALREADY SAID IN THIS THREAD')
+    expect(out).toContain('Tokenization replaces sensitive data.')
+    expect(out).toContain('Add only what is NOT above')
+    expect(out).toContain('nothing more to add')
+  })
+})
+
+describe('answerSimilarity / isRepeatOf', () => {
+  it('scores an identical answer as fully overlapping', () => {
+    const text = 'Tokenization replaces sensitive card data with a non-sensitive token.'
+    expect(answerSimilarity(text, text)).toBe(1)
+    expect(isRepeatOf(text, text)).toBe(true)
+  })
+
+  it('catches a rephrase that says the same thing', () => {
+    // The reported shape: two "Go deeper" clicks, same content, different words.
+    const a = 'Model hallucinations are identified through monitoring tool-call audit logs, analyzing prompt and response patterns, and running adversarial tests.'
+    const b = 'Model hallucinations are identified by monitoring tool-call audit logs, analyzing prompt and response patterns, and running adversarial tests.'
+    expect(isRepeatOf(a, b)).toBe(true)
+  })
+
+  it('lets a genuinely different answer through', () => {
+    const a = 'Tokenization replaces sensitive card data with a non-sensitive token.'
+    const b = 'Audit logs record which downstream systems acted on a given model output, and when.'
+    expect(answerSimilarity(a, b)).toBeLessThan(REPEAT_THRESHOLD)
+    expect(isRepeatOf(a, b)).toBe(false)
+  })
+
+  it('is not fooled by shared filler words alone', () => {
+    const a = 'The system is in the process of being reviewed by the team.'
+    const b = 'The report is in the hands of the auditor for the quarter.'
+    expect(isRepeatOf(a, b)).toBe(false)
+  })
+
+  it('handles empty input without dividing by zero', () => {
+    expect(answerSimilarity('', 'something')).toBe(0)
+    expect(answerSimilarity('', '')).toBe(0)
+    expect(isRepeatOf('', '')).toBe(false)
+  })
+})

--- a/src/lib/ai/__tests__/resolverFollowUpNoUndefinedTerm.test.ts
+++ b/src/lib/ai/__tests__/resolverFollowUpNoUndefinedTerm.test.ts
@@ -173,3 +173,48 @@ describe('looksLikeTerm — why the obvious fix would have failed', () => {
     expect(looksLikeTerm('how are they identified?')).toBe(false)
   })
 })
+
+
+describe('continueThread — the coverage ledger reaches the prompt', () => {
+  it('tells the model what this thread already said', async () => {
+    // buildBranchChain covers CROSS-annotation ancestry and returns nothing for
+    // a follow-up inside one card — which is exactly where "Go deeper" was
+    // handing back the same answer twice. Passing the transcript as chat
+    // history was never enough on its own.
+    const { continueThread } = await loadResolverWithGraph()
+    const sent: unknown[] = []
+    stubFetchCapturing(sent)
+
+    const annotation = makeAnnotation()
+    annotation.conversation = [
+      { id: 'u1', role: 'user', content: 'what is this?', suggestedEdit: null, timestamp: 0 },
+      {
+        id: 'a1',
+        role: 'agent',
+        content: 'Hallucinations are found via audit logs. Adversarial tests also help.',
+        suggestedEdit: null,
+        timestamp: 1,
+      },
+    ]
+
+    await continueThread(annotation, 'go deeper', makeEditorState())
+
+    const prompt = promptOf(sent)
+    expect(prompt).toContain('ALREADY SAID IN THIS THREAD')
+    expect(prompt).toContain('Hallucinations are found via audit logs.')
+    expect(prompt).toContain('Add only what is NOT above')
+    // Explicit permission to decline — without it there is no legitimate path
+    // to "there is nothing more", so the model pads instead.
+    expect(prompt).toContain('nothing more to add')
+  })
+
+  it('adds no ledger block to the first follow-up of an empty thread', async () => {
+    const { continueThread } = await loadResolverWithGraph()
+    const sent: unknown[] = []
+    stubFetchCapturing(sent)
+
+    await continueThread(makeAnnotation(), 'go deeper', makeEditorState())
+
+    expect(promptOf(sent)).not.toContain('ALREADY SAID IN THIS THREAD')
+  })
+})

--- a/src/lib/ai/coveredClaims.ts
+++ b/src/lib/ai/coveredClaims.ts
@@ -1,0 +1,109 @@
+import type { ConversationMessage } from '@/lib/annotations/types'
+
+/**
+ * What this thread has already said, and whether a new answer just said it
+ * again.
+ *
+ * Passing the raw transcript is not enough. Turn-level repetition is a measured
+ * failure distinct from decoding-level degeneration: models reuse the same
+ * discourse move at roughly twice the human rate, and the more they repeat the
+ * less willing readers are to keep engaging. What moves the needle is an
+ * explicit coverage constraint — telling the model what ground is taken, rather
+ * than handing it a transcript and hoping it infers novelty.
+ *
+ * Built locally, at prompt-assembly time. A model-generated ledger would be
+ * better prose but would need either a second call on every turn or a new SSE
+ * event on the streaming first turn, and neither is worth it to solve "you said
+ * the same thing twice".
+ */
+
+/** Ledger caps — the envelope competes with the document for context window. */
+const MAX_CLAIMS = 8
+const MAX_CLAIM_CHARS = 160
+
+function sentences(text: string): string[] {
+  return text
+    .replace(/\s+/g, ' ')
+    .split(/(?<=[.!?])\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function truncate(text: string): string {
+  return text.length <= MAX_CLAIM_CHARS ? text : `${text.slice(0, MAX_CLAIM_CHARS - 1)}…`
+}
+
+/**
+ * The points this thread has already made, newest last.
+ *
+ * Takes the leading sentences of each agent turn rather than the whole thing:
+ * the opening is where an answer states its claim, and a ledger the size of the
+ * conversation would defeat its own purpose.
+ */
+export function buildCoveredClaims(conversation: ConversationMessage[]): string[] {
+  const claims: string[] = []
+  for (const message of conversation) {
+    if (message.role !== 'agent') continue
+    for (const sentence of sentences(message.content).slice(0, 2)) {
+      claims.push(truncate(sentence))
+    }
+  }
+  // Keep the most recent, which is what a follow-up is most likely to echo.
+  return claims.slice(-MAX_CLAIMS)
+}
+
+/** The block of prompt text that states the constraint, or '' when nothing is covered. */
+export function formatCoveredClaims(claims: string[]): string {
+  if (claims.length === 0) return ''
+  return [
+    '',
+    'ALREADY SAID IN THIS THREAD — do not repeat, restate, or rephrase these as if new:',
+    ...claims.map((c) => `  - ${c}`),
+    'Add only what is NOT above. If the reader is asking for something already',
+    'covered, say so in one sentence and point at which part covered it.',
+    'If there is genuinely no new detail, evidence, mechanism or implication left',
+    'to add, say that plainly instead of padding — "there is nothing more to add',
+    'on this" is a correct and useful answer, and a rephrased repeat is not.',
+  ].join('\n')
+}
+
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'is', 'are', 'was', 'were', 'be', 'been',
+  'to', 'of', 'in', 'on', 'at', 'by', 'for', 'with', 'as', 'that', 'this',
+  'it', 'its', 'from', 'which', 'not', 'can', 'may', 'will', 'would', 'these',
+])
+
+function wordBag(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+      .split(/\s+/)
+      .filter((w) => w.length > 2 && !STOP_WORDS.has(w)),
+  )
+}
+
+/**
+ * Token-set Jaccard overlap between two answers, 0..1.
+ *
+ * Deliberately crude and local — no embeddings, no network. This is a backstop,
+ * not a judgement: the instruction above asks the model not to repeat itself,
+ * and verbosity-bias and sycophancy research both say it will sometimes do it
+ * anyway. Something has to catch that which does not depend on the model
+ * behaving.
+ */
+export function answerSimilarity(a: string, b: string): number {
+  const left = wordBag(a)
+  const right = wordBag(b)
+  if (left.size === 0 || right.size === 0) return 0
+  let shared = 0
+  for (const word of left) if (right.has(word)) shared++
+  return shared / (left.size + right.size - shared)
+}
+
+/** At or above this, a "new" answer is treated as a repeat. */
+export const REPEAT_THRESHOLD = 0.8
+
+export function isRepeatOf(candidate: string, previous: string): boolean {
+  return answerSimilarity(candidate, previous) >= REPEAT_THRESHOLD
+}

--- a/src/lib/ai/resolver.ts
+++ b/src/lib/ai/resolver.ts
@@ -19,6 +19,7 @@ import { logResolutionAudit } from '@/lib/audit/auditLogger'
 import { primaryProposedEdit, proposeCascadeEdits } from './orchestrator'
 import { pickUtilityModel } from './modelCapabilities'
 import { providerHeaders } from './providerHeaders'
+import { buildCoveredClaims, formatCoveredClaims } from './coveredClaims'
 import { blockIdAtPos } from '@/lib/prosemirror/blockIds'
 import { getDefaultVerbosity } from '@/lib/annotations/types'
 import type { Annotation, ConversationMessage, Resolution, ResolutionAction, SuggestedEdit, Scope, Verbosity } from '@/lib/annotations/types'
@@ -672,6 +673,10 @@ export async function continueThread(
   const branchChain = formatBranchChain(buildBranchChain(annotation.id))
 
   // Build messages from full conversation history
+  // What this thread has already said. buildBranchChain covers CROSS-annotation
+  // ancestry and returns nothing for a follow-up inside one card, which is
+  // exactly where "Go deeper" was handing back the same answer twice.
+  const coveredClaims = formatCoveredClaims(buildCoveredClaims(annotation.conversation))
   const messages: LLMMessage[] = [
     { role: 'system', content: systemPrompt },
     {
@@ -684,7 +689,7 @@ export async function continueThread(
     ? `Prompted by (context only, NOT the subject -- do not define or explain it, and do not remark on whether the document defines it): "${annotation.anchor.text}"\n  Answer what the reader actually said, on its own terms.`
     : `Selected text: "${annotation.anchor.text}"`}${annotation.sourceQuote ? `\n  Quoted from a previous answer — ANSWER ONLY ABOUT THIS: "${annotation.sourceQuote}"` : ''}
 
-${formatIntentContext(intentContext)}${branchChain}
+${formatIntentContext(intentContext)}${branchChain}${coveredClaims}
 ${reviewProgress}
 
 ${typePrompt}


### PR DESCRIPTION
Fifth of five tracks. Follows #153–#156.

## "Go deeper" clicked twice returned two near-identical answers

The prior conversation **was** already passed as chat history. What was missing was any statement of what had been *covered*.

Turn-level repetition is a measured failure distinct from decoding-level degeneration: models reuse the same discourse move at roughly twice the human rate, and the more they repeat the less willing readers are to keep engaging. The pattern that moves the needle is an **explicit coverage constraint**, not hoping the model infers novelty from a transcript.

`buildBranchChain` is exactly the right shape for this — but it walks `parentId`, so it covers **cross-annotation** ancestry and returns nothing at all for a follow-up inside one card. Which is precisely where this failed.

## Three changes

**A covered-claims ledger**, built locally from prior agent turns at prompt-assembly time and injected into **every follow-up** — not just "Go deeper", so a typed question can't get a recycled answer either. No model call, no latency, no wire-format change. A model-written ledger would read better but needs either a second call per turn or a new SSE event on the streaming first turn; not worth it to solve "you said that already".

**Explicit permission to decline**, worded so that *"there is nothing more to add on this"* is a correct answer and a rephrased repeat is not. Models default to producing something rather than admitting there's nothing left — the permission doesn't guarantee a clean refusal, but without it there's no legitimate path to one at all.

**A backstop that doesn't depend on the model behaving**: token-set Jaccard over the new answer against the previous one, client-side, no network. At ≥ 0.8 the answer is flagged as substantially the same rather than presented as fresh. **Flagged, not discarded** — a crude word-overlap measure shouldn't be allowed to eat a real reply.

Separately, "Go deeper" stops asking for *"more detail and evidence"*. Question taxonomies separate **mechanism**, **evidence**, **consequence** and **narrower detail** as genuinely different moves; asking for all of them invites a shallow survey, which is how two clicks produced two near-identical answers. It now asks for one named lane.

## Deliberately not in this change

The **derived follow-up directions** — 2–3 generated chips replacing the generic button — from the plan's Track B. That needs its own model call per answer plus its own UI, and the repetition fix stands on its own. Shipping this first means you can judge from real use whether generated directions are still what you want, rather than my guessing now.

## Verification

- `typecheck`, `lint`, unit suite: **123 files passed**. Full e2e: 17 passed, 6 self-skipped.
- 14 new tests: ledger construction (agent turns only, recency cap, whitespace), the prompt block including the decline permission, and the similarity measure — identical text, a real rephrase of the reported shape, a genuinely different answer, and shared filler words alone not triggering it.
- **Falsified**: removing the ledger from the prompt fails the ledger test and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL9b3KawBm8k76dBGhHTpp
